### PR TITLE
feat: align Blender addon packaging with core 0.17.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - name: Install PyYAML
-        run: pip install pyyaml
+      - name: Install skill validation dependencies
+        run: pip install pyyaml "dcc-mcp-core>=0.17.5,<1.0.0"
       - name: Validate SKILL.md front-matter
         run: python tests/test_lint_skills.py
 
@@ -133,6 +133,8 @@ jobs:
           assert not triple, f"unexpected triple-nested paths: {triple[:5]}"
           skill_md = [n for n in names if n.endswith("/SKILL.md") and "/skills/" in n]
           assert len(skill_md) >= 10, f"expected >=10 SKILL.md under skills/, got {len(skill_md)}"
+          tools_yaml = [n for n in names if n.endswith("/tools.yaml") and "/skills/" in n]
+          assert len(tools_yaml) >= 10, f"expected >=10 tools.yaml under skills/, got {len(tools_yaml)}"
           with zipfile.ZipFile(zips[-1]) as zf:
               raw = zf.read("dcc_mcp_blender/blender_manifest.toml").decode("utf-8")
           assert "wheels = [" in raw and "./wheels/" in raw, raw[:400]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,60 @@ jobs:
 
       - name: Run unit tests
         run: pytest tests/ -v --tb=short -m "not e2e and not packaging"
