### PR TITLE
fix(ci): fix Windows release packaging + add Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.10", "3.11", "3.12"]
         exclude:
-          # Reduce CI time — only test 3.10 on non-linux
+          # Reduce CI time — only test 3.7 and 3.10 on linux
+          - os: windows-latest
+            python-version: "3.7"
           - os: windows-latest
             python-version: "3.10"
+          - os: macos-latest
+            python-version: "3.7"
           - os: macos-latest
             python-version: "3.10"
 
@@ -62,7 +66,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install package with dev dependencies
-        run: pip install -e ".[dev]"
+        run: |
+          python -m pip install --upgrade pip
+          # On Python <3.9, some dev deps (pytest-cov, pytest-mock) are
+          # unavailable — install only what we need for the test run.
+          if python -c "import sys; sys.exit(0 if sys.version_info >= (3,9) else 1)"; then
+            pip install -e ".[dev]"
+          else
+            pip install -e . "pytest>=7.0" "pyyaml>=5.0"
+          fi
 
       - name: Run unit tests
         run: pytest tests/ -v --tb=short -m "not e2e and not packaging"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,7 @@ jobs:
         run: pip install requests packaging
 
       - name: Assemble addon ZIP
+        shell: bash
         run: |
           python packaging/assemble_zip.py \
             --platform ${{ matrix.platform }} \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,16 @@ description = "Blender addon for the DCC Model Context Protocol (MCP) ecosystem 
 authors = [{ name = "Long Hao", email = "hal.long@outlook.com" }]
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.10"
+requires-python = ">=3.7"
 keywords = ["blender", "mcp", "dcc", "ai", "llm", "model-context-protocol"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -33,8 +36,6 @@ dev = [
     "pytest-cov>=4.0",
     "pytest-mock>=3.0",
     "ruff>=0.8.0",
-    "hatchling",
-    "build",
     "pyyaml>=5.0",
 ]
 
@@ -76,7 +77,7 @@ exclude_lines = [
 
 [tool.ruff]
 line-length = 120
-target-version = "py310"
+target-version = "py37"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]


### PR DESCRIPTION
## Summary

- **release.yml**: add `shell: bash` to "Assemble addon ZIP" step — fixes `ParserError: Missing expression after unary operator '--'` on Windows PowerShell runners where `\` is not a valid line-continuation character
- **pyproject.toml**: lower `requires-python` to `>=3.7`, add classifiers for 3.7/3.8/3.9, update ruff `target-version` to `py37`, remove `hatchling`/`build` from dev deps (both require `>=3.9`/`>=3.10`)
- **ci.yml**: add Python 3.7 to test matrix (linux only), use conditional install for Python <3.9 where `pytest-cov`/`pytest-mock` require `>=3.9`

## Test plan

- [ ] CI passes on Python 3.7 (linux)
- [ ] CI passes on Python 3.10/3.11/3.12
- [ ] Release workflow: Assemble addon ZIP step succeeds on Windows (`win64` platform)