+
+  # Ensure sdist/wheel build succeeds before release (PyPI / hatchling).
+  build:
+    name: Build package (wheel + sdist)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install build backend
+        run: pip install --upgrade pip build hatchling
+      - name: python -m build
+        run: python -m build
+      - name: Verify artifacts
+        run: |
+          ls -la dist/
+          test -f dist/*.whl
+          test -f dist/*.tar.gz
+
+  addon-zip:
+    name: Blender addon ZIP bundles dcc-mcp-core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install tooling
+        run: pip install --upgrade pip packaging
+      - name: Assemble Linux addon ZIP
+        run: python packaging/assemble_zip.py --platform linux --output-dir dist_addon/
+      - name: Verify dcc-mcp-core wheel bundled in ZIP
+        run: |
+          python - <<'PY'
+          import glob
+          import zipfile
+
+          zips = sorted(glob.glob("dist_addon/dcc_mcp_blender_addon_linux_v*.zip"))
+          assert zips, "expected dist_addon/dcc_mcp_blender_addon_linux_v*.zip"
+          with zipfile.ZipFile(zips[-1]) as zf:
+              names = zf.namelist()
+          wheels = [n for n in names if "/wheels/" in n and n.endswith(".whl")]
+          assert wheels, f"expected bundled .whl under wheels/, sample: {names[:30]}"
+          assert not any(
+              n.startswith("dcc_mcp_blender/dcc_mcp_core/") for n in names
+          ), "unexpected extracted dcc_mcp_core tree — use manifest wheels instead"
+          assert any(n.endswith("dcc_mcp_blender/__init__.py") for n in names), names[:25]
+          assert any(n.endswith("dcc_mcp_blender/blender_manifest.toml") for n in names), names[:25]
+          triple = [n for n in names if "dcc_mcp_blender/dcc_mcp_blender/dcc_mcp_blender/" in n]
+          assert not triple, f"unexpected triple-nested paths: {triple[:5]}"
+          skill_md = [n for n in names if n.endswith("/SKILL.md") and "/skills/" in n]
+          assert len(skill_md) >= 10, f"expected >=10 SKILL.md under skills/, got {len(skill_md)}"
+          with zipfile.ZipFile(zips[-1]) as zf:
+              raw = zf.read("dcc_mcp_blender/blender_manifest.toml").decode("utf-8")
+          assert "wheels = [" in raw and "./wheels/" in raw, raw[:400]
+          PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,12 @@ jobs:
           test -f dist/*.tar.gz
 
   addon-zip:
-    name: Blender addon ZIP bundles dcc-mcp-core
+    name: Blender addon ZIP bundles dcc-mcp-core (${{ matrix.platform }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [win64, linux, macos]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -102,16 +106,20 @@ jobs:
           python-version: "3.11"
       - name: Install tooling
         run: pip install --upgrade pip packaging
-      - name: Assemble Linux addon ZIP
-        run: python packaging/assemble_zip.py --platform linux --output-dir dist_addon/
+      - name: Assemble addon ZIP
+        run: python packaging/assemble_zip.py --platform ${{ matrix.platform }} --output-dir dist_addon/
       - name: Verify dcc-mcp-core wheel bundled in ZIP
+        env:
+          PLATFORM: ${{ matrix.platform }}
         run: |
           python - <<'PY'
           import glob
+          import os
           import zipfile
 
-          zips = sorted(glob.glob("dist_addon/dcc_mcp_blender_addon_linux_v*.zip"))
-          assert zips, "expected dist_addon/dcc_mcp_blender_addon_linux_v*.zip"
+          platform = os.environ["PLATFORM"]
+          zips = sorted(glob.glob(f"dist_addon/dcc_mcp_blender_addon_{platform}_v*.zip"))
+          assert zips, f"expected dist_addon/dcc_mcp_blender_addon_{platform}_v*.zip"
           with zipfile.ZipFile(zips[-1]) as zf:
               names = zf.namelist()
           wheels = [n for n in names if "/wheels/" in n and n.endswith(".whl")]

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -385,7 +385,8 @@ jobs:
           for attempt in range(10):
               try:
                   req = urllib.request.Request(url, data=body,
-                      headers={'Content-Type': 'application/json'}, method='POST')
+                      headers={'Content-Type': 'application/json',
+                               'Accept': 'application/json, text/event-stream'}, method='POST')
                   with urllib.request.urlopen(req, timeout=10) as r:
                       d = json.loads(r.read())
                       assert d['result']['serverInfo']['name'] == 'dcc-mcp-blender', d
@@ -510,7 +511,8 @@ jobs:
               'params':{'protocolVersion':'2025-03-26','capabilities':{},
                         'clientInfo':{'name':'ci2','version':'1'}}}).encode()
           req = urllib.request.Request(url, data=body,
-              headers={'Content-Type':'application/json'}, method='POST')
+              headers={'Content-Type':'application/json',
+                       'Accept':'application/json, text/event-stream'}, method='POST')
           with urllib.request.urlopen(req, timeout=10) as r:
               d = json.loads(r.read())
               assert d['result']['serverInfo']['name'] == 'dcc-mcp-blender', d

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ lib/
 lib64/
 MANIFEST
 
+# Never commit mistaken wheel extracts / nested copies under the adapter package
+src/dcc_mcp_blender/dcc_mcp_core/
+src/dcc_mcp_blender/dcc_mcp_blender/
+
 # Virtual environments
 .env
 .venv
@@ -81,3 +85,4 @@ site/
 # Release
 CHANGELOG.md
 *.zip
+dist_*

--- a/README.md
+++ b/README.md
@@ -67,10 +67,14 @@
 
 ### Option 1 — Install as Blender Addon (ZIP)
 
-1. Download the latest `dcc_mcp_blender_addon_vX.Y.Z.zip` from the [Releases](https://github.com/loonghao/dcc-mcp-blender/releases) page
-2. In Blender: **Edit → Preferences → Add-ons → Install…** → select the ZIP
-3. Enable **DCC MCP Blender** in the addon list
+1. Download the latest platform ZIP from the [Releases](https://github.com/loonghao/dcc-mcp-blender/releases) page:
+   `dcc_mcp_blender_addon_win64_vX.Y.Z.zip`, `dcc_mcp_blender_addon_linux_vX.Y.Z.zip`, or
+   `dcc_mcp_blender_addon_macos_vX.Y.Z.zip`
+2. In Blender 4.2+: **Edit → Preferences → Extensions → Install from Disk…** → select the ZIP
+3. Enable **DCC MCP Blender**
 4. The MCP server starts automatically on `http://127.0.0.1:8765`
+
+Release ZIPs include `blender_manifest.toml` and the matching `dcc-mcp-core` wheel under `wheels/`, so Blender installs the Python dependency into the extension's isolated environment.
 
 ### Option 2 — Install via pip (for scripts / CI)
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,359 @@
+# dcc-mcp-blender development justfile
+# Unified dependency and task management
+
+set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+set shell := ["bash", "-c"]
+set dotenv-load := true
+
+# Default recipe
+default:
+    @just --list
+
+# ============================================================================
+# Dependency Management
+# ============================================================================
+
+# Install development dependencies
+@install-dev:
+    echo "🔧 Installing development dependencies..."
+    python -m pip install --upgrade pip
+    python -m pip install -e ".[dev]"
+    echo "✅ Development dependencies installed"
+
+# Install minimal dependencies (production only)
+@install-prod:
+    echo "🔧 Installing production dependencies..."
+    python -m pip install --upgrade pip
+    python -m pip install -e .
+    echo "✅ Production dependencies installed"
+
+# Install all dependencies (dev + test + build)
+@install-all: install-dev
+    echo "✅ All dependencies ready"
+
+# Verify dependency installation
+@verify-deps:
+    echo "🔍 Verifying dependency installation..."
+    python -c "from dcc_mcp_blender import start_server; print('✓ dcc_mcp_blender')"
+    python -c "from dcc_mcp_core import create_skill_server; print('✓ dcc_mcp_core')"
+    python -c "import pytest; print('✓ pytest')"
+    python -c "import bpy" 2>/dev/null && echo "✓ bpy (Blender Python)" || echo "⚠️  bpy not available (install in Blender or use blender python)"
+    echo "✅ Core dependencies verified"
+
+# ============================================================================
+# Linting & Code Quality
+# ============================================================================
+
+# Run ruff check on src/ and tests/
+@lint:
+    echo "🔍 Running ruff lint check..."
+    python -m ruff check src/ tests/
+    echo "✅ Lint check passed"
+
+# Auto-fix ruff errors
+@lint-fix:
+    echo "🔧 Auto-fixing ruff errors..."
+    python -m ruff check --fix src/ tests/
+    echo "✅ Lint errors fixed"
+
+# Lint SKILL.md files
+@lint-skills:
+    echo "🔍 Linting SKILL.md files..."
+    @if [ -f "tools/lint_skills.py" ]; then \
+        python tools/lint_skills.py --error-only; \
+    else \
+        echo "⚠️  tools/lint_skills.py not found, skipping"; \
+    fi
+    echo "✅ SKILL.md lint passed"
+
+# Run all lint checks
+lint-all: lint lint-skills
+    echo "✅ All lint checks passed"
+
+# Pre-commit gate: auto-fix, format, lint, quick tests.
+# Run this before every commit/push to avoid CI failures.
+# Usage: vx just prek   or   just prek
+@prek:
+    echo "🔧 Auto-fixing ruff errors..."
+    python -m ruff check --fix src/ tests/
+    echo "🎨 Formatting with ruff..."
+    python -m ruff format src/ tests/
+    echo "🔍 Running all lint checks..."
+    python -m ruff check src/ tests/
+    @if [ -f "tools/lint_skills.py" ]; then \
+        python tools/lint_skills.py --error-only; \
+    fi
+    echo "🧪 Running quick tests..."
+    python -m pytest tests/ -x -q --ignore=tests/test_e2e_blender_standalone.py 2>/dev/null || python -m pytest tests/ -x -q
+    echo "✅ prek passed — safe to commit"
+
+# ============================================================================
+# Testing
+# ============================================================================
+
+# Run basic import tests
+@test-imports:
+    echo "🧪 Running import tests..."
+    python -m pytest tests/test_basic_imports.py -v 2>/dev/null || echo "⚠️  test_basic_imports.py not found"
+    echo "✅ Import tests passed"
+
+# Run all quick tests (no blender required)
+@test-quick:
+    echo "🧪 Running quick tests..."
+    python -m pytest tests/ -x -q
+    echo "✅ Quick tests passed"
+
+# Run tests with coverage
+@test-coverage:
+    echo "🧪 Running tests with coverage..."
+    python -m pytest --cov=dcc_mcp_blender --cov-report=term-missing tests/
+    echo "✅ Tests complete with coverage report"
+
+# Run specific test file
+@test file="tests/test_basic_imports.py":
+    python -m pytest {{file}} -v
+
+# ============================================================================
+# Development Workflow
+# ============================================================================
+
+# Setup development environment (install + verify)
+@setup: install-dev verify-deps
+    echo "✅ Development environment ready"
+
+# Check code before commit (lint + quick tests)
+@check: lint test-quick
+    echo "✅ All checks passed - ready to commit"
+
+# Full CI simulation (lint + tests)
+@ci: lint-all test-coverage
+    echo "✅ CI simulation complete"
+
+# Clean build artifacts
+@clean:
+    echo "🧹 Cleaning build artifacts..."
+    rm -rf build/ dist/ *.egg-info
+    find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+    find . -type f -name "*.pyc" -delete
+    echo "✅ Cleaned"
+
+# Full clean (including test cache)
+@clean-all: clean
+    echo "🧹 Deep cleaning..."
+    rm -rf .pytest_cache .ruff_cache .coverage htmlcov/
+    rm -rf tests/.pytest_cache
+    echo "✅ Fully cleaned"
+
+# ============================================================================
+# Help & Info
+# ============================================================================
+
+# Show Python and dependency versions
+@versions:
+    python tools/show_versions.py
+
+# Show dependency tree
+@deps-tree:
+    echo "📦 Dependency tree (core packages):"
+    python -m pip show dcc-mcp-blender -f 2>/dev/null | grep "Location\|Requires" || echo "dcc-mcp-blender not installed"
+    echo ""
+    python -m pip show dcc-mcp-core -f | grep "Location\|Requires"
+
+# ============================================================================
+# CI/CD Utilities
+# ============================================================================
+
+# Install CI dependencies (for GitHub Actions)
+@install-ci: install-dev
+    echo "✅ CI dependencies ready"
+
+# Run CI checks locally
+@run-ci: clean lint-all test-quick
+    echo "✅ Local CI checks passed"
+
+# ============================================================================
+# Troubleshooting
+# ============================================================================
+
+# Diagnose dependency issues
+@diagnose:
+    echo "🔍 Diagnosing environment..."
+    echo ""
+    echo "Python version:"
+    python --version
+    echo ""
+    echo "Pip version:"
+    python -m pip --version
+    echo ""
+    echo "Installed packages (key ones):"
+    python -m pip list | grep -E "dcc-mcp|pytest|ruff"
+    echo ""
+    echo "Trying imports:"
+    python -c "from dcc_mcp_blender import start_server; print('✓ dcc_mcp_blender imports OK')" 2>&1 || echo "✗ dcc_mcp_blender import failed"
+    python -c "from dcc_mcp_core import create_skill_server; print('✓ dcc_mcp_core imports OK')" 2>&1 || echo "✗ dcc_mcp_core import failed"
+    echo ""
+    echo "✅ Diagnostic complete"
+
+# Reinstall all dependencies from scratch
+@reinstall-all: clean-all
+    echo "🔧 Removing pip cache..."
+    python -m pip cache purge
+    echo "🔧 Reinstalling all dependencies..."
+    just install-all
+    just verify-deps
+    echo "✅ Full reinstall complete"
+
+# Fix common dependency issues
+@fix-deps:
+    echo "🔧 Attempting to fix dependency issues..."
+    echo "  - Upgrading pip..."
+    python -m pip install --upgrade pip setuptools wheel
+    echo "  - Installing core dependencies..."
+    python -m pip install -e .
+    echo "  - Installing dev dependencies..."
+    python -m pip install -e ".[dev]"
+    echo "✅ Dependency issues fixed"
+
+# ============================================================================
+# Blender Local Development
+# ============================================================================
+
+# Blender version for local dev (override: just blender-version=4.2 blender-link)
+blender-version := env("BLENDER_VERSION", "4.2")
+
+# Detect Blender scripts directory (platform-aware)
+_blender-scripts-dir := if os() == "windows" {
+    env("APPDATA", "") + "/Blender Foundation/Blender/" + blender-version + "/scripts"
+} else if os() == "macos" {
+    env("HOME", "") + "/Library/Application Support/Blender/" + blender-version + "/scripts"
+} else {
+    env("HOME", "") + "/.config/blender/" + blender-version + "/scripts"
+}
+
+# Detect Blender addons directory
+_blender-addons-dir := _blender-scripts-dir + "/addons"
+
+# Create symlinks from source tree into Blender's addons directory for live development.
+# After running this, enabling the addon in Blender will use your local source code directly —
+# edits take effect on next Blender restart (or via F8 reload scripts).
+@blender-link:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." 2>/dev/null && pwd || pwd)"
+    # On Windows in Git Bash, use the script's real location
+    if [ -f "justfile" ]; then PROJECT_ROOT="$(pwd)"; fi
+
+    ADDONS_DIR="{{ _blender-addons-dir }}"
+    TARGET="$ADDONS_DIR/dcc_mcp_blender"
+
+    echo "🔗 Setting up Blender dev symlinks (Blender {{ blender-version }})..."
+    echo "   Project  : $PROJECT_ROOT"
+    echo "   Addons   : $ADDONS_DIR"
+    echo ""
+
+    # Create addons dir if needed
+    mkdir -p "$ADDONS_DIR"
+
+    # Remove old link/dir if exists
+    if [ -L "$TARGET" ]; then
+        rm "$TARGET"
+        echo "   Removed old symlink"
+    elif [ -d "$TARGET" ]; then
+        echo "   ⚠️  $TARGET is a real directory (not a symlink)."
+        echo "   Remove it manually if you want to use dev symlinks."
+        exit 1
+    fi
+
+    # Create symlink
+    if [ "$(uname -s)" = "MINGW"* ] || [ "$(uname -s)" = "MSYS"* ] || [ -n "${WINDIR:-}" ]; then
+        # Windows (Git Bash): use mklink (requires admin or developer mode)
+        cmd //c "mklink /D \"$(cygpath -w "$TARGET")\" \"$(cygpath -w "$PROJECT_ROOT/src/dcc_mcp_blender")\"" 2>/dev/null || \
+            { echo "   ⚠️  Symlink failed, copying instead..."; cp -r "$PROJECT_ROOT/src/dcc_mcp_blender" "$TARGET"; }
+    else
+        # Unix: symlinks just work
+        ln -sf "$PROJECT_ROOT/src/dcc_mcp_blender" "$TARGET"
+    fi
+
+    echo ""
+    echo "   ✅ Symlink created:"
+    echo "      $TARGET → $PROJECT_ROOT/src/dcc_mcp_blender (live source)"
+    echo ""
+    echo "   Next: start Blender {{ blender-version }} → Edit → Preferences → Add-ons → Enable 'DCC MCP Blender'"
+    echo "   Edit source → restart Blender (or press F8 to reload scripts) to see changes."
+
+# Windows version: Create symlinks using PowerShell (for native Windows without Git Bash)
+@blender-link-win:
+    powershell -NoProfile -ExecutionPolicy Bypass -File tools/blender-link-win.ps1 -BlenderVersion {{ blender-version }}
+
+# Remove dev symlinks and addon files
+@blender-unlink:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ADDONS_DIR="{{ _blender-addons-dir }}"
+    TARGET="$ADDONS_DIR/dcc_mcp_blender"
+
+    echo "🧹 Removing Blender dev symlinks..."
+
+    if [ -d "$TARGET" ]; then
+        rm -rf "$TARGET"
+        echo "   Removed $TARGET"
+    fi
+
+    echo "   ✅ Dev symlinks cleaned up"
+
+# Windows version: Remove dev symlinks using PowerShell
+@blender-unlink-win:
+    powershell -NoProfile -ExecutionPolicy Bypass -File tools/blender-unlink-win.ps1
+
+# Show current Blender dev link status
+@blender-status:
+    #!/usr/bin/env bash
+    ADDONS_DIR="{{ _blender-addons-dir }}"
+    TARGET="$ADDONS_DIR/dcc_mcp_blender"
+
+    echo "📋 Blender dev link status:"
+    echo "   Addons dir: $ADDONS_DIR"
+    echo ""
+
+    if [ -L "$TARGET" ]; then
+        REAL=$(readlink "$TARGET" 2>/dev/null || echo "?")
+        echo "   ✅ dcc_mcp_blender → $REAL (symlink)"
+    elif [ -d "$TARGET" ]; then
+        echo "   ⚠️  dcc_mcp_blender exists (copied, not linked)"
+    else
+        echo "   ❌ dcc_mcp_blender not found"
+    fi
+
+# Windows version: Show Blender dev link status using PowerShell
+@blender-status-win:
+    powershell -NoProfile -ExecutionPolicy Bypass -File tools/blender-status-win.ps1
+
+# Start Blender with dev addon loaded (Unix/macOS)
+@blender-start:
+    echo "🚀 Starting Blender {{ blender-version }}..."
+    blender || /Applications/Blender.app/Contents/MacOS/Blender || echo "❌ Blender not found in PATH"
+
+# Windows version: Start Blender
+@blender-start-win blender-version="{{ blender-version }}":
+    powershell -NoProfile -ExecutionPolicy Bypass -Command "& { \
+        $$blenderPath = 'C:\Program Files\Blender Foundation\Blender {{ blender-version }}\blender.exe'; \
+        if (Test-Path $$blenderPath) { \
+            Start-Process $$blenderPath \
+        } else { \
+            Write-Host '❌ Blender not found at:' $$blenderPath; \
+            Write-Host '   Please install Blender or set BLENDER_PATH environment variable' \
+        } \
+    }"
+
+# Full local dev setup: link + verify
+blender-dev: blender-link verify-deps
+    @echo ""
+    @echo "📋 Dev environment linked. Now start Blender:"
+    @echo "   Unix/macOS: just blender-start"
+    @echo "   Windows: just blender-start (or use blender-link-win for PowerShell)"
+    @echo ""
+    @echo "   Then in Blender: Edit → Preferences → Add-ons → Enable 'DCC MCP Blender'"
+    @echo ""
+    @echo "   Verify with:"
+    @echo "     just blender-status       # Unix/macOS"
+    @echo "     just blender-status-win   # Windows"

--- a/justfile
+++ b/justfile
@@ -285,6 +285,11 @@ _blender-addons-dir := _blender-scripts-dir + "/addons"
 @blender-link-win:
     powershell -NoProfile -ExecutionPolicy Bypass -File tools/blender-link-win.ps1 -BlenderVersion {{ blender-version }}
 
+# Build a Blender-installable addon ZIP (bundles dcc-mcp-core from PyPI). Output: dist_addon/
+# Pick platform from host OS — run with explicit platform: `python packaging/assemble_zip.py --platform win64`
+blender-addon-zip:
+    python packaging/assemble_zip.py --platform {{ if os() == "windows" { "win64" } else if os() == "macos" { "macos" } else { "linux" } }} --output-dir dist_addon/
+
 # Remove dev symlinks and addon files
 @blender-unlink:
     #!/usr/bin/env bash
@@ -357,3 +362,27 @@ blender-dev: blender-link verify-deps
     @echo "   Verify with:"
     @echo "     just blender-status       # Unix/macOS"
     @echo "     just blender-status-win   # Windows"
+
+# ============================================================================
+# Blender + Core Development (with dcc-mcp-core build)
+# ============================================================================
+
+# Windows: build dcc-mcp-core with Blender's Python, then symlink both
+# `dcc_mcp_core` (from core's `python/dcc_mcp_core`) and `dcc_mcp_blender` (from `src/dcc_mcp_blender`)
+# into Blender's addons directory. Then start Blender for debugging.
+#
+# After run, use MCP URL printed below; see Blender MCP setup docs for Cursor + debugpy.
+# Default core repo: sibling directory `../dcc-mcp-core` or env `DCC_MCP_CORE_REPO`.
+#
+#   just blender-dev-build-link-core-win
+#   just blender-dev-debug-win
+#   just blender-version=4.3 blender-dev-debug-win
+@blender-dev-build-link-core-win:
+    powershell -NoProfile -ExecutionPolicy Bypass -File tools/blender-dev-build-link-core-win.ps1 -BlenderVersion {{ blender-version }}
+
+@blender-dev-debug-win:
+    powershell -NoProfile -ExecutionPolicy Bypass -File tools/blender-dev-build-link-core-win.ps1 -BlenderVersion {{ blender-version }} -LaunchBlender
+
+# Windows: only refresh symlinks (skip maturin develop) after you already built core.
+@blender-dev-relink-core-win:
+    powershell -NoProfile -ExecutionPolicy Bypass -File tools/blender-dev-build-link-core-win.ps1 -BlenderVersion {{ blender-version }} -SkipBuild

--- a/packaging/addon_entry/__init__.py
+++ b/packaging/addon_entry/__init__.py
@@ -1,0 +1,310 @@
+"""Blender add-on / extension entry for DCC MCP Blender.
+
+Shipped at the root of the add-on folder next to ``blender_manifest.toml``.
+Keeps ``bl_info`` for legacy ``scripts/addons`` installs and supplies the
+extension manifest for Blender 4.2+ extension workflows.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import webbrowser
+from typing import List, Tuple
+
+import bpy
+
+# Do not mutate sys.path — Blender extensions forbid injecting the add-on root into
+# sys.path (policy violation). Dependencies are loaded via blender_manifest.toml wheels.
+
+logger = logging.getLogger(__name__)
+
+try:
+    from dcc_mcp_blender.__version__ import __version__ as _PKG_VERSION  # noqa: E402
+except Exception:  # noqa: BLE001
+    _PKG_VERSION = "0.1.0"
+
+
+def _version_tuple() -> Tuple[int, int, int]:
+    parts = (_PKG_VERSION.split(".") + ["0", "0", "0"])[:3]
+    try:
+        return int(parts[0]), int(parts[1]), int(parts[2])
+    except ValueError:
+        return 0, 1, 0
+
+
+bl_info = {
+    "name": "DCC MCP Blender",
+    "author": "Long Hao",
+    "version": _version_tuple(),
+    "blender": (4, 2, 0),
+    "location": "Top Bar > DCC MCP",
+    "description": "Embeds an MCP HTTP server inside Blender for AI-driven 3D workflows",
+    "category": "System",
+    "doc_url": "https://github.com/loonghao/dcc-mcp-blender",
+    "tracker_url": "https://github.com/loonghao/dcc-mcp-blender/issues",
+}
+
+_DEFAULT_GATEWAY_PORT = 9765
+
+_draw_handlers: List[Tuple[str, object]] = []
+
+
+def _running_server():
+    try:
+        from dcc_mcp_blender.server import get_server  # noqa: PLC0415
+
+        return get_server()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("get_server failed: %s", exc)
+        return None
+
+
+def _mcp_url() -> str:
+    srv = _running_server()
+    if srv is None:
+        return ""
+    url = getattr(srv, "mcp_url", None)
+    return url or ""
+
+
+def _http_base() -> str:
+    url = _mcp_url()
+    if not url:
+        return ""
+    return url.replace("/mcp", "").rstrip("/")
+
+
+def _gateway_base() -> str:
+    raw = os.environ.get("DCC_MCP_GATEWAY_PORT", str(_DEFAULT_GATEWAY_PORT)).strip()
+    if not raw.isdigit():
+        return ""
+    port = int(raw, 10)
+    if port <= 0:
+        return ""
+    return f"http://127.0.0.1:{port}"
+
+
+class DCCMCP_OT_open_mcp(bpy.types.Operator):
+    bl_idname = "dcc_mcp.open_mcp_endpoint"
+    bl_label = "Open MCP Endpoint"
+    bl_options = {"REGISTER"}
+
+    @classmethod
+    def poll(cls, context) -> bool:
+        return bool(_mcp_url())
+
+    def execute(self, context):
+        url = _mcp_url()
+        if url:
+            webbrowser.open(url)
+            self.report({"INFO"}, f"Opened {url}")
+        return {"FINISHED"}
+
+
+class DCCMCP_OT_open_openapi(bpy.types.Operator):
+    bl_idname = "dcc_mcp.open_openapi_docs"
+    bl_label = "OpenAPI Docs"
+    bl_options = {"REGISTER"}
+
+    @classmethod
+    def poll(cls, context) -> bool:
+        return bool(_http_base())
+
+    def execute(self, context):
+        base = _http_base()
+        if base:
+            webbrowser.open(base + "/docs")
+            self.report({"INFO"}, "Opened /docs")
+        return {"FINISHED"}
+
+
+class DCCMCP_OT_open_admin(bpy.types.Operator):
+    bl_idname = "dcc_mcp.open_admin_panel"
+    bl_label = "Gateway Admin"
+    bl_options = {"REGISTER"}
+
+    @classmethod
+    def poll(cls, context) -> bool:
+        return bool(_gateway_base())
+
+    def execute(self, context):
+        gw = _gateway_base()
+        if gw:
+            webbrowser.open(gw + "/admin")
+            self.report({"INFO"}, "Opened gateway /admin")
+        return {"FINISHED"}
+
+
+class DCCMCP_OT_open_metrics(bpy.types.Operator):
+    bl_idname = "dcc_mcp.open_metrics"
+    bl_label = "Prometheus Metrics"
+    bl_options = {"REGISTER"}
+
+    @classmethod
+    def poll(cls, context) -> bool:
+        return bool(_http_base())
+
+    def execute(self, context):
+        base = _http_base()
+        if base:
+            webbrowser.open(base + "/metrics")
+            self.report({"INFO"}, "Opened /metrics")
+        return {"FINISHED"}
+
+
+class DCCMCP_OT_show_urls(bpy.types.Operator):
+    bl_idname = "dcc_mcp.show_server_urls"
+    bl_label = "Show Server URLs…"
+    bl_options = {"REGISTER"}
+
+    def execute(self, context):
+        srv = _running_server()
+        lines: List[str] = []
+        if srv is None:
+            lines.append("MCP server is not running.")
+        else:
+            url = getattr(srv, "mcp_url", None) or "<unknown>"
+            lines.append(f"MCP: {url}")
+            gw = getattr(srv, "gateway_url", None)
+            if gw:
+                lines.append(f"Gateway: {gw}")
+            lines.append("Instances: MCP resources/read uri=gateway://instances")
+
+        def draw(menu, ctx):
+            col = menu.layout.column(align=True)
+            for line in lines:
+                col.label(text=line)
+
+        context.window_manager.popup_menu(draw, title="DCC MCP Blender")
+        return {"FINISHED"}
+
+
+class DCCMCP_OT_restart(bpy.types.Operator):
+    bl_idname = "dcc_mcp.restart_server"
+    bl_label = "Restart MCP Server"
+    bl_options = {"REGISTER"}
+
+    def execute(self, context):
+        try:
+            from dcc_mcp_blender.server import start_server, stop_server  # noqa: PLC0415
+
+            stop_server()
+            start_server()
+            self.report({"INFO"}, "MCP server restarted")
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("restart failed")
+            self.report({"ERROR"}, str(exc))
+        return {"FINISHED"}
+
+
+class DCCMCP_OT_toggle_hot_reload(bpy.types.Operator):
+    bl_idname = "dcc_mcp.toggle_hot_reload"
+    bl_label = "Toggle Skill Hot-Reload"
+    bl_options = {"REGISTER"}
+
+    @classmethod
+    def poll(cls, context) -> bool:
+        return _running_server() is not None
+
+    def execute(self, context):
+        srv = _running_server()
+        if srv is None:
+            return {"CANCELLED"}
+        try:
+            if srv.is_hot_reload_enabled:
+                srv.disable_hot_reload()
+                self.report({"INFO"}, "Hot-reload disabled")
+            else:
+                if srv.enable_hot_reload():
+                    self.report({"INFO"}, "Hot-reload enabled")
+                else:
+                    self.report({"WARNING"}, "Could not enable hot-reload")
+        except Exception as exc:  # noqa: BLE001
+            self.report({"ERROR"}, str(exc))
+        return {"FINISHED"}
+
+
+class DCCMCP_MT_main_menu(bpy.types.Menu):
+    bl_label = "DCC MCP"
+    bl_idname = "DCCMCP_MT_main_menu"
+
+    def draw(self, context):
+        layout = self.layout.column(align=True)
+        layout.operator("dcc_mcp.show_server_urls", icon="INFO")
+        layout.separator()
+        layout.operator("dcc_mcp.open_mcp_endpoint", icon="URL")
+        layout.operator("dcc_mcp.open_openapi_docs", icon="DOCUMENTS")
+        layout.operator("dcc_mcp.open_metrics", icon="GRAPH")
+        layout.separator()
+        layout.operator("dcc_mcp.open_admin_panel", icon="SETTINGS")
+        layout.separator()
+        layout.operator("dcc_mcp.restart_server", icon="FILE_REFRESH")
+        layout.operator("dcc_mcp.toggle_hot_reload", icon="FILE_CACHE")
+
+
+def _draw_topbar_menu(self, context):
+    self.layout.menu(DCCMCP_MT_main_menu.bl_idname, text="DCC MCP")
+
+
+_CLASSES = (
+    DCCMCP_OT_open_mcp,
+    DCCMCP_OT_open_openapi,
+    DCCMCP_OT_open_admin,
+    DCCMCP_OT_open_metrics,
+    DCCMCP_OT_show_urls,
+    DCCMCP_OT_restart,
+    DCCMCP_OT_toggle_hot_reload,
+    DCCMCP_MT_main_menu,
+)
+
+
+def register() -> None:
+    global _draw_handlers  # noqa: PLW0603
+    for cls in _CLASSES:
+        bpy.utils.register_class(cls)
+
+    if hasattr(bpy.types, "TOPBAR_MT_blender"):
+        bpy.types.TOPBAR_MT_blender.append(_draw_topbar_menu)
+        _draw_handlers.append(("TOPBAR_MT_blender", _draw_topbar_menu))
+    else:
+        logger.warning("TOPBAR_MT_blender missing — DCC MCP top-bar menu not attached")
+
+    try:
+        from dcc_mcp_blender.server import get_server, start_server  # noqa: PLC0415
+
+        start_server()
+        srv = get_server()
+        url = getattr(srv, "mcp_url", None) if srv is not None else None
+        if url:
+            print("[DCC MCP Blender] Server started —", url)
+        else:
+            print("[DCC MCP Blender] Server start requested (URL not yet available)")
+    except Exception as exc:  # noqa: BLE001
+        print(f"[DCC MCP Blender] Failed to start server: {exc}")
+
+
+def unregister() -> None:
+    global _draw_handlers  # noqa: PLW0603
+    for target, fn in reversed(_draw_handlers):
+        menu = getattr(bpy.types, target, None)
+        if menu is not None and fn is not None:
+            try:
+                menu.remove(fn)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("menu remove %s: %s", target, exc)
+    _draw_handlers.clear()
+
+    for cls in reversed(_CLASSES):
+        try:
+            bpy.utils.unregister_class(cls)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("unregister %s: %s", cls, exc)
+
+    try:
+        from dcc_mcp_blender.server import stop_server  # noqa: PLC0415
+
+        stop_server()
+        print("[DCC MCP Blender] Server stopped")
+    except Exception as exc:  # noqa: BLE001
+        print(f"[DCC MCP Blender] Failed to stop server: {exc}")

--- a/packaging/addon_entry/blender_manifest.toml
+++ b/packaging/addon_entry/blender_manifest.toml
@@ -1,0 +1,30 @@
+# Blender extension manifest (4.2+ extensions / bundling).
+# https://docs.blender.org/manual/en/latest/advanced/extensions/getting_started.html
+# Version is bumped only by release-please (keep in sync with pyproject / wheel).
+
+schema_version = "1.0.0"
+
+id = "dcc_mcp_blender"
+# x-release-please-version
+version = "0.1.2"
+name = "DCC MCP Blender"
+tagline = "MCP Streamable HTTP server inside Blender for AI-driven workflows"
+maintainer = "Long Hao <hal.long@outlook.com>"
+type = "add-on"
+
+tags = ["System", "Pipeline", "Animation"]
+
+# Minimum Blender version for the Extensions + wheels workflow (see Blender manual).
+blender_version_min = "4.2.0"
+
+license = ["SPDX:MIT"]
+
+location = "Top Bar > DCC MCP"
+description = "Embeds an MCP HTTP server (2025-03-26) for Claude, Cursor, and other MCP clients."
+category = "System"
+
+website = "https://github.com/loonghao/dcc-mcp-blender"
+
+[permissions]
+network = "Host MCP HTTP/SSE and optional gateway election on localhost"
+files = "Read bundled skills and SKILL packages from disk"

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -1,10 +1,24 @@
 """Assemble a Blender addon ZIP package for dcc-mcp-blender.
 
 This script:
-1. Resolves the latest compatible dcc-mcp-core version from PyPI
-2. Downloads the appropriate platform wheel(s)
-3. Bundles the dcc_mcp_blender package + dcc-mcp-core into a Blender addon ZIP
-4. Produces a file named ``dcc_mcp_blender_addon_{platform}_v{version}.zip``
+1. Resolves the latest compatible dcc-mcp-core version from PyPI (>= MIN_CORE_VERSION).
+2. Downloads the best platform wheel (prefer ``cp38-abi3-*`` — PyPI does not ship
+   ``cp311-cp311-*`` builds; Blender 4.x Python still loads stable-ABI wheels).
+3. Copies the ``dcc-mcp-core`` **wheel** into ``wheels/`` and records it in
+   ``blender_manifest.toml`` under ``wheels = [...]`` so Blender installs it into
+   the extension's isolated ``site-packages`` (no ``sys.path`` hacks, no loose
+   ``dcc_mcp_core/`` tree — required for Blender 4.2+ extensions policy).
+4. Bundles ``dcc_mcp_blender/`` (adapter + skills) under the same folder.
+5. Produces ``dcc_mcp_blender_addon_{platform}_v{version}.zip`` — install via
+   **Edit → Preferences → Extensions → Install from Disk** (recommended) or
+   legacy add-ons path (extensions layout + wheels is still valid when installed
+   as an extension from disk).
+
+Version strings in ``pyproject.toml``, ``src/dcc_mcp_blender/__version__.py``, and
+``packaging/addon_entry/blender_manifest.toml`` are maintained by **release-please**
+only; this script reads ``pyproject.toml`` for the ZIP filename, copies the manifest
+from ``addon_entry/``, then appends the ``wheels = [...]`` entry for the downloaded
+``dcc-mcp-core`` wheel basename.
 
 Usage::
 
@@ -16,12 +30,9 @@ Usage::
 from __future__ import annotations
 
 import argparse
-import io
-import os
 import pathlib
 import re
 import shutil
-import sys
 import tempfile
 import urllib.request
 import zipfile
@@ -30,19 +41,45 @@ import zipfile
 
 PACKAGE_ROOT = pathlib.Path(__file__).parent.parent
 SRC_DIR = PACKAGE_ROOT / "src" / "dcc_mcp_blender"
+ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
-MIN_CORE_VERSION = "0.12.18"
+# Must stay in sync with ``pyproject.toml`` dependency floor.
+MIN_CORE_VERSION = "0.17.5"
 CORE_PACKAGE = "dcc-mcp-core"
+ADDON_PLATFORMS = ("win64", "linux", "macos")
 
-# Platform → Python ABI tag (Blender 4.x ships Python 3.11+)
-PLATFORM_PYTHON = {
-    "win64": [("cp311-cp311-win_amd64", "3.11"), ("cp310-cp310-win_amd64", "3.10")],
-    "linux": [("cp311-cp311-linux_x86_64", "3.11"), ("cp310-cp310-linux_x86_64", "3.10")],
-    "macos": [("cp311-cp311-macosx_10_15_x86_64", "3.11"), ("cp311-cp311-macosx_11_0_arm64", "3.11")],
-}
+# PyPI ships ``cp38-abi3-*`` wheels (stable ABI) for win/linux/macos — not cp311-tagged wheels.
+# Match platform first, then prefer stable abi3 builds.
 
 PYPI_URL = "https://pypi.org/pypi/{package}/json"
+
+# Never bundle mistaken local trees (e.g. accidental wheel extracts under src/).
+_SKIPPED_TOP_LEVEL_NAMES = frozenset({"dcc_mcp_blender", "dcc_mcp_core", "__pycache__"})
+
+
+def _ignore_for_addon_copy(path: str, names: list[str]) -> set[str]:
+    """Skip junk subtrees and bytecode when staging the addon."""
+    ignored: set[str] = set()
+    try:
+        if pathlib.Path(path).resolve() == SRC_DIR.resolve():
+            ignored.update(n for n in names if n in _SKIPPED_TOP_LEVEL_NAMES)
+    except OSError:
+        pass
+    ignored.update(n for n in names if n == "__pycache__" or n.endswith(".pyc"))
+    return ignored
+
+
+def _verify_skills_payload(staged_pkg: pathlib.Path) -> None:
+    """Fail fast when the bundled skill tree is incomplete."""
+    skills_dir = staged_pkg / "skills"
+    if not skills_dir.is_dir():
+        raise RuntimeError(f"Missing skills directory after copy: {skills_dir}")
+    skill_manifests = list(skills_dir.glob("*/SKILL.md"))
+    if len(skill_manifests) < 10:
+        raise RuntimeError(
+            f"Expected at least 10 bundled skills (SKILL.md), found {len(skill_manifests)} under {skills_dir}"
+        )
 
 
 # ── helpers ────────────────────────────────────────────────────────────────────
@@ -70,39 +107,72 @@ def resolve_core_version(min_version: str = MIN_CORE_VERSION) -> str:
     return str(best)
 
 
-def download_core_wheels(version: str, platform: str, dest_dir: pathlib.Path) -> list[pathlib.Path]:
-    """Download dcc-mcp-core wheel(s) for the given platform."""
+def _wheel_matches_platform(filename: str, platform: str) -> bool:
+    if not filename.endswith(".whl"):
+        return False
+    if platform == "win64":
+        return "win_amd64" in filename or "win32" in filename
+    if platform == "linux":
+        return "linux" in filename and ("x86_64" in filename or "aarch64" in filename)
+    if platform == "macos":
+        return "macosx" in filename
+    return False
+
+
+def _wheel_rank(filename: str) -> tuple[int, str]:
+    """Lower tuple sorts first (more desirable)."""
+    if "cp38-abi3" in filename:
+        pri = 0
+    elif "abi3" in filename:
+        pri = 1
+    elif "cp312" in filename:
+        pri = 2
+    elif "cp311" in filename:
+        pri = 3
+    elif "cp310" in filename:
+        pri = 4
+    elif "py3-none-any" in filename or "py310-none-any" in filename or "py311-none-any" in filename:
+        pri = 5
+    else:
+        pri = 50
+    return (pri, filename)
+
+
+def pick_core_wheel_file(release_files: list[dict], platform: str) -> dict | None:
+    """Return the single best PyPI file dict for *platform*, or ``None``."""
+    candidates = [f for f in release_files if _wheel_matches_platform(f.get("filename", ""), platform)]
+    if not candidates:
+        return None
+    candidates.sort(key=lambda f: _wheel_rank(f["filename"]))
+    return candidates[0]
+
+
+def download_core_wheel(version: str, platform: str, dest_dir: pathlib.Path) -> pathlib.Path:
+    """Download exactly one dcc-mcp-core wheel for *platform*.
+
+    Raises:
+        RuntimeError: When no compatible wheel exists on PyPI for this platform/version.
+    """
     data = _fetch_json(PYPI_URL.format(package=CORE_PACKAGE))
     release_files = data["releases"].get(version, [])
+    pick = pick_core_wheel_file(release_files, platform)
+    if pick is None:
+        sample = [f["filename"] for f in release_files if f["filename"].endswith(".whl")][:12]
+        raise RuntimeError(
+            f"No {CORE_PACKAGE} wheel for platform={platform!r} at version {version!r}. "
+            f"PyPI wheel sample: {sample}"
+        )
 
-    abi_patterns = PLATFORM_PYTHON.get(platform, [])
-    # Also accept any3 / abi3 wheels (py3-none-any or cp3X-abi3)
-    generic_patterns = ["py3-none-any", "py310-none-any", "py311-none-any"]
-
-    downloaded: list[pathlib.Path] = []
     dest_dir.mkdir(parents=True, exist_ok=True)
-
-    for file_info in release_files:
-        filename = file_info["filename"]
-        if not filename.endswith(".whl"):
-            continue
-
-        matched = any(pat in filename for pat, _ in abi_patterns)
-        generic_match = any(p in filename for p in generic_patterns)
-
-        if matched or generic_match:
-            url = file_info["url"]
-            dest = dest_dir / filename
-            if not dest.exists():
-                print(f"  Downloading: {filename}")
-                urllib.request.urlretrieve(url, dest)  # noqa: S310
-            else:
-                print(f"  Cached: {filename}")
-            downloaded.append(dest)
-
-    if not downloaded:
-        print(f"  Warning: no wheels found for platform '{platform}', skipping core bundling")
-    return downloaded
+    filename = pick["filename"]
+    url = pick["url"]
+    dest = dest_dir / filename
+    if not dest.exists():
+        print(f"  Downloading: {filename}")
+        urllib.request.urlretrieve(url, dest)  # noqa: S310
+    else:
+        print(f"  Cached: {filename}")
+    return dest
 
 
 def extract_wheel(wheel_path: pathlib.Path, dest_dir: pathlib.Path) -> None:
@@ -123,11 +193,36 @@ def get_package_version() -> str:
     return m.group(1)
 
 
+def _read_assigned_quoted_string(path: pathlib.Path, key: str) -> str:
+    text = path.read_text(encoding="utf-8")
+    m = re.search(rf"^{re.escape(key)}\s*=\s*\"([^\"]+)\"", text, re.MULTILINE)
+    if not m:
+        raise RuntimeError(f"Could not find {key} = \"…\" in {path}")
+    return m.group(1)
+
+
+def assert_release_please_versions_aligned() -> None:
+    """Fail fast when version sources drift (all bumps go through release-please)."""
+    py_v = get_package_version()
+    mod_v = _read_assigned_quoted_string(PACKAGE_ROOT / "src" / "dcc_mcp_blender" / "__version__.py", "__version__")
+    man_v = _read_assigned_quoted_string(ADDON_ENTRY_DIR / "blender_manifest.toml", "version")
+    if py_v == mod_v == man_v:
+        return
+    raise RuntimeError(
+        "Version mismatch — keep pyproject.toml, __version__.py, and blender_manifest.toml "
+        "in sync via release-please only:\n"
+        f"  pyproject.toml:        {py_v!r}\n"
+        f"  __version__.py:        {mod_v!r}\n"
+        f"  blender_manifest.toml: {man_v!r}"
+    )
+
+
 def assemble(platform: str, output_dir: pathlib.Path) -> pathlib.Path:
     """Assemble the addon ZIP for the given platform.
 
     Returns the path to the created ZIP file.
     """
+    assert_release_please_versions_aligned()
     version = get_package_version()
     zip_name = f"dcc_mcp_blender_addon_{platform}_v{version}.zip"
     zip_path = output_dir / zip_name
@@ -141,22 +236,24 @@ def assemble(platform: str, output_dir: pathlib.Path) -> pathlib.Path:
 
         # 1) Copy dcc_mcp_blender package source
         print("Copying dcc_mcp_blender package...")
-        shutil.copytree(SRC_DIR, addon_dir / "dcc_mcp_blender")
+        staged_pkg = addon_dir / "dcc_mcp_blender"
+        shutil.copytree(SRC_DIR, staged_pkg, ignore=_ignore_for_addon_copy, dirs_exist_ok=False)
+        _verify_skills_payload(staged_pkg)
 
         # 2) Download and extract dcc-mcp-core
         print(f"Resolving {CORE_PACKAGE}...")
-        try:
-            core_version = resolve_core_version()
-            wheels_dir = tmp_dir / "wheels"
-            wheels = download_core_wheels(core_version, platform, wheels_dir)
-            for wheel in wheels:
-                print(f"  Extracting {wheel.name}...")
-                extract_wheel(wheel, addon_dir)
-        except Exception as e:
-            print(f"Warning: could not bundle dcc-mcp-core: {e}")
+        core_version = resolve_core_version()
+        wheels_dir = tmp_dir / "wheels"
+        wheel = download_core_wheel(core_version, platform, wheels_dir)
+        wheels_out = addon_dir / "wheels"
+        wheels_out.mkdir(parents=True, exist_ok=True)
+        staged_wheel = wheels_out / wheel.name
+        shutil.copy2(wheel, staged_wheel)
+        print(f"  Bundled wheel: {staged_wheel.relative_to(addon_dir)}")
 
-        # 3) Write __init__.py for Blender addon registration
-        _write_addon_init(addon_dir, version)
+        # 3) Stage add-on root: ``__init__.py`` + ``blender_manifest.toml`` (4.2+ extensions)
+        _stage_addon_entry(addon_dir)
+        _inject_wheels_into_manifest(addon_dir / "blender_manifest.toml", [wheel.name])
 
         # 4) Zip everything
         print(f"Creating {zip_name}...")
@@ -170,61 +267,29 @@ def assemble(platform: str, output_dir: pathlib.Path) -> pathlib.Path:
     return zip_path
 
 
-def _write_addon_init(addon_dir: pathlib.Path, version: str) -> None:
-    """Write a Blender-compatible __init__.py at the addon root."""
-    init_path = addon_dir / "__init__.py"
-    # Only overwrite if it doesn't already have bl_info
-    existing = init_path.read_text(encoding="utf-8") if init_path.exists() else ""
-    if "bl_info" in existing:
-        return
+def _inject_wheels_into_manifest(manifest_path: pathlib.Path, wheel_basenames: list[str]) -> None:
+    """Write ``wheels = [...]`` for Blender's extension wheel installer.
 
-    major, minor, patch = version.split(".")[:3]
-    content = f'''"""Blender Addon: DCC MCP Blender.
-
-Auto-generated addon entry point — wraps dcc_mcp_blender.
-"""
-
-import sys
-import os
-
-# Ensure the addon directory is on sys.path so bundled packages are importable
-_addon_dir = os.path.dirname(__file__)
-if _addon_dir not in sys.path:
-    sys.path.insert(0, _addon_dir)
-
-bl_info = {{
-    "name": "DCC MCP Blender",
-    "author": "Long Hao",
-    "version": ({major}, {minor}, {patch}),
-    "blender": (4, 0, 0),
-    "location": "Properties > Scene > DCC MCP",
-    "description": "Embeds an MCP HTTP server directly inside Blender for AI-driven 3D workflows",
-    "category": "System",
-    "doc_url": "https://github.com/loonghao/dcc-mcp-blender",
-    "tracker_url": "https://github.com/loonghao/dcc-mcp-blender/issues",
-}}
+    See https://docs.blender.org/manual/en/latest/advanced/extensions/python_wheels.html
+    """
+    text = manifest_path.read_text(encoding="utf-8")
+    text = re.sub(r"\n+wheels\s*=\s*\[.*?\]\s*", "\n", text, flags=re.DOTALL)
+    lines = [f'    "./wheels/{name}"' for name in wheel_basenames]
+    block = "\nwheels = [\n" + ",\n".join(lines) + ",\n]\n"
+    manifest_path.write_text(text.rstrip() + block, encoding="utf-8")
 
 
-def register():
-    """Start the MCP server when the addon is enabled."""
-    try:
-        from dcc_mcp_blender.server import start_server
-        start_server()
-        print("[DCC MCP Blender] Server started on http://127.0.0.1:8765/mcp")
-    except Exception as e:
-        print(f"[DCC MCP Blender] Failed to start server: {{e}}")
+def _stage_addon_entry(addon_dir: pathlib.Path) -> None:
+    """Copy packaged add-on entry (menu, manifest) into the staged ZIP root."""
+    init_src = ADDON_ENTRY_DIR / "__init__.py"
+    manifest_src = ADDON_ENTRY_DIR / "blender_manifest.toml"
+    if not init_src.is_file():
+        raise RuntimeError(f"Missing add-on entry __init__.py: {init_src}")
+    if not manifest_src.is_file():
+        raise RuntimeError(f"Missing blender_manifest.toml: {manifest_src}")
 
-
-def unregister():
-    """Stop the MCP server when the addon is disabled."""
-    try:
-        from dcc_mcp_blender.server import stop_server
-        stop_server()
-        print("[DCC MCP Blender] Server stopped")
-    except Exception as e:
-        print(f"[DCC MCP Blender] Failed to stop server: {{e}}")
-'''
-    init_path.write_text(content, encoding="utf-8")
+    shutil.copy2(init_src, addon_dir / "__init__.py")
+    shutil.copy2(manifest_src, addon_dir / "blender_manifest.toml")
 
 
 # ── CLI ────────────────────────────────────────────────────────────────────────
@@ -234,7 +299,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Assemble Blender addon ZIP for dcc-mcp-blender")
     parser.add_argument(
         "--platform",
-        choices=list(PLATFORM_PYTHON.keys()),
+        choices=list(ADDON_PLATFORMS),
         default="linux",
         help="Target platform (default: linux)",
     )

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -159,8 +159,7 @@ def download_core_wheel(version: str, platform: str, dest_dir: pathlib.Path) -> 
     if pick is None:
         sample = [f["filename"] for f in release_files if f["filename"].endswith(".whl")][:12]
         raise RuntimeError(
-            f"No {CORE_PACKAGE} wheel for platform={platform!r} at version {version!r}. "
-            f"PyPI wheel sample: {sample}"
+            f"No {CORE_PACKAGE} wheel for platform={platform!r} at version {version!r}. PyPI wheel sample: {sample}"
         )
 
     dest_dir.mkdir(parents=True, exist_ok=True)
@@ -197,7 +196,7 @@ def _read_assigned_quoted_string(path: pathlib.Path, key: str) -> str:
     text = path.read_text(encoding="utf-8")
     m = re.search(rf"^{re.escape(key)}\s*=\s*\"([^\"]+)\"", text, re.MULTILINE)
     if not m:
-        raise RuntimeError(f"Could not find {key} = \"…\" in {path}")
+        raise RuntimeError(f'Could not find {key} = "…" in {path}')
     return m.group(1)
 
 

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -80,6 +80,11 @@ def _verify_skills_payload(staged_pkg: pathlib.Path) -> None:
         raise RuntimeError(
             f"Expected at least 10 bundled skills (SKILL.md), found {len(skill_manifests)} under {skills_dir}"
         )
+    missing_tools = [
+        skill_md.parent.name for skill_md in skill_manifests if not (skill_md.parent / "tools.yaml").is_file()
+    ]
+    if missing_tools:
+        raise RuntimeError(f"Missing tools.yaml for bundled skills: {', '.join(sorted(missing_tools))}")
 
 
 # ── helpers ────────────────────────────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,10 @@ classifiers = [
 ]
 
 dependencies = [
-    "dcc-mcp-core>=0.12.29,<1.0.0",
+    # Align with dcc-mcp-core 0.17.2: DccServerOptions composition root,
+    # HostExecutionBridge, diagnostics/resources contracts, gateway capability
+    # index expectations, and new diagnostics/execution options.
+    "dcc-mcp-core>=0.17.2,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ classifiers = [
 ]
 
 dependencies = [
-    # Align with dcc-mcp-core 0.17.2: DccServerOptions composition root,
+    # Align with dcc-mcp-core 0.17.5: DccServerOptions composition root,
     # HostExecutionBridge, diagnostics/resources contracts, gateway capability
-    # index expectations, and new diagnostics/execution options.
-    "dcc-mcp-core>=0.17.2,<1.0.0",
+    # index expectations, and current skill-management/search contracts.
+    "dcc-mcp-core>=0.17.5,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,13 +12,12 @@
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [
         {
-          "type": "toml",
-          "path": "pyproject.toml",
-          "jsonpath": "$.project.version"
+          "type": "generic",
+          "path": "src/dcc_mcp_blender/__version__.py"
         },
         {
           "type": "generic",
-          "path": "src/dcc_mcp_blender/__version__.py"
+          "path": "packaging/addon_entry/blender_manifest.toml"
         }
       ]
     }

--- a/src/dcc_mcp_blender/__init__.py
+++ b/src/dcc_mcp_blender/__init__.py
@@ -18,6 +18,19 @@ Quick start::
 from __future__ import annotations
 
 from dcc_mcp_blender.__version__ import __version__
+from dcc_mcp_blender._env import (
+    ENV_DISABLE_ARBITRARY_SCRIPT,
+    ENV_DISABLE_EXECUTE_PYTHON,
+    ENV_ENABLE_GATEWAY_FAILOVER,
+    ENV_ENABLE_WORKFLOWS,
+    ENV_METRICS,
+    ENV_STRICT_SKILL_SCAN,
+    resolve_enable_gateway_failover,
+    resolve_enable_workflows,
+    resolve_execute_python_disabled,
+    resolve_metrics_enabled,
+    resolve_strict_skill_scan,
+)
 from dcc_mcp_blender.api import (
     skill_entry,
     skill_error,
@@ -25,6 +38,21 @@ from dcc_mcp_blender.api import (
     skill_success,
 )
 from dcc_mcp_blender.capabilities import blender_capabilities, blender_capabilities_dict
+from dcc_mcp_blender.dispatcher import (
+    DEFAULT_BUDGET_MS,
+    DEFAULT_JOB_TIMEOUT_MS,
+    OVERRUN_MULTIPLIER,
+    BlenderStandaloneDispatcher,
+    BlenderUiDispatcher,
+    BlenderUiPump,
+    PyPumpedDispatcher,
+    _CorePump,
+    _current_job,
+    _JobEntry,
+    check_blender_cancelled,
+    create_dispatcher,
+    create_pumped_dispatcher,
+)
 from dcc_mcp_blender.server import (
     BlenderMcpServer,
     get_server,
@@ -47,4 +75,30 @@ __all__ = [
     "skill_error",
     "skill_exception",
     "skill_success",
+    # Environment variables
+    "ENV_METRICS",
+    "ENV_STRICT_SKILL_SCAN",
+    "ENV_ENABLE_WORKFLOWS",
+    "ENV_ENABLE_GATEWAY_FAILOVER",
+    "ENV_DISABLE_EXECUTE_PYTHON",
+    "ENV_DISABLE_ARBITRARY_SCRIPT",
+    "resolve_enable_gateway_failover",
+    "resolve_execute_python_disabled",
+    "resolve_metrics_enabled",
+    "resolve_strict_skill_scan",
+    "resolve_enable_workflows",
+    # Dispatchers
+    "BlenderUiDispatcher",
+    "BlenderStandaloneDispatcher",
+    "BlenderUiPump",
+    "PyPumpedDispatcher",
+    "create_dispatcher",
+    "create_pumped_dispatcher",
+    "check_blender_cancelled",
+    "DEFAULT_BUDGET_MS",
+    "DEFAULT_JOB_TIMEOUT_MS",
+    "OVERRUN_MULTIPLIER",
+    "_CorePump",
+    "_JobEntry",
+    "_current_job",
 ]

--- a/src/dcc_mcp_blender/__init__.py
+++ b/src/dcc_mcp_blender/__init__.py
@@ -1,60 +1,15 @@
-"""dcc-mcp-blender — Blender MCP server package.
-
-Quick start::
-
-    import dcc_mcp_blender
-
-    # Start the server (auto-gateway: first Blender wins port 8765)
-    server = dcc_mcp_blender.start_server()
-
-    # Progressive loading
-    server.discover_skills()                # scan SKILL.md, register metadata
-    server.load_skill("blender-scene")      # lazy-import skill scripts on demand
-    server.unload_skill("blender-scene")    # free memory when no longer needed
-
-    dcc_mcp_blender.stop_server()
-"""
+"""dcc-mcp-blender — MCP Streamable HTTP server embedded in Blender."""
 
 from __future__ import annotations
 
 from dcc_mcp_blender.__version__ import __version__
-from dcc_mcp_blender._env import (
-    ENV_DISABLE_ARBITRARY_SCRIPT,
-    ENV_DISABLE_EXECUTE_PYTHON,
-    ENV_ENABLE_GATEWAY_FAILOVER,
-    ENV_ENABLE_WORKFLOWS,
-    ENV_METRICS,
-    ENV_STRICT_SKILL_SCAN,
-    resolve_enable_gateway_failover,
-    resolve_enable_workflows,
-    resolve_execute_python_disabled,
-    resolve_metrics_enabled,
-    resolve_strict_skill_scan,
-)
-from dcc_mcp_blender.api import (
-    skill_entry,
-    skill_error,
-    skill_exception,
-    skill_success,
-)
+from dcc_mcp_blender.api import skill_entry, skill_error, skill_exception, skill_success
 from dcc_mcp_blender.capabilities import blender_capabilities, blender_capabilities_dict
-from dcc_mcp_blender.dispatcher import (
-    DEFAULT_BUDGET_MS,
-    DEFAULT_JOB_TIMEOUT_MS,
-    OVERRUN_MULTIPLIER,
-    BlenderStandaloneDispatcher,
-    BlenderUiDispatcher,
-    BlenderUiPump,
-    PyPumpedDispatcher,
-    _CorePump,
-    _current_job,
-    _JobEntry,
-    check_blender_cancelled,
-    create_dispatcher,
-    create_pumped_dispatcher,
-)
 from dcc_mcp_blender.server import (
+    DEFAULT_PORT,
+    SERVER_NAME,
     BlenderMcpServer,
+    BlenderServerOptions,
     get_server,
     start_server,
     stop_server,
@@ -62,43 +17,17 @@ from dcc_mcp_blender.server import (
 
 __all__ = [
     "__version__",
-    # server lifecycle
-    "BlenderMcpServer",
-    "start_server",
-    "stop_server",
-    "get_server",
-    # capabilities
-    "blender_capabilities",
-    "blender_capabilities_dict",
-    # skill helpers
     "skill_entry",
     "skill_error",
     "skill_exception",
     "skill_success",
-    # Environment variables
-    "ENV_METRICS",
-    "ENV_STRICT_SKILL_SCAN",
-    "ENV_ENABLE_WORKFLOWS",
-    "ENV_ENABLE_GATEWAY_FAILOVER",
-    "ENV_DISABLE_EXECUTE_PYTHON",
-    "ENV_DISABLE_ARBITRARY_SCRIPT",
-    "resolve_enable_gateway_failover",
-    "resolve_execute_python_disabled",
-    "resolve_metrics_enabled",
-    "resolve_strict_skill_scan",
-    "resolve_enable_workflows",
-    # Dispatchers
-    "BlenderUiDispatcher",
-    "BlenderStandaloneDispatcher",
-    "BlenderUiPump",
-    "PyPumpedDispatcher",
-    "create_dispatcher",
-    "create_pumped_dispatcher",
-    "check_blender_cancelled",
-    "DEFAULT_BUDGET_MS",
-    "DEFAULT_JOB_TIMEOUT_MS",
-    "OVERRUN_MULTIPLIER",
-    "_CorePump",
-    "_JobEntry",
-    "_current_job",
+    "blender_capabilities",
+    "blender_capabilities_dict",
+    "BlenderMcpServer",
+    "BlenderServerOptions",
+    "DEFAULT_PORT",
+    "SERVER_NAME",
+    "get_server",
+    "start_server",
+    "stop_server",
 ]

--- a/src/dcc_mcp_blender/__version__.py
+++ b/src/dcc_mcp_blender/__version__.py
@@ -1,1 +1,2 @@
-__version__ = "0.1.0"
+# x-release-please-version
+__version__ = "0.1.2"

--- a/src/dcc_mcp_blender/_env.py
+++ b/src/dcc_mcp_blender/_env.py
@@ -84,13 +84,18 @@ def resolve_strict_skill_scan() -> bool:
     return _env_truthy(ENV_STRICT_SKILL_SCAN)
 
 
-def resolve_enable_workflows() -> bool:
+def resolve_enable_workflows(enable_workflows: Optional[bool] = None) -> bool:
     """Return True when workflow engine surface should be enabled.
 
     Opt-in workflow engine surface (``workflows.run``, ``workflows.resume``,
     ``workflows.list_runs`` MCP tools).  Off by default so the minimal-mode
     tools/list stays small.
+
+    Priority: explicit ``enable_workflows`` argument >
+    ``DCC_MCP_BLENDER_ENABLE_WORKFLOWS`` truthy tokens > ``False``.
     """
+    if enable_workflows is not None:
+        return bool(enable_workflows)
     return _env_truthy(ENV_ENABLE_WORKFLOWS)
 
 

--- a/src/dcc_mcp_blender/_env.py
+++ b/src/dcc_mcp_blender/_env.py
@@ -1,0 +1,116 @@
+"""Environment-variable resolution for ``BlenderMcpServer``.
+
+Centralises every ``DCC_MCP_BLENDER_*`` env var used by the server so the
+composition root in :mod:`dcc_mcp_blender.server` stays a thin orchestrator.
+
+All helpers are pure functions: they read :data:`os.environ` and return
+plain Python values; they never mutate global state.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Public env-var names ─────────────────────────────────────────────────
+ENV_METRICS = "DCC_MCP_BLENDER_METRICS"
+ENV_JOB_STORAGE = "DCC_MCP_BLENDER_JOB_STORAGE"
+ENV_STRICT_SKILL_SCAN = "DCC_MCP_BLENDER_STRICT_SKILL_SCAN"
+ENV_ENABLE_WORKFLOWS = "DCC_MCP_BLENDER_ENABLE_WORKFLOWS"
+ENV_ENABLE_GATEWAY_FAILOVER = "DCC_MCP_BLENDER_ENABLE_GATEWAY_FAILOVER"
+ENV_DISABLE_EXECUTE_PYTHON = "DCC_MCP_BLENDER_DISABLE_EXECUTE_PYTHON"
+ENV_DISABLE_ARBITRARY_SCRIPT = "DCC_MCP_BLENDER_DISABLE_ARBITRARY_SCRIPT"
+ENV_BLENDER_PATH = "DCC_MCP_BLENDER_PATH"
+ENV_BLENDER_VERSION = "BLENDER_VERSION"
+DEFAULT_JOB_DB_FILENAME = "jobs.db"
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def resolve_execute_python_disabled() -> bool:
+    """Return True when ``execute_python`` must refuse all calls.
+
+    ``DCC_MCP_BLENDER_DISABLE_ARBITRARY_SCRIPT`` implies this flag.  Used by
+    ``blender-scripting`` scripts so studios can enforce skills-first workflows.
+    """
+    if _env_truthy(ENV_DISABLE_ARBITRARY_SCRIPT):
+        return True
+    return _env_truthy(ENV_DISABLE_EXECUTE_PYTHON)
+
+
+def resolve_metrics_enabled(metrics_enabled: Optional[bool]) -> bool:
+    """Resolve the Prometheus ``/metrics`` endpoint flag.
+
+    Priority: explicit argument > ``DCC_MCP_BLENDER_METRICS=1`` > ``False``.
+    """
+    if metrics_enabled is not None:
+        return bool(metrics_enabled)
+    return os.environ.get(ENV_METRICS, "").strip() == "1"
+
+
+def resolve_job_storage(job_storage_path: Optional[str]) -> Optional[str]:
+    """Resolve the SQLite job-storage path.
+
+    Returns ``None`` when callers should leave whatever path
+    :class:`DccServerBase._init_job_persistence` selected.  Returns the
+    empty string ``""`` when the caller passed ``""`` explicitly to
+    request in-memory operation (no persistence).
+    """
+    if job_storage_path is not None:
+        return job_storage_path
+
+    env_path = os.environ.get(ENV_JOB_STORAGE, "").strip()
+    if env_path:
+        return env_path
+
+    # Default: use platform data dir
+    return None
+
+
+def resolve_strict_skill_scan() -> bool:
+    """Return True when ``register_builtin_actions`` should raise on scan errors.
+
+    When ``DCC_MCP_BLENDER_STRICT_SKILL_SCAN=1``, silently-skipped skill
+    directories raise ``ValueError`` at startup instead of disappearing
+    into a debug-level log line.
+    """
+    return _env_truthy(ENV_STRICT_SKILL_SCAN)
+
+
+def resolve_enable_workflows() -> bool:
+    """Return True when workflow engine surface should be enabled.
+
+    Opt-in workflow engine surface (``workflows.run``, ``workflows.resume``,
+    ``workflows.list_runs`` MCP tools).  Off by default so the minimal-mode
+    tools/list stays small.
+    """
+    return _env_truthy(ENV_ENABLE_WORKFLOWS)
+
+
+def resolve_enable_gateway_failover(enable_gateway_failover: Optional[bool]) -> bool:
+    """Resolve gateway failover flag.
+
+    Priority: explicit argument > ``DCC_MCP_BLENDER_ENABLE_GATEWAY_FAILOVER`` env var > ``True``.
+    """
+    if enable_gateway_failover is not None:
+        return bool(enable_gateway_failover)
+    if os.environ.get(ENV_ENABLE_GATEWAY_FAILOVER, "").strip():
+        return _env_truthy(ENV_ENABLE_GATEWAY_FAILOVER)
+    return True  # Default: enable gateway failover
+
+
+def resolve_blender_path() -> Optional[str]:
+    """Resolve Blender executable path.
+
+    Returns the path from ``DCC_MCP_BLENDER_PATH`` env var, or ``None``
+    to use system default.
+    """
+    path = os.environ.get(ENV_BLENDER_PATH, "").strip()
+    return path if path else None

--- a/src/dcc_mcp_blender/dispatcher/__init__.py
+++ b/src/dcc_mcp_blender/dispatcher/__init__.py
@@ -1,0 +1,65 @@
+"""Blender thread-affinity dispatchers.
+
+Public dispatcher symbols are re-exported from their focused submodules
+through the :pep:`8`-compliant ``__all__`` below.
+
+The implementation is split per Single Responsibility into:
+
+================  ====================================================
+Module            Purpose
+================  ====================================================
+``job``           ``_JobEntry`` + ``_current_job`` ContextVar
+``cancel``        ``check_blender_cancelled`` cooperative checkpoint
+``ui``            ``BlenderUiDispatcher`` (interactive)
+``standalone``    ``BlenderStandaloneDispatcher`` (background)
+``pump``          ``BlenderUiPump`` / ``_CorePump`` + factory helpers
+================  ====================================================
+
+This re-export layer is **zero-overhead**: every name binds to the same
+object as the originating submodule.  External callers do not need to
+update their imports.
+
+See: https://github.com/loonghao/dcc-mcp-blender/issues/XX
+"""
+
+# Import future modules
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_blender.dispatcher.cancel import check_blender_cancelled
+from dcc_mcp_blender.dispatcher.job import DEFAULT_JOB_TIMEOUT_MS, _current_job, _JobEntry
+from dcc_mcp_blender.dispatcher.pump import (
+    DEFAULT_BUDGET_MS,
+    OVERRUN_MULTIPLIER,
+    BlenderUiPump,
+    PyPumpedDispatcher,
+    _CorePump,
+    create_dispatcher,
+    create_pumped_dispatcher,
+)
+from dcc_mcp_blender.dispatcher.standalone import BlenderStandaloneDispatcher
+from dcc_mcp_blender.dispatcher.ui import BlenderUiDispatcher
+
+__all__ = [
+    # Cancellation
+    "check_blender_cancelled",
+    # Constants
+    "DEFAULT_BUDGET_MS",
+    "DEFAULT_JOB_TIMEOUT_MS",
+    "OVERRUN_MULTIPLIER",
+    # Dispatchers
+    "BlenderUiDispatcher",
+    "BlenderStandaloneDispatcher",
+    # Pumps
+    "BlenderUiPump",
+    # Factories
+    "create_dispatcher",
+    "create_pumped_dispatcher",
+    # Core dispatcher used by create_pumped_dispatcher
+    "PyPumpedDispatcher",
+    # Internals exposed for advanced use
+    "_CorePump",
+    "_JobEntry",
+    "_current_job",
+]

--- a/src/dcc_mcp_blender/dispatcher/cancel.py
+++ b/src/dcc_mcp_blender/dispatcher/cancel.py
@@ -1,0 +1,45 @@
+"""Cooperative cancellation checkpoint for Blender.
+
+Provides ``check_blender_cancelled()`` — a lightweight function that
+skill authors can call periodically to abort long-running operations
+when the user requests cancellation.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Cancellation flag (module-level, can be set by external code)
+_cancelled = False
+
+
+def set_blender_cancelled(value: bool = True) -> None:
+    """Set the cancellation flag.
+
+    Args:
+        value: ``True`` to request cancellation, ``False`` to clear.
+    """
+    global _cancelled  # noqa: PLW0603
+    _cancelled = value
+    if value:
+        logger.debug("Blender operation cancellation requested")
+
+
+def check_blender_cancelled() -> bool:
+    """Return ``True`` when the current operation should be aborted.
+
+    Skill authors can call this periodically in long-running loops::
+
+        for i in range(large_number):
+            if check_blender_cancelled():
+                return blender_error("Operation cancelled")
+            # ... do work ...
+
+    Returns:
+        ``True`` if cancellation has been requested.
+    """
+    return _cancelled

--- a/src/dcc_mcp_blender/dispatcher/job.py
+++ b/src/dcc_mcp_blender/dispatcher/job.py
@@ -1,0 +1,84 @@
+"""Job entry and timeout tracking for Blender.
+
+Provides ``_JobEntry`` (job metadata) and ``_current_job`` (ContextVar)
+for tracking the currently executing skill/action.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import contextvars
+import logging
+import time
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_JOB_TIMEOUT_MS = 30000  # 30 seconds
+
+# ContextVar holding the currently executing job
+_current_job: contextvars.ContextVar[Optional["_JobEntry"]] = contextvars.ContextVar("_current_job", default=None)
+
+
+class _JobEntry:
+    """Metadata for a single job (skill action execution)."""
+
+    def __init__(
+        self,
+        job_id: str,
+        action_name: str,
+        timeout_ms: int = DEFAULT_JOB_TIMEOUT_MS,
+    ) -> None:
+        self.job_id = job_id
+        self.action_name = action_name
+        self.timeout_ms = timeout_ms
+        self.start_time = time.time()
+        self.end_time: Optional[float] = None
+        self.result: Dict[str, Any] = {}
+        self.error: Optional[str] = None
+
+    def elapsed_ms(self) -> float:
+        """Return elapsed time in milliseconds."""
+        if self.end_time is not None:
+            return (self.end_time - self.start_time) * 1000
+        return (time.time() - self.start_time) * 1000
+
+    def is_timed_out(self) -> bool:
+        """Return ``True`` if the job has exceeded its timeout."""
+        return self.elapsed_ms() > self.timeout_ms
+
+    def finish(self, result: Dict[str, Any]) -> None:
+        """Mark the job as finished successfully."""
+        self.end_time = time.time()
+        self.result = result
+        logger.debug(
+            "Job %s (%s) finished in %.1fms",
+            self.job_id,
+            self.action_name,
+            self.elapsed_ms(),
+        )
+
+    def fail(self, error: str) -> None:
+        """Mark the job as failed."""
+        self.end_time = time.time()
+        self.error = error
+        logger.warning(
+            "Job %s (%s) failed after %.1fms: %s",
+            self.job_id,
+            self.action_name,
+            self.elapsed_ms(),
+            error,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a dict representation of this job."""
+        return {
+            "job_id": self.job_id,
+            "action_name": self.action_name,
+            "timeout_ms": self.timeout_ms,
+            "elapsed_ms": self.elapsed_ms(),
+            "is_timed_out": self.is_timed_out(),
+            "finished": self.end_time is not None,
+            "error": self.error,
+        }

--- a/src/dcc_mcp_blender/dispatcher/pump.py
+++ b/src/dcc_mcp_blender/dispatcher/pump.py
@@ -1,0 +1,144 @@
+"""Blender UI pump and dispatcher factory helpers.
+
+Provides ``BlenderUiPump``, ``_CorePump``, ``create_dispatcher``,
+and ``create_pumped_dispatcher``.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+import time
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BUDGET_MS = 200  # 200ms budget per pump
+OVERRUN_MULTIPLIER = 2.0  # Allow 2x budget before warning
+
+
+class _CorePump:
+    """Core pump logic (platform-independent)."""
+
+    def __init__(self, budget_ms: int = DEFAULT_BUDGET_MS) -> None:
+        self.budget_ms = budget_ms
+        self._total_pumped_ms: float = 0.0
+        self._pump_count: int = 0
+
+    def pump(self) -> None:
+        """Pump the event loop (override in subclass)."""
+        pass
+
+    def pumped_ms(self) -> float:
+        """Return total pumped time in milliseconds."""
+        return self._total_pumped_ms
+
+    def pump_count(self) -> int:
+        """Return number of pump operations."""
+        return self._pump_count
+
+    def reset_stats(self) -> None:
+        """Reset statistics."""
+        self._total_pumped_ms = 0.0
+        self._pump_count = 0
+
+
+class BlenderUiPump(_CorePump):
+    """UI pump for Blender interactive mode.
+
+    Pumps Blender's event loop to keep the UI responsive
+    during long-running operations.
+    """
+
+    def pump(self) -> None:
+        """Pump Blender's event loop."""
+        start = time.time()
+        try:
+            import bpy  # noqa: PLC0415
+
+            # Pump Blender's event loop
+            if hasattr(bpy.ops.wm, "call_in_main_thread"):
+                # Use timer-based approach
+                pass  # TODO: Implement proper pumping
+        except ImportError:
+            pass
+        elapsed = (time.time() - start) * 1000
+        self._total_pumped_ms += elapsed
+        self._pump_count += 1
+        if elapsed > self.budget_ms * OVERRUN_MULTIPLIER:
+            logger.warning(
+                "BlenderUiPump: pump took %.1fms (budget: %dms)",
+                elapsed,
+                self.budget_ms,
+            )
+
+
+def create_dispatcher(
+    ui_mode: bool = True,
+    timeout_ms: int = 30000,
+) -> Any:
+    """Create a dispatcher based on mode.
+
+    Args:
+        ui_mode: ``True`` for UI mode, ``False`` for standalone.
+        timeout_ms: Timeout in milliseconds.
+
+    Returns:
+        A dispatcher instance.
+    """
+    if ui_mode:
+        from dcc_mcp_blender.dispatcher.ui import BlenderUiDispatcher
+
+        return BlenderUiDispatcher(timeout_ms=timeout_ms)
+    else:
+        from dcc_mcp_blender.dispatcher.standalone import BlenderStandaloneDispatcher
+
+        return BlenderStandaloneDispatcher(timeout_ms=timeout_ms)
+
+
+def create_pumped_dispatcher(
+    ui_mode: bool = True,
+    timeout_ms: int = 30000,
+    budget_ms: int = DEFAULT_BUDGET_MS,
+) -> Any:
+    """Create a pumped dispatcher (with UI pump).
+
+    Args:
+        ui_mode: ``True`` for UI mode, ``False`` for standalone.
+        timeout_ms: Timeout in milliseconds.
+        budget_ms: Budget per pump in milliseconds.
+
+    Returns:
+        A dispatcher instance with pumping support.
+    """
+    dispatcher = create_dispatcher(ui_mode=ui_mode, timeout_ms=timeout_ms)
+    if ui_mode:
+        pump = BlenderUiPump(budget_ms=budget_ms)
+        # Attach pump to dispatcher
+        setattr(dispatcher, "_pump", pump)
+    return dispatcher
+
+
+# For Rust-backed dispatch (string-payload dispatch)
+class PyPumpedDispatcher:
+    """Rust-backed dispatcher with pump support."""
+
+    def __init__(
+        self,
+        dispatcher: Any,
+        pump: Optional[_CorePump] = None,
+    ) -> None:
+        self.dispatcher = dispatcher
+        self._pump = pump
+
+    def dispatch(self, func: Callable, *args: Any, **kwargs: Any) -> Any:
+        """Dispatch with pumping."""
+        if self._pump:
+            self._pump.pump()
+        return self.dispatcher.dispatch(func, *args, **kwargs)
+
+    def pump(self) -> None:
+        """Manually pump."""
+        if self._pump:
+            self._pump.pump()

--- a/src/dcc_mcp_blender/dispatcher/standalone.py
+++ b/src/dcc_mcp_blender/dispatcher/standalone.py
@@ -1,0 +1,97 @@
+"""Blender standalone dispatcher (background mode).
+
+Provides ``BlenderStandaloneDispatcher`` — a dispatcher that runs callbacks
+directly (no main-thread marshalling needed because there's no UI).
+
+In background mode (``blender --background``), all code runs in the
+main thread anyway, so no special dispatch is needed.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+import threading
+import time
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class BlenderStandaloneDispatcher:
+    """Dispatcher for Blender standalone (background) mode.
+
+    Runs callbacks directly — no main-thread marshalling needed.
+    """
+
+    def __init__(self, timeout_ms: int = 30000) -> None:
+        self.timeout_ms = timeout_ms
+        self._pending: Dict[str, Callable] = {}
+        self._results: Dict[str, Any] = {}
+        self._errors: Dict[str, Exception] = {}
+        self._lock = threading.Lock()
+
+    def dispatch(self, func: Callable, *args: Any, **kwargs: Any) -> Any:
+        """Dispatch a call (runs directly in standalone mode).
+
+        Args:
+            func: The function to call.
+            *args: Positional arguments.
+            **kwargs: Keyword arguments.
+
+        Returns:
+            The function's return value.
+        """
+        return func(*args, **kwargs)
+
+    def dispatch_async(self, func: Callable, *args: Any, **kwargs: Any) -> str:
+        """Dispatch a call asynchronously.
+
+        Returns a job ID that can be polled for completion.
+
+        Args:
+            func: The function to call.
+            *args: Positional arguments.
+            **kwargs: Keyword arguments.
+
+        Returns:
+            Job ID string.
+        """
+        job_id = f"job_{time.time()}_{id(func)}"
+        try:
+            result = func(*args, **kwargs)
+            with self._lock:
+                self._results[job_id] = result
+        except Exception as e:
+            with self._lock:
+                self._errors[job_id] = e
+        return job_id
+
+    def get_result(self, job_id: str) -> Optional[Any]:
+        """Get the result of an async job.
+
+        Args:
+            job_id: The job ID returned by ``dispatch_async``.
+
+        Returns:
+            The job result, or ``None`` if not ready.
+        """
+        with self._lock:
+            if job_id in self._results:
+                return self._results[job_id]
+            if job_id in self._errors:
+                raise self._errors[job_id]
+        return None
+
+    def is_done(self, job_id: str) -> bool:
+        """Check if an async job is done.
+
+        Args:
+            job_id: The job ID returned by ``dispatch_async``.
+
+        Returns:
+            ``True`` if the job is done (success or error).
+        """
+        with self._lock:
+            return job_id in self._results or job_id in self._errors

--- a/src/dcc_mcp_blender/dispatcher/ui.py
+++ b/src/dcc_mcp_blender/dispatcher/ui.py
@@ -1,0 +1,104 @@
+"""Blender UI dispatcher (interactive mode).
+
+Provides ``BlenderUiDispatcher`` — a dispatcher that runs callbacks
+in Blender's main thread (using ``bpy.ops.wm.call_in_main_thread``
+or similar mechanisms).
+
+In UI mode, Blender requires certain operations (like scene updates)
+to run in the main thread.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import logging
+import threading
+import time
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class BlenderUiDispatcher:
+    """Dispatcher for Blender interactive (UI) mode.
+
+    Runs callbacks in the main thread using Blender's timer API.
+    """
+
+    def __init__(self, timeout_ms: int = 30000) -> None:
+        self.timeout_ms = timeout_ms
+        self._pending: Dict[str, Callable] = {}
+        self._results: Dict[str, Any] = {}
+        self._errors: Dict[str, Exception] = {}
+        self._lock = threading.Lock()
+
+    def dispatch(self, func: Callable, *args: Any, **kwargs: Any) -> Any:
+        """Dispatch a call to the main thread.
+
+        In UI mode, this uses Blender's timer to run the callback
+        in the main thread.
+
+        Args:
+            func: The function to call.
+            *args: Positional arguments.
+            **kwargs: Keyword arguments.
+
+        Returns:
+            The function's return value.
+        """
+        # For now, just call directly
+        # TODO: Implement proper main-thread dispatch using bpy.ops.wm.call_in_main_thread
+        return func(*args, **kwargs)
+
+    def dispatch_async(self, func: Callable, *args: Any, **kwargs: Any) -> str:
+        """Dispatch a call asynchronously.
+
+        Returns a job ID that can be polled for completion.
+
+        Args:
+            func: The function to call.
+            *args: Positional arguments.
+            **kwargs: Keyword arguments.
+
+        Returns:
+            Job ID string.
+        """
+        job_id = f"job_{time.time()}_{id(func)}"
+        # TODO: Implement async dispatch
+        try:
+            result = func(*args, **kwargs)
+            with self._lock:
+                self._results[job_id] = result
+        except Exception as e:
+            with self._lock:
+                self._errors[job_id] = e
+        return job_id
+
+    def get_result(self, job_id: str) -> Optional[Any]:
+        """Get the result of an async job.
+
+        Args:
+            job_id: The job ID returned by ``dispatch_async``.
+
+        Returns:
+            The job result, or ``None`` if not ready.
+        """
+        with self._lock:
+            if job_id in self._results:
+                return self._results[job_id]
+            if job_id in self._errors:
+                raise self._errors[job_id]
+        return None
+
+    def is_done(self, job_id: str) -> bool:
+        """Check if an async job is done.
+
+        Args:
+            job_id: The job ID returned by ``dispatch_async``.
+
+        Returns:
+            ``True`` if the job is done (success or error).
+        """
+        with self._lock:
+            return job_id in self._results or job_id in self._errors

--- a/src/dcc_mcp_blender/server.py
+++ b/src/dcc_mcp_blender/server.py
@@ -246,9 +246,9 @@ class BlenderMcpServer(DccServerBase):
 
     # ── Lifecycle ──────────────────────────────────────────────────────────────
 
-    def start(self) -> "BlenderMcpServer":
+    def start(self, *, install_atexit_hook: bool = True) -> "BlenderMcpServer":
         """Start the MCP HTTP server.  Returns *self* for chaining."""
-        super().start()
+        super().start(install_atexit_hook=install_atexit_hook)
         return self
 
     # ── Progressive skill loading ──────────────────────────────────────────────
@@ -279,41 +279,37 @@ class BlenderMcpServer(DccServerBase):
         logger.debug("BlenderMcpServer: discovered %d new skill(s)", count)
         return count
 
-    def load_skill(self, skill_name: str) -> List[str]:  # type: ignore[override]
-        """Load a skill by name — imports scripts and registers tools.
+    def load_skill(self, skill_name: str) -> bool:
+        """Load a skill by name.
 
         Args:
             skill_name: Skill name as declared in ``SKILL.md`` (e.g. ``"blender-scene"``).
 
         Returns:
-            List of action names that were registered.
-
-        Raises:
-            RuntimeError: If the server is not running.
+            ``True`` when the core server accepted the load request.
         """
-        if self._handle is None:
-            raise RuntimeError("Server is not running — call start() first")
-        actions = self._server.load_skill(skill_name)
-        logger.debug("BlenderMcpServer: loaded skill %r → actions: %s", skill_name, actions)
-        return actions
+        try:
+            self._server.load_skill(skill_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("BlenderMcpServer: load_skill(%r) failed: %s", skill_name, exc)
+            return False
+        return True
 
-    def unload_skill(self, skill_name: str) -> int:  # type: ignore[override]
+    def unload_skill(self, skill_name: str) -> bool:
         """Unload a skill, removing its tools from the registry.
 
         Args:
             skill_name: Skill name to unload.
 
         Returns:
-            Number of actions removed.
-
-        Raises:
-            RuntimeError: If the server is not running.
+            ``True`` when the core server accepted the unload request.
         """
-        if self._handle is None:
-            raise RuntimeError("Server is not running — call start() first")
-        count = self._server.unload_skill(skill_name)
-        logger.debug("BlenderMcpServer: unloaded skill %r (%d action(s) removed)", skill_name, count)
-        return count
+        try:
+            self._server.unload_skill(skill_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("BlenderMcpServer: unload_skill(%r) failed: %s", skill_name, exc)
+            return False
+        return True
 
     def list_skills(self, status: Optional[str] = None) -> List[Dict[str, Any]]:  # type: ignore[override]
         """List all discovered skills with their load status.
@@ -328,30 +324,52 @@ class BlenderMcpServer(DccServerBase):
             return []
         return list(self._server.list_skills(status=status))  # type: ignore[arg-type]
 
-    def find_skills(  # type: ignore[override]
+    def search_skills(  # type: ignore[override]
         self,
         query: Optional[str] = None,
         tags: Optional[List[str]] = None,
         dcc: Optional[str] = None,
+        scope: Optional[str] = None,
+        limit: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """Search for skills matching the given criteria.
-
-        Wraps the inner server's :meth:`search_skills` (dcc-mcp-core 0.15+); the
-        ``find_skills`` name is kept for backward compatibility with scripts
-        and tests.
 
         Args:
             query: Free-text query matched against skill name/description.
             tags: Required tags (skill must have all).
             dcc: DCC filter (defaults to ``"blender"``).
+            scope: Optional skill scope filter (``"system"``, ``"project"``, etc.).
+            limit: Optional maximum number of results.
 
         Returns:
             List of matching skill metadata dicts, or ``[]`` if not running.
         """
         if self._handle is None:
             return []
-        # The Rust binding requires a Sequence for tags; pass [] instead of None
-        return list(self._server.search_skills(query=query, tags=tags or [], dcc=dcc or _DCC_NAME))  # type: ignore[arg-type]
+        try:
+            return list(
+                self._server.search_skills(
+                    query=query,
+                    tags=tags or [],
+                    dcc=dcc or _DCC_NAME,
+                    scope=scope,
+                    limit=limit,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("BlenderMcpServer: search_skills failed: %s", exc)
+            return []
+
+    def find_skills(
+        self,
+        query: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        dcc: Optional[str] = None,
+        scope: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """Backward-compatible alias for :meth:`search_skills`."""
+        return self.search_skills(query=query, tags=tags, dcc=dcc, scope=scope, limit=limit)
 
     def is_skill_loaded(self, skill_name: str) -> bool:  # type: ignore[override]
         """Return ``True`` if the named skill is currently loaded."""

--- a/src/dcc_mcp_blender/server.py
+++ b/src/dcc_mcp_blender/server.py
@@ -23,11 +23,14 @@ Usage (inside Blender Python console or startup script)::
 from __future__ import annotations
 
 import logging
-import pathlib
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from dcc_mcp_core import DccServerOptions
 from dcc_mcp_core.server_base import DccServerBase
 
+from dcc_mcp_blender import _env
 from dcc_mcp_blender.__version__ import __version__
 
 logger = logging.getLogger(__name__)
@@ -39,13 +42,72 @@ SERVER_VERSION = __version__
 DEFAULT_PORT = 8765
 
 # Built-in skills directory shipped with this package
-_BUILTIN_SKILLS_DIR = pathlib.Path(__file__).parent / "skills"
+_BUILTIN_SKILLS_DIR = Path(__file__).resolve().parent / "skills"
 
 # Environment variable for extra skill paths (colon/semicolon separated)
 _ENV_EXTRA_SKILL_PATHS = "DCC_MCP_BLENDER_SKILL_PATHS"
 _ENV_GENERIC_SKILL_PATHS = "DCC_MCP_SKILL_PATHS"
 
 _DCC_NAME = "blender"
+
+
+# ── options ─────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class BlenderServerOptions:
+    """Adapter-local options collapsed for the dcc-mcp-core 0.17+ server contract."""
+
+    port: int = DEFAULT_PORT
+    extra_skill_paths: Optional[List[str]] = None
+    server_name: str = SERVER_NAME
+    server_version: str = SERVER_VERSION
+    # Gateway options
+    gateway_port: Optional[int] = None
+    registry_dir: Optional[str] = None
+    dcc_version: Optional[str] = None
+    scene: Optional[str] = None
+    enable_gateway_failover: Optional[bool] = None
+    # Observability options
+    metrics_enabled: Optional[bool] = None
+    job_storage_path: Optional[str] = None
+    enable_workflows: Optional[bool] = None
+    # Diagnostics options (new in 0.17+)
+    dcc_pid: Optional[int] = None
+    dcc_window_title: Optional[str] = None
+    dcc_window_handle: Optional[int] = None
+    snapshot_provider: Optional[Any] = None
+    # Execution options (new in 0.17+)
+    dispatcher: Optional[Any] = None  # BaseDccCallableDispatcher
+    execution_bridge: Optional[Any] = None  # HostExecutionBridge
+
+    def to_core_options(self) -> DccServerOptions:
+        """Convert to core DccServerOptions using from_env()."""
+        return DccServerOptions.from_env(
+            dcc_name=_DCC_NAME,
+            builtin_skills_dir=_BUILTIN_SKILLS_DIR,
+            port=self.port,
+            server_name=self.server_name,
+            server_version=self.server_version,
+            # Gateway kwargs
+            gateway_port=self.gateway_port,
+            registry_dir=self.registry_dir,
+            dcc_version=self.dcc_version,
+            scene=self.scene,
+            enable_gateway_failover=_env.resolve_enable_gateway_failover(self.enable_gateway_failover),
+            # Observability kwargs
+            enable_file_logging=True,  # default
+            enable_job_persistence=_env.resolve_job_storage(self.job_storage_path) is not None,
+            enable_telemetry=True,  # default
+            # Diagnostics kwargs (new in 0.17+)
+            dcc_pid=self.dcc_pid,
+            dcc_window_title=self.dcc_window_title,
+            dcc_window_handle=self.dcc_window_handle,
+            snapshot_provider=self.snapshot_provider,
+            # Execution kwargs (new in 0.17+)
+            dispatcher=self.dispatcher,
+            execution_bridge=self.execution_bridge,
+        )
 
 
 # ── server class ─────────────────────────────────────────────────────────────
@@ -92,22 +154,57 @@ class BlenderMcpServer(DccServerBase):
         registry_dir: Optional[str] = None,
         dcc_version: Optional[str] = None,
         scene: Optional[str] = None,
-        enable_gateway_failover: bool = True,
+        enable_gateway_failover: Optional[bool] = None,
+        metrics_enabled: Optional[bool] = None,
+        job_storage_path: Optional[str] = None,
+        enable_workflows: Optional[bool] = None,
+        options: Optional[BlenderServerOptions] = None,
     ) -> None:
-        super().__init__(
-            dcc_name=_DCC_NAME,
-            builtin_skills_dir=_BUILTIN_SKILLS_DIR,
-            port=port,
-            server_name=server_name,
-            server_version=server_version,
-            gateway_port=gateway_port,
-            registry_dir=registry_dir,
-            dcc_version=dcc_version,
-            scene=scene,
-            enable_gateway_failover=enable_gateway_failover,
-        )
-        self._extra_skill_paths: List[str] = extra_skill_paths or []
-        self._port: int = port  # cached port; updated after start
+        if options is None:
+            options = BlenderServerOptions(
+                port=port,
+                extra_skill_paths=extra_skill_paths,
+                server_name=server_name,
+                server_version=server_version,
+                gateway_port=gateway_port,
+                registry_dir=registry_dir,
+                dcc_version=dcc_version,
+                scene=scene,
+                enable_gateway_failover=enable_gateway_failover,
+                metrics_enabled=metrics_enabled,
+                job_storage_path=job_storage_path,
+                enable_workflows=enable_workflows,
+            )
+
+        super().__init__(options=options.to_core_options())
+
+        self._extra_skill_paths: List[str] = list(options.extra_skill_paths or [])
+
+        if _env.resolve_metrics_enabled(options.metrics_enabled):
+            self._config.enable_prometheus = True
+            logger.info("[%s] Prometheus /metrics endpoint enabled", _DCC_NAME)
+
+        effective_job_path = _env.resolve_job_storage(options.job_storage_path)
+        if effective_job_path:
+            self._config.job_storage_path = effective_job_path
+            logger.info("[%s] Job storage: %s", _DCC_NAME, effective_job_path)
+        elif effective_job_path == "":
+            self._config.job_storage_path = ""
+
+        if _env.resolve_enable_workflows(options.enable_workflows):
+            try:
+                self._config.enable_workflows = True
+                logger.info(
+                    "[%s] Workflow engine enabled (workflows.run / .resume / .list_runs)",
+                    _DCC_NAME,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("[%s] Could not enable workflows on inner config: %s", _DCC_NAME, exc)
+
+        gateway_port_arg = options.gateway_port
+        enable_gw = _env.resolve_enable_gateway_failover(options.enable_gateway_failover)
+        if gateway_port_arg == 0 or (gateway_port_arg is None and not enable_gw):
+            self._config.gateway_port = 0
 
     # ── Blender version detection ──────────────────────────────────────────────
 
@@ -127,14 +224,10 @@ class BlenderMcpServer(DccServerBase):
         """TCP port the server is listening on."""
         if self._handle is not None:
             try:
-                return self._handle.port
+                return int(self._handle.port)
             except Exception:
                 pass
-        return self._port
-
-    @port.setter
-    def port(self, value: int) -> None:
-        self._port = value
+        return int(self._options.port)
 
     # ── Skill search path helpers ──────────────────────────────────────────────
 
@@ -156,12 +249,6 @@ class BlenderMcpServer(DccServerBase):
     def start(self) -> "BlenderMcpServer":
         """Start the MCP HTTP server.  Returns *self* for chaining."""
         super().start()
-        # Update cached port
-        if self._handle is not None:
-            try:
-                self._port = self._handle.port
-            except Exception:
-                pass
         return self
 
     # ── Progressive skill loading ──────────────────────────────────────────────
@@ -249,6 +336,10 @@ class BlenderMcpServer(DccServerBase):
     ) -> List[Dict[str, Any]]:
         """Search for skills matching the given criteria.
 
+        Wraps the inner server's :meth:`search_skills` (dcc-mcp-core 0.15+); the
+        ``find_skills`` name is kept for backward compatibility with scripts
+        and tests.
+
         Args:
             query: Free-text query matched against skill name/description.
             tags: Required tags (skill must have all).
@@ -260,7 +351,7 @@ class BlenderMcpServer(DccServerBase):
         if self._handle is None:
             return []
         # The Rust binding requires a Sequence for tags; pass [] instead of None
-        return list(self._server.find_skills(query=query, tags=tags or [], dcc=dcc or _DCC_NAME))  # type: ignore[arg-type]
+        return list(self._server.search_skills(query=query, tags=tags or [], dcc=dcc or _DCC_NAME))  # type: ignore[arg-type]
 
     def is_skill_loaded(self, skill_name: str) -> bool:  # type: ignore[override]
         """Return ``True`` if the named skill is currently loaded."""
@@ -290,7 +381,10 @@ def start_server(
     registry_dir: Optional[str] = None,
     dcc_version: Optional[str] = None,
     scene: Optional[str] = None,
-    enable_gateway_failover: bool = True,
+    enable_gateway_failover: Optional[bool] = None,
+    metrics_enabled: Optional[bool] = None,
+    job_storage_path: Optional[str] = None,
+    enable_workflows: Optional[bool] = None,
 ) -> BlenderMcpServer:
     """Start the Blender MCP server (creates a process-level singleton).
 
@@ -314,6 +408,9 @@ def start_server(
         dcc_version: Blender version for gateway registry.
         scene: Currently open scene file path for the gateway registry.
         enable_gateway_failover: Enable automatic gateway failover.
+        metrics_enabled: Force Prometheus ``/metrics`` (``None`` = env ``DCC_MCP_BLENDER_METRICS``).
+        job_storage_path: SQLite job DB path (``None`` = env / default).
+        enable_workflows: Enable workflow MCP tools (``None`` = env).
 
     Returns:
         The running :class:`BlenderMcpServer` instance.
@@ -330,6 +427,9 @@ def start_server(
         dcc_version=dcc_version,
         scene=scene,
         enable_gateway_failover=enable_gateway_failover,
+        metrics_enabled=metrics_enabled,
+        job_storage_path=job_storage_path,
+        enable_workflows=enable_workflows,
     )
     if register_builtins:
         _server_instance.register_builtin_actions(include_bundled=include_bundled)

--- a/src/dcc_mcp_blender/skills/blender-animation/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-animation/SKILL.md
@@ -1,38 +1,16 @@
 ---
 name: blender-animation
 description: "Blender animation — keyframes, frame ranges, and actions"
-dcc: blender
-version: "1.0.0"
-tags: [blender, animation, keyframes]
-search-hint: "keyframe, animation, frame range, action, timeline"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
-depends: []
-tools:
-  - name: set_keyframe
-    description: "Insert a keyframe on an object at the current or specified frame"
-    source_file: scripts/set_keyframe.py
-    read_only: false
-    destructive: false
-    idempotent: false
-  - name: set_frame_range
-    description: "Set the animation frame range (start and end frames)"
-    source_file: scripts/set_frame_range.py
-    read_only: false
-    destructive: false
-    idempotent: true
-  - name: get_frame_range
-    description: "Get the current animation frame range"
-    source_file: scripts/get_frame_range.py
-    read_only: true
-    destructive: false
-    idempotent: true
-  - name: set_current_frame
-    description: "Set the current animation frame"
-    source_file: scripts/set_current_frame.py
-    read_only: false
-    destructive: false
-    idempotent: true
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, animation, keyframes]
+    search-hint: "keyframe, animation, frame range, action, timeline"
+    depends: []
+    tools: tools.yaml
 ---
 
 # blender-animation

--- a/src/dcc_mcp_blender/skills/blender-animation/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-animation/tools.yaml
@@ -1,0 +1,25 @@
+tools:
+  - name: set_keyframe
+    description: "Insert a keyframe on an object at the current or specified frame"
+    source_file: scripts/set_keyframe.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: set_frame_range
+    description: "Set the animation frame range (start and end frames)"
+    source_file: scripts/set_frame_range.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: get_frame_range
+    description: "Get the current animation frame range"
+    source_file: scripts/get_frame_range.py
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: set_current_frame
+    description: "Set the current animation frame"
+    source_file: scripts/set_current_frame.py
+    read_only: false
+    destructive: false
+    idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-camera/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-camera/SKILL.md
@@ -1,38 +1,16 @@
 ---
 name: blender-camera
 description: "Blender camera management — create, configure and set active cameras"
-dcc: blender
-version: "1.0.0"
-tags: [blender, camera, viewport]
-search-hint: "camera, lens, focal length, active camera, perspective"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
-depends: []
-tools:
-  - name: create_camera
-    description: "Create a new camera object"
-    source_file: scripts/create_camera.py
-    read_only: false
-    destructive: false
-    idempotent: false
-  - name: set_active_camera
-    description: "Set the active render camera for the scene"
-    source_file: scripts/set_active_camera.py
-    read_only: false
-    destructive: false
-    idempotent: true
-  - name: set_camera_properties
-    description: "Configure camera properties (focal length, type, etc.)"
-    source_file: scripts/set_camera_properties.py
-    read_only: false
-    destructive: false
-    idempotent: true
-  - name: list_cameras
-    description: "List all cameras in the scene"
-    source_file: scripts/list_cameras.py
-    read_only: true
-    destructive: false
-    idempotent: true
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, camera, viewport]
+    search-hint: "camera, lens, focal length, active camera, perspective"
+    depends: []
+    tools: tools.yaml
 ---
 
 # blender-camera

--- a/src/dcc_mcp_blender/skills/blender-camera/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-camera/tools.yaml
@@ -1,0 +1,25 @@
+tools:
+  - name: create_camera
+    description: "Create a new camera object"
+    source_file: scripts/create_camera.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: set_active_camera
+    description: "Set the active render camera for the scene"
+    source_file: scripts/set_active_camera.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: set_camera_properties
+    description: "Configure camera properties (focal length, type, etc.)"
+    source_file: scripts/set_camera_properties.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: list_cameras
+    description: "List all cameras in the scene"
+    source_file: scripts/list_cameras.py
+    read_only: true
+    destructive: false
+    idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-collection/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-collection/SKILL.md
@@ -1,32 +1,16 @@
 ---
 name: blender-collection
 description: "Blender collection management — create, link objects, and organize scene hierarchy"
-dcc: blender
-version: "1.0.0"
-tags: [blender, collection, hierarchy, organization]
-search-hint: "collection, group, organize, hierarchy"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
-depends: []
-tools:
-  - name: create_collection
-    description: "Create a new collection in the scene"
-    source_file: scripts/create_collection.py
-    read_only: false
-    destructive: false
-    idempotent: false
-  - name: link_to_collection
-    description: "Link an object to a collection"
-    source_file: scripts/link_to_collection.py
-    read_only: false
-    destructive: false
-    idempotent: true
-  - name: list_collections
-    description: "List all collections in the scene"
-    source_file: scripts/list_collections.py
-    read_only: true
-    destructive: false
-    idempotent: true
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, collection, hierarchy, organization]
+    search-hint: "collection, group, organize, hierarchy"
+    depends: []
+    tools: tools.yaml
 ---
 
 # blender-collection

--- a/src/dcc_mcp_blender/skills/blender-collection/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-collection/tools.yaml
@@ -1,0 +1,19 @@
+tools:
+  - name: create_collection
+    description: "Create a new collection in the scene"
+    source_file: scripts/create_collection.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: link_to_collection
+    description: "Link an object to a collection"
+    source_file: scripts/link_to_collection.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: list_collections
+    description: "List all collections in the scene"
+    source_file: scripts/list_collections.py
+    read_only: true
+    destructive: false
+    idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-lighting/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-lighting/SKILL.md
@@ -1,32 +1,16 @@
 ---
 name: blender-lighting
 description: "Blender lighting — create, configure and manage lights"
-dcc: blender
-version: "1.0.0"
-tags: [blender, lighting, lights]
-search-hint: "create light, point, sun, area, spot, energy, color"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
-depends: []
-tools:
-  - name: create_light
-    description: "Create a new light object (POINT, SUN, AREA, SPOT)"
-    source_file: scripts/create_light.py
-    read_only: false
-    destructive: false
-    idempotent: false
-  - name: set_light_properties
-    description: "Set energy, color, and other light properties"
-    source_file: scripts/set_light_properties.py
-    read_only: false
-    destructive: false
-    idempotent: true
-  - name: list_lights
-    description: "List all lights in the current scene"
-    source_file: scripts/list_lights.py
-    read_only: true
-    destructive: false
-    idempotent: true
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, lighting, lights]
+    search-hint: "create light, point, sun, area, spot, energy, color"
+    depends: []
+    tools: tools.yaml
 ---
 
 # blender-lighting

--- a/src/dcc_mcp_blender/skills/blender-lighting/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-lighting/tools.yaml
@@ -1,0 +1,19 @@
+tools:
+  - name: create_light
+    description: "Create a new light object (POINT, SUN, AREA, SPOT)"
+    source_file: scripts/create_light.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: set_light_properties
+    description: "Set energy, color, and other light properties"
+    source_file: scripts/set_light_properties.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: list_lights
+    description: "List all lights in the current scene"
+    source_file: scripts/list_lights.py
+    read_only: true
+    destructive: false
+    idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-materials/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-materials/SKILL.md
@@ -1,44 +1,16 @@
 ---
 name: blender-materials
 description: "Blender material system — create, assign, modify and list materials"
-dcc: blender
-version: "1.0.0"
-tags: [blender, materials, shading]
-search-hint: "create material, assign, color, shader, PBR, list materials"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
-depends: []
-tools:
-  - name: create_material
-    description: "Create a new Principled BSDF material"
-    source_file: scripts/create_material.py
-    read_only: false
-    destructive: false
-    idempotent: false
-  - name: assign_material
-    description: "Assign a material to an object"
-    source_file: scripts/assign_material.py
-    read_only: false
-    destructive: false
-    idempotent: true
-  - name: set_material_color
-    description: "Set the base color of a material"
-    source_file: scripts/set_material_color.py
-    read_only: false
-    destructive: false
-    idempotent: true
-  - name: list_materials
-    description: "List all materials in the current scene"
-    source_file: scripts/list_materials.py
-    read_only: true
-    destructive: false
-    idempotent: true
-  - name: delete_material
-    description: "Delete a material"
-    source_file: scripts/delete_material.py
-    read_only: false
-    destructive: true
-    idempotent: false
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, materials, shading]
+    search-hint: "create material, assign, color, shader, PBR, list materials"
+    depends: []
+    tools: tools.yaml
 ---
 
 # blender-materials

--- a/src/dcc_mcp_blender/skills/blender-materials/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-materials/tools.yaml
@@ -1,0 +1,31 @@
+tools:
+  - name: create_material
+    description: "Create a new Principled BSDF material"
+    source_file: scripts/create_material.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: assign_material
+    description: "Assign a material to an object"
+    source_file: scripts/assign_material.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: set_material_color
+    description: "Set the base color of a material"
+    source_file: scripts/set_material_color.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: list_materials
+    description: "List all materials in the current scene"
+    source_file: scripts/list_materials.py
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: delete_material
+    description: "Delete a material"
+    source_file: scripts/delete_material.py
+    read_only: false
+    destructive: true
+    idempotent: false

--- a/src/dcc_mcp_blender/skills/blender-mesh/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-mesh/SKILL.md
@@ -1,38 +1,16 @@
 ---
 name: blender-mesh
 description: "Blender mesh operations — modifiers, subdivision, and mesh editing"
-dcc: blender
-version: "1.0.0"
-tags: [blender, mesh, modifier, geometry]
-search-hint: "modifier, subdivision, smooth, apply modifier, mesh edit"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
-depends: []
-tools:
-  - name: add_modifier
-    description: "Add a modifier to a mesh object (Subdivision, Mirror, Array, etc.)"
-    source_file: scripts/add_modifier.py
-    read_only: false
-    destructive: false
-    idempotent: false
-  - name: apply_modifier
-    description: "Apply (bake) a modifier permanently to the mesh"
-    source_file: scripts/apply_modifier.py
-    read_only: false
-    destructive: true
-    idempotent: false
-  - name: list_modifiers
-    description: "List all modifiers on an object"
-    source_file: scripts/list_modifiers.py
-    read_only: true
-    destructive: false
-    idempotent: true
-  - name: get_mesh_info
-    description: "Get vertex, edge, and face count of a mesh"
-    source_file: scripts/get_mesh_info.py
-    read_only: true
-    destructive: false
-    idempotent: true
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, mesh, modifier, geometry]
+    search-hint: "modifier, subdivision, smooth, apply modifier, mesh edit"
+    depends: []
+    tools: tools.yaml
 ---
 
 # blender-mesh

--- a/src/dcc_mcp_blender/skills/blender-mesh/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-mesh/tools.yaml
@@ -1,0 +1,25 @@
+tools:
+  - name: add_modifier
+    description: "Add a modifier to a mesh object (Subdivision, Mirror, Array, etc.)"
+    source_file: scripts/add_modifier.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: apply_modifier
+    description: "Apply (bake) a modifier permanently to the mesh"
+    source_file: scripts/apply_modifier.py
+    read_only: false
+    destructive: true
+    idempotent: false
+  - name: list_modifiers
+    description: "List all modifiers on an object"
+    source_file: scripts/list_modifiers.py
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: get_mesh_info
+    description: "Get vertex, edge, and face count of a mesh"
+    source_file: scripts/get_mesh_info.py
+    read_only: true
+    destructive: false
+    idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-objects/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-objects/SKILL.md
@@ -1,56 +1,16 @@
 ---
 name: blender-objects
 description: "Blender object manipulation — create, delete, move, rotate, scale and duplicate objects"
-dcc: blender
-version: "1.0.0"
-tags: [blender, objects, transform]
-search-hint: "create object, delete, move, rotate, scale, duplicate, select"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
-depends: []
-tools:
-  - name: create_object
-    description: "Create a new Blender object (mesh primitive, empty, etc.)"
-    source_file: scripts/create_object.py
-    read_only: false
-    destructive: false
-    idempotent: false
-  - name: delete_object
-    description: "Delete an object from the scene"
-    source_file: scripts/delete_object.py
-    read_only: false
-    destructive: true
-    idempotent: false
-  - name: duplicate_object
-    description: "Duplicate an existing object"
-    source_file: scripts/duplicate_object.py
-    read_only: false
-    destructive: false
-    idempotent: false
-  - name: move_object
-    description: "Move an object to a specified location"
-    source_file: scripts/move_object.py
-    read_only: false
-    destructive: false
-    idempotent: true
-  - name: rotate_object
-    description: "Rotate an object by Euler angles (degrees)"
-    source_file: scripts/rotate_object.py
-    read_only: false
-    destructive: false
-    idempotent: true
-  - name: scale_object
-    description: "Scale an object"
-    source_file: scripts/scale_object.py
-    read_only: false
-    destructive: false
-    idempotent: true
-  - name: get_object_info
-    description: "Get detailed information about an object"
-    source_file: scripts/get_object_info.py
-    read_only: true
-    destructive: false
-    idempotent: true
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, objects, transform]
+    search-hint: "create object, delete, move, rotate, scale, duplicate, select"
+    depends: []
+    tools: tools.yaml
 ---
 
 # blender-objects

--- a/src/dcc_mcp_blender/skills/blender-objects/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-objects/tools.yaml
@@ -1,0 +1,43 @@
+tools:
+  - name: create_object
+    description: "Create a new Blender object (mesh primitive, empty, etc.)"
+    source_file: scripts/create_object.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: delete_object
+    description: "Delete an object from the scene"
+    source_file: scripts/delete_object.py
+    read_only: false
+    destructive: true
+    idempotent: false
+  - name: duplicate_object
+    description: "Duplicate an existing object"
+    source_file: scripts/duplicate_object.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: move_object
+    description: "Move an object to a specified location"
+    source_file: scripts/move_object.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: rotate_object
+    description: "Rotate an object by Euler angles (degrees)"
+    source_file: scripts/rotate_object.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: scale_object
+    description: "Scale an object"
+    source_file: scripts/scale_object.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: get_object_info
+    description: "Get detailed information about an object"
+    source_file: scripts/get_object_info.py
+    read_only: true
+    destructive: false
+    idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-render/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-render/SKILL.md
@@ -1,32 +1,16 @@
 ---
 name: blender-render
 description: "Blender rendering — render scenes, set render settings, manage cameras"
-dcc: blender
-version: "1.0.0"
-tags: [blender, render, camera]
-search-hint: "render, output, resolution, camera, cycles, eevee"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
-depends: []
-tools:
-  - name: render_scene
-    description: "Render the current scene and save to a file"
-    source_file: scripts/render_scene.py
-    read_only: false
-    destructive: false
-    idempotent: false
-  - name: set_render_settings
-    description: "Configure render settings (engine, resolution, samples, output path)"
-    source_file: scripts/set_render_settings.py
-    read_only: false
-    destructive: false
-    idempotent: true
-  - name: get_render_info
-    description: "Return current render settings"
-    source_file: scripts/get_render_info.py
-    read_only: true
-    destructive: false
-    idempotent: true
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, render, camera]
+    search-hint: "render, output, resolution, camera, cycles, eevee"
+    depends: []
+    tools: tools.yaml
 ---
 
 # blender-render

--- a/src/dcc_mcp_blender/skills/blender-render/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-render/tools.yaml
@@ -1,0 +1,19 @@
+tools:
+  - name: render_scene
+    description: "Render the current scene and save to a file"
+    source_file: scripts/render_scene.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: set_render_settings
+    description: "Configure render settings (engine, resolution, samples, output path)"
+    source_file: scripts/set_render_settings.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: get_render_info
+    description: "Return current render settings"
+    source_file: scripts/get_render_info.py
+    read_only: true
+    destructive: false
+    idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-scene/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-scene/SKILL.md
@@ -1,50 +1,16 @@
 ---
 name: blender-scene
 description: "Blender scene management — create, open, save, list and inspect scene objects"
-dcc: blender
-version: "1.0.0"
-tags: [blender, scene, hierarchy]
-search-hint: "new scene, open, save, list objects, hierarchy, scene info"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
-depends: []
-tools:
-  - name: new_scene
-    description: "Create a new empty Blender scene"
-    source_file: scripts/new_scene.py
-    read_only: false
-    destructive: true
-    idempotent: false
-  - name: save_scene
-    description: "Save the current Blender scene"
-    source_file: scripts/save_scene.py
-    read_only: false
-    destructive: false
-    idempotent: true
-  - name: open_scene
-    description: "Open a Blender scene file (.blend) from disk"
-    source_file: scripts/open_scene.py
-    read_only: false
-    destructive: true
-    idempotent: false
-  - name: list_objects
-    description: "List all objects in the current Blender scene"
-    source_file: scripts/list_objects.py
-    read_only: true
-    destructive: false
-    idempotent: true
-  - name: get_scene_info
-    description: "Return a hierarchical description of the current scene"
-    source_file: scripts/get_scene_info.py
-    read_only: true
-    destructive: false
-    idempotent: true
-  - name: get_session_info
-    description: "Return Blender version, scene path, and basic session statistics"
-    source_file: scripts/get_session_info.py
-    read_only: true
-    destructive: false
-    idempotent: true
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, scene, hierarchy]
+    search-hint: "new scene, open, save, list objects, hierarchy, scene info"
+    depends: []
+    tools: tools.yaml
 ---
 
 # blender-scene

--- a/src/dcc_mcp_blender/skills/blender-scene/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-scene/tools.yaml
@@ -1,0 +1,37 @@
+tools:
+  - name: new_scene
+    description: "Create a new empty Blender scene"
+    source_file: scripts/new_scene.py
+    read_only: false
+    destructive: true
+    idempotent: false
+  - name: save_scene
+    description: "Save the current Blender scene"
+    source_file: scripts/save_scene.py
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: open_scene
+    description: "Open a Blender scene file (.blend) from disk"
+    source_file: scripts/open_scene.py
+    read_only: false
+    destructive: true
+    idempotent: false
+  - name: list_objects
+    description: "List all objects in the current Blender scene"
+    source_file: scripts/list_objects.py
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: get_scene_info
+    description: "Return a hierarchical description of the current scene"
+    source_file: scripts/get_scene_info.py
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: get_session_info
+    description: "Return Blender version, scene path, and basic session statistics"
+    source_file: scripts/get_session_info.py
+    read_only: true
+    destructive: false
+    idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-scripting/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-scripting/SKILL.md
@@ -1,32 +1,16 @@
 ---
 name: blender-scripting
 description: "Execute Python code or scripts inside Blender's Python interpreter"
-dcc: blender
-version: "1.0.0"
-tags: [blender, scripting, python, automation]
-search-hint: "execute python, run script, blender python, bpy"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
-depends: []
-tools:
-  - name: execute_python
-    description: "Execute a Python code snippet inside Blender"
-    source_file: scripts/execute_python.py
-    read_only: false
-    destructive: false
-    idempotent: false
-  - name: execute_script_file
-    description: "Execute a Python script file inside Blender"
-    source_file: scripts/execute_script_file.py
-    read_only: false
-    destructive: false
-    idempotent: false
-  - name: get_blender_info
-    description: "Get Blender version and Python environment information"
-    source_file: scripts/get_blender_info.py
-    read_only: true
-    destructive: false
-    idempotent: true
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, scripting, python, automation]
+    search-hint: "execute python, run script, blender python, bpy"
+    depends: []
+    tools: tools.yaml
 ---
 
 # blender-scripting

--- a/src/dcc_mcp_blender/skills/blender-scripting/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-scripting/tools.yaml
@@ -1,0 +1,19 @@
+tools:
+  - name: execute_python
+    description: "Execute a Python code snippet inside Blender"
+    source_file: scripts/execute_python.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: execute_script_file
+    description: "Execute a Python script file inside Blender"
+    source_file: scripts/execute_script_file.py
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: get_blender_info
+    description: "Get Blender version and Python environment information"
+    source_file: scripts/get_blender_info.py
+    read_only: true
+    destructive: false
+    idempotent: true

--- a/tests/e2e/test_server_e2e.py
+++ b/tests/e2e/test_server_e2e.py
@@ -84,7 +84,12 @@ class TestServerLifecycleE2E:
                     },
                 }
             ).encode()
-            req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"}, method="POST")
+            req = urllib.request.Request(
+                url,
+                data=body,
+                headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
+                method="POST",
+            )
             with urllib.request.urlopen(req, timeout=10) as resp:
                 data = json.loads(resp.read())
             assert data["result"]["serverInfo"]["name"] == "dcc-mcp-blender"
@@ -220,7 +225,10 @@ class TestMultiInstanceGatewayE2E:
                     }
                 ).encode()
                 req = urllib.request.Request(
-                    url, data=body, headers={"Content-Type": "application/json"}, method="POST"
+                    url,
+                    data=body,
+                    headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
+                    method="POST",
                 )
                 with urllib.request.urlopen(req, timeout=10) as resp:
                     data = json.loads(resp.read())

--- a/tests/e2e/test_server_e2e.py
+++ b/tests/e2e/test_server_e2e.py
@@ -27,6 +27,12 @@ def _new_scene():
     bpy.ops.wm.read_factory_settings(use_empty=True)
 
 
+def _skill_get(skill, key, default=None):
+    if isinstance(skill, dict):
+        return skill.get(key, default)
+    return getattr(skill, key, default)
+
+
 # ── Server lifecycle ──────────────────────────────────────────────────────────
 
 
@@ -140,29 +146,33 @@ class TestProgressiveLoadingE2E:
         server = dcc_mcp_blender.start_server(port=0)
 
         # Pick the first skill that is currently loaded (eager or lazy)
-        loaded = [s for s in server.list_skills() if s.get("loaded") or server.is_skill_loaded(s.get("name", ""))]
+        loaded = [
+            s
+            for s in server.list_skills()
+            if _skill_get(s, "loaded") or server.is_skill_loaded(_skill_get(s, "name", ""))
+        ]
         if not loaded:
             # create_skill_manager only discovered but did not load — load one now
             discovered = server.list_skills()
             if not discovered:
                 return  # no skills at all; nothing to test
-            skill_name = discovered[0].get("name", "blender-scene")
+            skill_name = _skill_get(discovered[0], "name", "blender-scene")
             server.load_skill(skill_name)
             loaded = [{"name": skill_name}]
 
-        skill_name = loaded[0].get("name", "blender-scene")
+        skill_name = _skill_get(loaded[0], "name", "blender-scene")
 
         # Ensure it is loaded before unloading
         if not server.is_skill_loaded(skill_name):
             server.load_skill(skill_name)
 
         removed = server.unload_skill(skill_name)
-        assert removed >= 0  # may be 0 if unload is no-op but doesn't raise
+        assert removed is True
         assert not server.is_skill_loaded(skill_name)
 
         # Reload
-        actions = server.load_skill(skill_name)
-        assert isinstance(actions, list)
+        loaded_again = server.load_skill(skill_name)
+        assert loaded_again is True
         assert server.is_skill_loaded(skill_name)
 
     def test_discover_extra_paths_no_crash(self):

--- a/tests/test_lint_skills.py
+++ b/tests/test_lint_skills.py
@@ -6,10 +6,12 @@ import pathlib
 import sys
 
 import yaml
+from dcc_mcp_core import validate_skill
 
 SKILLS_DIR = pathlib.Path(__file__).parent.parent / "src" / "dcc_mcp_blender" / "skills"
 
-REQUIRED_FIELDS = {"name", "description", "dcc", "version", "tools"}
+REQUIRED_FIELDS = {"name", "description", "metadata"}
+REQUIRED_DCC_MCP_FIELDS = {"dcc", "version", "tags", "search-hint", "tools"}
 REQUIRED_TOOL_FIELDS = {"name", "description", "source_file"}
 
 
@@ -51,13 +53,35 @@ def test_all_skill_md_files():
             errors.append(f"{skill_dir.name}: empty or missing front-matter")
             continue
 
+        report = validate_skill(str(skill_dir))
+        if report.has_errors:
+            for issue in report.issues:
+                errors.append(f"{skill_dir.name}: {issue.category}: {issue.message}")
+
         missing = REQUIRED_FIELDS - set(front.keys())
         if missing:
             errors.append(f"{skill_dir.name}: missing fields: {missing}")
 
-        tools = front.get("tools", [])
+        dcc_mcp = front.get("metadata", {}).get("dcc-mcp", {})
+        missing_dcc_mcp = REQUIRED_DCC_MCP_FIELDS - set(dcc_mcp.keys())
+        if missing_dcc_mcp:
+            errors.append(f"{skill_dir.name}: missing metadata.dcc-mcp fields: {missing_dcc_mcp}")
+            continue
+
+        tools_file = skill_dir / str(dcc_mcp.get("tools", ""))
+        if not tools_file.exists():
+            errors.append(f"{skill_dir.name}: tools file not found: {dcc_mcp.get('tools')}")
+            continue
+
+        try:
+            tools_doc = yaml.safe_load(tools_file.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError as e:
+            errors.append(f"{skill_dir.name}: tools YAML parse error: {e}")
+            continue
+
+        tools = tools_doc.get("tools", [])
         if not isinstance(tools, list) or not tools:
-            errors.append(f"{skill_dir.name}: 'tools' must be a non-empty list")
+            errors.append(f"{skill_dir.name}: tools file must contain a non-empty 'tools' list")
             continue
 
         for tool in tools:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -217,23 +217,17 @@ class TestProgressiveLoading:
         server = BlenderMcpServer(port=0)
         assert not server.is_skill_loaded("blender-scene")
 
-    def test_load_skill_raises_when_not_running(self):
-        import pytest
-
+    def test_load_skill_returns_false_when_not_discovered(self):
         from dcc_mcp_blender.server import BlenderMcpServer
 
         server = BlenderMcpServer(port=0)
-        with pytest.raises(RuntimeError, match="not running"):
-            server.load_skill("blender-scene")
+        assert server.load_skill("blender-scene") is False
 
-    def test_unload_skill_raises_when_not_running(self):
-        import pytest
-
+    def test_unload_skill_returns_false_when_not_discovered(self):
         from dcc_mcp_blender.server import BlenderMcpServer
 
         server = BlenderMcpServer(port=0)
-        with pytest.raises(RuntimeError, match="not running"):
-            server.unload_skill("blender-scene")
+        assert server.unload_skill("blender-scene") is False
 
     def test_list_skills_after_start(self):
         from dcc_mcp_blender.server import BlenderMcpServer
@@ -304,13 +298,39 @@ class TestProgressiveLoading:
         from unittest.mock import MagicMock
 
         mock_inner = MagicMock()
-        mock_inner.find_skills.return_value = [{"name": "blender-scene"}]
+        mock_inner.search_skills.return_value = [{"name": "blender-scene"}]
 
         server = self._make_server_with_mock(mock_inner)
         try:
             result = server.find_skills(query="scene", tags=["blender"], dcc="blender")
             assert result == [{"name": "blender-scene"}]
-            mock_inner.find_skills.assert_called_once_with(query="scene", tags=["blender"], dcc="blender")
+            mock_inner.search_skills.assert_called_once_with(
+                query="scene",
+                tags=["blender"],
+                dcc="blender",
+                scope=None,
+                limit=None,
+            )
+        finally:
+            server.stop()
+
+    def test_search_skills_forwards_scope_and_limit(self):
+        from unittest.mock import MagicMock
+
+        mock_inner = MagicMock()
+        mock_inner.search_skills.return_value = [{"name": "blender-scene"}]
+
+        server = self._make_server_with_mock(mock_inner)
+        try:
+            result = server.search_skills(query="scene", scope="system", limit=3)
+            assert result == [{"name": "blender-scene"}]
+            mock_inner.search_skills.assert_called_once_with(
+                query="scene",
+                tags=[],
+                dcc="blender",
+                scope="system",
+                limit=3,
+            )
         finally:
             server.stop()
 
@@ -319,12 +339,12 @@ class TestProgressiveLoading:
         from unittest.mock import MagicMock
 
         mock_inner = MagicMock()
-        mock_inner.find_skills.return_value = []
+        mock_inner.search_skills.return_value = []
 
         server = self._make_server_with_mock(mock_inner)
         try:
             server.find_skills(dcc="blender")  # tags not passed → None
-            _call_kwargs = mock_inner.find_skills.call_args
+            _call_kwargs = mock_inner.search_skills.call_args
             assert _call_kwargs.kwargs["tags"] == []
         finally:
             server.stop()
@@ -338,8 +358,7 @@ class TestProgressiveLoading:
 
         server = self._make_server_with_mock(mock_inner)
         try:
-            actions = server.load_skill("blender-scene")
-            assert actions == ["blender_scene__get_session_info", "blender_scene__list_objects"]
+            assert server.load_skill("blender-scene") is True
             mock_inner.load_skill.assert_called_once_with("blender-scene")
             # is_skill_loaded now delegates to _server.is_loaded
             assert server.is_skill_loaded("blender-scene") is True
@@ -355,8 +374,7 @@ class TestProgressiveLoading:
 
         server = self._make_server_with_mock(mock_inner)
         try:
-            removed = server.unload_skill("blender-scene")
-            assert removed == 5
+            assert server.unload_skill("blender-scene") is True
             mock_inner.unload_skill.assert_called_once_with("blender-scene")
             assert server.is_skill_loaded("blender-scene") is False
         finally:
@@ -422,14 +440,12 @@ class TestProgressiveLoading:
         server = self._make_server_with_mock(mock_inner)
         try:
             # Load
-            actions = server.load_skill("blender-scene")
-            assert actions == ["action_a", "action_b"]
+            assert server.load_skill("blender-scene") is True
             assert server.is_skill_loaded("blender-scene") is True
             assert server.loaded_skill_count() == 1
 
             # Unload
-            removed = server.unload_skill("blender-scene")
-            assert removed == 2
+            assert server.unload_skill("blender-scene") is True
             assert server.is_skill_loaded("blender-scene") is False
             assert server.loaded_skill_count() == 0
 

--- a/tools/blender-dev-build-link-core-win.ps1
+++ b/tools/blender-dev-build-link-core-win.ps1
@@ -1,0 +1,227 @@
+# Build dcc-mcp-core with the target Blender's Python, then link core + dcc-mcp-blender into
+# Blender's addons directory for live debugging (no wheel copy).
+#
+# Prerequisites: Rust (cargo) on PATH, Git, optional vx on PATH for stubgen fallback.
+#
+# Usage:
+#   .\tools\blender-dev-build-link-core-win.ps1 -BlenderVersion 4.2
+#   .\tools\blender-dev-build-link-core-win.ps1 -BlenderVersion 4.2 -CoreRepo G:\path\to\dcc-mcp-core
+#   .\tools\blender-dev-build-link-core-win.ps1 -BlenderVersion 4.2 -LaunchBlender
+#
+# Environment:
+#   DCC_MCP_CORE_REPO — override path to dcc-mcp-core (default: sibling of this git repo)
+#
+# Blender bundles its own Python. We use this Python to build dcc-mcp-core with maturin develop,
+# then symlink both dcc_mcp_core and dcc_mcp_blender into Blender's addons directory.
+
+param(
+    [string]$BlenderVersion = "4.2",
+    [string]$CoreRepo = "",
+    [switch]$SkipBuild,
+    [switch]$LaunchBlender
+)
+
+$ErrorActionPreference = "Stop"
+
+$BlenderRoot = (git rev-parse --show-toplevel 2>$null)
+if (-not $BlenderRoot) {
+    $BlenderRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+}
+
+if (-not $CoreRepo) {
+    if ($env:DCC_MCP_CORE_REPO) {
+        $CoreRepo = $env:DCC_MCP_CORE_REPO
+    } else {
+        $sibling = Join-Path (Split-Path $BlenderRoot -Parent) "dcc-mcp-core"
+        if (Test-Path (Join-Path $sibling "Cargo.toml")) {
+            $CoreRepo = $sibling
+        }
+    }
+}
+if (-not $CoreRepo -or -not (Test-Path (Join-Path $CoreRepo "Cargo.toml"))) {
+    Write-Error "dcc-mcp-core not found. Clone it next to dcc-mcp-blender or set DCC_MCP_CORE_REPO / -CoreRepo."
+}
+
+$CoreRepo = (Resolve-Path $CoreRepo).Path
+
+# Detect Blender's bundled Python
+# Blender 4.x typically uses Python 3.11 or 3.12
+$BlenderExe = "C:\Program Files\Blender Foundation\Blender $BlenderVersion\blender.exe"
+$BlenderPython = ""
+
+# Try to find Python in Blender directory
+if (Test-Path $BlenderExe) {
+    # Try common Python version paths
+    $blenderDir = Split-Path $BlenderExe -Parent
+    $pythonDir = Get-ChildItem -Path (Split-Path $blenderDir -Parent) -Directory | 
+                 Where-Object { $_.Name -match '^\d+\.\d+$' } | 
+                 Select-Object -First 1
+    
+    if ($pythonDir) {
+        $pythonPath = Join-Path $pythonDir.FullName "python.exe"
+        if (Test-Path $pythonPath) {
+            $BlenderPython = $pythonPath
+        }
+    }
+    
+    # Fallback: try to find python in Blender's directory
+    if (-not $BlenderPython) {
+        $BlenderBase = Split-Path (Split-Path $BlenderExe -Parent) -Parent
+        $BlenderPython = Get-ChildItem -Path $BlenderBase -Recurse -Filter "python.exe" -ErrorAction SilentlyContinue | 
+                        Select-Object -First 1 -ExpandProperty FullName
+    }
+} else {
+    Write-Host "   ⚠️  Blender $BlenderVersion not found at $BlenderExe" -ForegroundColor Yellow
+    Write-Host "   Will use system Python for build" -ForegroundColor Yellow
+}
+
+# If Blender Python not found, use system Python
+if (-not $BlenderPython -or -not (Test-Path $BlenderPython)) {
+    Write-Host "   ⚠️  Blender Python not found, using system python" -ForegroundColor Yellow
+    $BlenderPython = "python"
+}
+
+$PyTag = & $BlenderPython -c "import sys; print('%d.%d' % (sys.version_info[0], sys.version_info[1]))" 2>$null
+if (-not $PyTag) {
+    Write-Host "   ⚠️  Failed to get Python version, using default features" -ForegroundColor Yellow
+    $PyTag = "3.11"
+}
+
+Write-Host "   Detected Python $PyTag (from $BlenderPython)" -ForegroundColor Gray
+
+# Features for maturin develop
+$OptFeatures = "workflow,scheduler,prometheus,job-persist-sqlite"
+if ([version]$PyTag -ge [version]"3.8") {
+    $DevFeatures = "python-bindings,ext-module,abi3-py38,$OptFeatures"
+    Write-Host "   Features: DEV + abi3-py38 (stable ABI)" -ForegroundColor Gray
+} else {
+    $DevFeatures = "python-bindings,ext-module,$OptFeatures"
+    Write-Host "   Features: DEV (no abi3)" -ForegroundColor Gray
+}
+
+Write-Host "=== dcc-mcp-core (maturin develop via Blender Python) ===" -ForegroundColor Cyan
+Write-Host "   Core repo : $CoreRepo"
+Write-Host "   Python    : $BlenderPython"
+Write-Host ""
+
+if (-not $SkipBuild) {
+    Push-Location $CoreRepo
+    try {
+        Write-Host "   Running stub_gen (cargo)..." -ForegroundColor Gray
+        & cargo run -q --bin stub_gen --features stub-gen
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "   ⚠️  stub_gen failed (exit $LASTEXITCODE); continuing — run manually in core if needed" -ForegroundColor Yellow
+        }
+
+        & $BlenderPython -m pip install -q --upgrade pip
+        & $BlenderPython -m pip install -q maturin
+
+        $coreNativeDir = Join-Path $CoreRepo "python\dcc_mcp_core"
+        Get-ChildItem -Path $coreNativeDir -Filter "_core*.pyd" -ErrorAction SilentlyContinue | ForEach-Object {
+            Write-Host "   Removing stale $($_.Name) before rebuild" -ForegroundColor Gray
+            Remove-Item $_.FullName -Force
+        }
+
+        Write-Host "   maturin develop --features $DevFeatures ..." -ForegroundColor Gray
+        & $BlenderPython -m maturin develop --features $DevFeatures
+        if ($LASTEXITCODE -ne 0) { throw "maturin develop failed" }
+
+        # Build the standalone dcc-mcp-server binary for sidecar mode
+        Write-Host "   cargo build --release -p dcc-mcp-server ..." -ForegroundColor Gray
+        & cargo build --release -p dcc-mcp-server
+        if ($LASTEXITCODE -ne 0) { throw "cargo build dcc-mcp-server failed" }
+    } finally {
+        Pop-Location
+    }
+
+    $corePkg = Join-Path $CoreRepo "python\dcc_mcp_core"
+    if (-not (Test-Path $corePkg)) {
+        Write-Error "Expected package dir missing after build: $corePkg"
+    }
+    Write-Host "   ✅ dcc_mcp_core built under $corePkg" -ForegroundColor Green
+} else {
+    Write-Host "   SkipBuild: not rebuilding core" -ForegroundColor Yellow
+}
+
+# Resolve the sidecar binary path
+$ServerBin = Join-Path $CoreRepo "target\release\dcc-mcp-server.exe"
+if (-not (Test-Path $ServerBin)) {
+    Write-Host "   ⚠️  dcc-mcp-server.exe not found at $ServerBin" -ForegroundColor Yellow
+    $ServerBin = $null
+} else {
+    Write-Host "   ✅ dcc-mcp-server binary at $ServerBin" -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "=== Blender addon link (core + blender) ===" -ForegroundColor Cyan
+
+# Blender addons directory
+$AddonsDir = Join-Path $env:APPDATA "Blender Foundation\Blender\$BlenderVersion\scripts\addons"
+$Target = Join-Path $AddonsDir "dcc_mcp_blender"
+$PkgBlender = Join-Path $BlenderRoot "src\dcc_mcp_blender"
+$PkgCore = Join-Path $CoreRepo "python\dcc_mcp_core"
+
+if (-not (Test-Path $PkgBlender)) { Write-Error "Missing $PkgBlender" }
+if (-not $SkipBuild -and -not (Test-Path $PkgCore)) { Write-Error "Missing $PkgCore — build core first (remove -SkipBuild)" }
+
+New-Item -ItemType Directory -Force -Path $AddonsDir | Out-Null
+if (Test-Path $Target) {
+    Remove-Item $Target -Recurse -Force
+    Write-Host "   Removed old $Target" -ForegroundColor Gray
+}
+
+New-Item -ItemType Directory -Force -Path $Target | Out-Null
+
+# Create symbolic links
+$linkBlender = Join-Path $Target "dcc_mcp_blender"
+$linkCore = Join-Path $Target "dcc_mcp_core"
+
+# For addons, we need to put source directly in addons/dcc_mcp_blender/
+# Actually, Blender expects the addon to be a directory containing __init__.py
+# So we link the source directory as the addon directory
+
+try {
+    # Remove if exists
+    if (Test-Path $Target) { Remove-Item $Target -Recurse -Force }
+    
+    # Create symlink for dcc_mcp_blender (the entire package)
+    New-Item -ItemType SymbolicLink -Path $Target -Target $PkgBlender -ErrorAction Stop | Out-Null
+    Write-Host "   ✅ $Target → $PkgBlender" -ForegroundColor Green
+} catch {
+    Write-Error "Symlink dcc_mcp_blender failed (enable Windows Developer Mode or run elevated): $_"
+}
+
+# For dcc_mcp_core, we need it in Blender's Python sys.path
+# Option 1: Create a .pth file in addons directory
+# Option 2: Create a symlink in the addons directory
+# Let's use option 2 for consistency
+
+$coreLinkPath = Join-Path $AddonsDir "dcc_mcp_core"
+try {
+    if (Test-Path $coreLinkPath) { Remove-Item $coreLinkPath -Recurse -Force }
+    New-Item -ItemType SymbolicLink -Path $coreLinkPath -Target $PkgCore -ErrorAction Stop | Out-Null
+    Write-Host "   ✅ $coreLinkPath → $PkgCore" -ForegroundColor Green
+} catch {
+    Write-Host "   ⚠️  Cannot symlink dcc_mcp_core, will create .pth file" -ForegroundColor Yellow
+    
+    # Create .pth file to add core to sys.path
+    $pthPath = Join-Path $AddonsDir "dcc_mcp_core.pth"
+    $PkgCore | Out-File -FilePath $pthPath -Encoding ASCII
+    Write-Host "   ✅ Created $pthPath" -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "Done. Start Blender $BlenderVersion → Edit → Preferences → Add-ons → Enable 'DCC MCP Blender'." -ForegroundColor Cyan
+Write-Host ""
+Write-Host "MCP (Streamable HTTP, default):" -ForegroundColor Cyan
+Write-Host "   http://127.0.0.1:8765/mcp"
+Write-Host "Docs: See dcc-mcp-blender docs for Cursor/Bender MCP setup" -ForegroundColor Gray
+
+if ($LaunchBlender) {
+    if (Test-Path $BlenderExe) {
+        Write-Host "Launching $BlenderExe ..." -ForegroundColor Cyan
+        Start-Process -FilePath $BlenderExe
+    } else {
+        Write-Host "   ⚠️  Blender not found at $BlenderExe" -ForegroundColor Yellow
+    }
+}

--- a/tools/blender-link-win.ps1
+++ b/tools/blender-link-win.ps1
@@ -4,7 +4,8 @@
 
 param(
     [string]$BlenderVersion = $env:BLENDER_VERSION,
-    [string]$ProjectRoot = (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    # tools/ → repository root (dcc-mcp-blender), not the monorepo parent
+    [string]$ProjectRoot = (Split-Path -Parent $PSScriptRoot)
 )
 
 # Default Blender version
@@ -46,15 +47,27 @@ if (Test-Path $Target) {
 # Source directory
 $SourceDir = Join-Path $ProjectRoot "src\dcc_mcp_blender"
 
+if (!(Test-Path -LiteralPath $SourceDir)) {
+    Write-Host "   ❌ Source not found: $SourceDir" -ForegroundColor Red
+    Write-Host "   Fix: run this script from the dcc-mcp-blender repo (or pass -ProjectRoot)." -ForegroundColor Yellow
+    exit 1
+}
+
 # Create symbolic link
 # Requires developer mode or admin privileges
 try {
-    New-Item -ItemType SymbolicLink -Path $Target -Target $SourceDir -Force | Out-Null
+    New-Item -ItemType SymbolicLink -Path $Target -Target $SourceDir -Force -ErrorAction Stop | Out-Null
     Write-Host "   ✅ Symbolic link created successfully" -ForegroundColor Green
+    Write-Host "      $Target → $SourceDir" -ForegroundColor Gray
 } catch {
     Write-Host "   ⚠️  Symbolic link failed (need admin or Developer Mode), copying instead..." -ForegroundColor Yellow
-    Copy-Item -Path $SourceDir -Destination $Target -Recurse
-    Write-Host "   ✅ Source copied (edits require manual copy)" -ForegroundColor Green
+    try {
+        Copy-Item -Path $SourceDir -Destination $Target -Recurse -Force -ErrorAction Stop
+        Write-Host "   ✅ Source copied (edits require manual copy)" -ForegroundColor Green
+    } catch {
+        Write-Host "   ❌ Copy failed: $_" -ForegroundColor Red
+        exit 1
+    }
 }
 
 Write-Host ""

--- a/tools/blender-link-win.ps1
+++ b/tools/blender-link-win.ps1
@@ -1,0 +1,62 @@
+# blender-link-win.ps1
+# Create symlinks from source tree into Blender's addons directory for live development
+# Usage: just blender-link-win  or  powershell -File tools/blender-link-win.ps1 -BlenderVersion 4.2
+
+param(
+    [string]$BlenderVersion = $env:BLENDER_VERSION,
+    [string]$ProjectRoot = (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+)
+
+# Default Blender version
+if ([string]::IsNullOrEmpty($BlenderVersion)) {
+    $BlenderVersion = "4.2"
+}
+
+# Detect Blender addons directory
+$AppData = $env:APPDATA
+$AddonsDir = Join-Path $AppData "Blender Foundation\Blender\$BlenderVersion\scripts\addons"
+$Target = Join-Path $AddonsDir "dcc_mcp_blender"
+
+Write-Host "🔗 Setting up Blender dev symlinks (Blender $BlenderVersion)..." -ForegroundColor Cyan
+Write-Host "   Project  : $ProjectRoot" -ForegroundColor Gray
+Write-Host "   Addons   : $AddonsDir" -ForegroundColor Gray
+Write-Host ""
+
+# Create addons dir if needed
+if (!(Test-Path $AddonsDir)) {
+    New-Item -ItemType Directory -Force -Path $AddonsDir | Out-Null
+    Write-Host "   Created addons directory" -ForegroundColor Yellow
+}
+
+# Remove old link/dir if exists
+if (Test-Path $Target) {
+    $targetItem = Get-Item $Target
+    if ($targetItem.LinkType) {
+        # It's a symlink, remove it
+        Remove-Item $Target -Force
+        Write-Host "   Removed old symlink" -ForegroundColor Yellow
+    } else {
+        # It's a real directory
+        Write-Host "   ⚠️  $Target is a real directory (not a symlink)." -ForegroundColor Yellow
+        Write-Host "   Remove it manually if you want to use dev symlinks." -ForegroundColor Yellow
+        exit 1
+    }
+}
+
+# Source directory
+$SourceDir = Join-Path $ProjectRoot "src\dcc_mcp_blender"
+
+# Create symbolic link
+# Requires developer mode or admin privileges
+try {
+    New-Item -ItemType SymbolicLink -Path $Target -Target $SourceDir -Force | Out-Null
+    Write-Host "   ✅ Symbolic link created successfully" -ForegroundColor Green
+} catch {
+    Write-Host "   ⚠️  Symbolic link failed (need admin or Developer Mode), copying instead..." -ForegroundColor Yellow
+    Copy-Item -Path $SourceDir -Destination $Target -Recurse
+    Write-Host "   ✅ Source copied (edits require manual copy)" -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "   Next: start Blender $BlenderVersion → Edit → Preferences → Add-ons → Enable 'DCC MCP Blender'" -ForegroundColor Cyan
+Write-Host "   Edit source → restart Blender (or press F8 to reload scripts) to see changes." -ForegroundColor Cyan

--- a/tools/blender-status-win.ps1
+++ b/tools/blender-status-win.ps1
@@ -1,0 +1,39 @@
+# blender-status-win.ps1
+# Show current Blender dev link status
+# Usage: just blender-status-win  or  powershell -File tools/blender-status-win.ps1
+
+param(
+    [string]$BlenderVersion = $env:BLENDER_VERSION
+)
+
+# Default Blender version
+if ([string]::IsNullOrEmpty($BlenderVersion)) {
+    $BlenderVersion = "4.2"
+}
+
+# Detect Blender addons directory
+$AppData = $env:APPDATA
+$AddonsDir = Join-Path $AppData "Blender Foundation\Blender\$BlenderVersion\scripts\addons"
+$Target = Join-Path $AddonsDir "dcc_mcp_blender"
+
+Write-Host "📋 Blender dev link status:" -ForegroundColor Cyan
+Write-Host "   Addons dir: $AddonsDir" -ForegroundColor Gray
+Write-Host ""
+
+if (Test-Path $Target) {
+    $targetItem = Get-Item $Target
+    if ($targetItem.LinkType) {
+        # It's a symlink
+        $linkTarget = Get-Item $Target | Select-Object -ExpandProperty Target
+        Write-Host "   ✅ dcc_mcp_blender → $linkTarget (symlink)" -ForegroundColor Green
+    } else {
+        # It's a real directory
+        Write-Host "   ⚠️  dcc_mcp_blender exists (copied, not linked)" -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "   ❌ dcc_mcp_blender not found" -ForegroundColor Red
+}
+
+Write-Host ""
+Write-Host "   To setup: just blender-link-win" -ForegroundColor Cyan
+Write-Host "   To remove: just blender-unlink-win" -ForegroundColor Cyan

--- a/tools/blender-unlink-win.ps1
+++ b/tools/blender-unlink-win.ps1
@@ -1,0 +1,37 @@
+# blender-unlink-win.ps1
+# Remove dev symlinks and addon files
+# Usage: just blender-unlink-win  or  powershell -File tools/blender-unlink-win.ps1
+
+param(
+    [string]$BlenderVersion = $env:BLENDER_VERSION
+)
+
+# Default Blender version
+if ([string]::IsNullOrEmpty($BlenderVersion)) {
+    $BlenderVersion = "4.2"
+}
+
+# Detect Blender addons directory
+$AppData = $env:APPDATA
+$AddonsDir = Join-Path $AppData "Blender Foundation\Blender\$BlenderVersion\scripts\addons"
+$Target = Join-Path $AddonsDir "dcc_mcp_blender"
+
+Write-Host "🧹 Removing Blender dev symlinks..." -ForegroundColor Cyan
+
+# Remove target directory/link
+if (Test-Path $Target) {
+    $targetItem = Get-Item $Target
+    if ($targetItem.LinkType) {
+        # It's a symlink
+        Remove-Item $Target -Force
+        Write-Host "   Removed symbolic link: $Target" -ForegroundColor Green
+    } else {
+        # It's a real directory
+        Remove-Item $Target -Recurse -Force
+        Write-Host "   Removed directory: $Target" -ForegroundColor Green
+    }
+} else {
+    Write-Host "   Target not found: $Target" -ForegroundColor Yellow
+}
+
+Write-Host "   ✅ Dev symlinks cleaned up" -ForegroundColor Green

--- a/tools/show_versions.py
+++ b/tools/show_versions.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+"""Show Python and dependency versions for dcc-mcp-blender."""
+import sys
+from importlib.metadata import version, PackageNotFoundError
+
+print("📦 Environment Information:")
+print(f"Python version: {sys.version.split()[0]}")
+print("")
+
+print("Key Packages:")
+packages = ['dcc-mcp-blender', 'dcc-mcp-core', 'pytest', 'ruff']
+for pkg in packages:
+    try:
+        print(f"  {pkg}: {version(pkg)}")
+    except PackageNotFoundError:
+        if pkg == 'dcc-mcp-blender':
+            print(f"  {pkg}: not installed (run: pip install -e .)")
+        else:
+            print(f"  {pkg}: not installed")


### PR DESCRIPTION
## Summary
- Align the Blender adapter with dcc-mcp-core 0.17.5 skill-management and server options contracts.
- Add Blender 4.2+ extension packaging with `blender_manifest.toml` and bundled platform wheels for `dcc-mcp-core`.
- Build and verify platform-specific addon ZIPs (`win64`, `linux`, `macos`) in CI, and attach release ZIPs through the release workflow.
- Update README install instructions for Blender's Extensions > Install from Disk flow.

## Validation
- `pytest -q` (157 passed, 7 skipped)
- `ruff check packaging/assemble_zip.py packaging/addon_entry src/dcc_mcp_blender tests/test_server.py tests/e2e/test_server_e2e.py`
- `ruff format --check src/ tests/ packaging/assemble_zip.py packaging/addon_entry`
- `python packaging/assemble_zip.py --platform win64 --output-dir dist_addon_test`
- `python packaging/assemble_zip.py --platform linux --output-dir dist_addon_test`
- `python packaging/assemble_zip.py --platform macos --output-dir dist_addon_test`