### PR TITLE
test: expand Blender host skill coverage

### DIFF
--- a/.github/scripts/run_blender_e2e.py
+++ b/.github/scripts/run_blender_e2e.py
@@ -1,0 +1,40 @@
+"""Run pytest E2E tests inside a real Blender background process."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    workspace = os.environ.get("GITHUB_WORKSPACE", ".")
+    dep_dir = os.environ.get("BLENDER_E2E_SITE")
+    if dep_dir and os.path.isdir(dep_dir) and dep_dir not in sys.path:
+        sys.path.insert(0, dep_dir)
+
+    if workspace not in sys.path:
+        sys.path.insert(0, workspace)
+
+    src_dir = os.path.join(workspace, "src")
+    if os.path.isdir(src_dir) and src_dir not in sys.path:
+        sys.path.insert(0, src_dir)
+
+    import pytest
+
+    exit_code = pytest.main(
+        [
+            os.path.join(workspace, "tests", "e2e"),
+            "-v",
+            "--tb=short",
+            "-m",
+            "e2e",
+            "--override-ini=addopts=",
+        ]
+    )
+    return 0 if exit_code == 5 else exit_code
+
+
+if __name__ == "__main__":
+    # Bypass Blender C++ cleanup in Linux background mode; sys.exit() can
+    # otherwise try to destroy uninitialized X11/OpenGL resources.
+    os._exit(main())

--- a/.github/scripts/run_docker_blender_e2e.sh
+++ b/.github/scripts/run_docker_blender_e2e.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace="${GITHUB_WORKSPACE:-/workspace}"
+temp_dir="${RUNNER_TEMP:-/tmp}"
+
+BLENDER_BIN=$(command -v blender || find /usr /opt /app -type f -name blender 2>/dev/null | head -1)
+if [ -z "${BLENDER_BIN:-}" ]; then
+  echo "Unable to locate blender in image"
+  exit 1
+fi
+
+BLENDER_PYTHON=$(find /usr /opt /app -path "*/python/bin/python3*" -type f 2>/dev/null | head -1)
+if [ -z "${BLENDER_PYTHON:-}" ]; then
+  BLENDER_PYTHON=$(command -v python3 || true)
+fi
+if [ -z "${BLENDER_PYTHON:-}" ]; then
+  echo "Unable to locate Python in image"
+  exit 1
+fi
+
+"$BLENDER_BIN" --version
+"$BLENDER_PYTHON" --version
+
+PYTHON_INSTALLER="$BLENDER_PYTHON"
+if ! "$PYTHON_INSTALLER" -m pip --version >/dev/null 2>&1; then
+  "$PYTHON_INSTALLER" -m ensurepip --upgrade || true
+fi
+if ! "$PYTHON_INSTALLER" -m pip --version >/dev/null 2>&1; then
+  get_pip="$temp_dir/get-pip.py"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL https://bootstrap.pypa.io/get-pip.py -o "$get_pip"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q https://bootstrap.pypa.io/get-pip.py -O "$get_pip"
+  fi
+  if [ -f "$get_pip" ]; then
+    "$PYTHON_INSTALLER" "$get_pip" --break-system-packages || "$PYTHON_INSTALLER" "$get_pip" || true
+  fi
+fi
+if ! "$PYTHON_INSTALLER" -m pip --version >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1; then
+    rm -f /etc/apt/sources.list.d/*nodesource*
+    apt-get update
+    apt-get install -y python3-pip
+    PYTHON_INSTALLER=$(command -v python3)
+  else
+    echo "Unable to install pip in image"
+    exit 1
+  fi
+fi
+
+dep_dir="$temp_dir/blender-e2e-site"
+mkdir -p "$dep_dir"
+PIP_BREAK_SYSTEM_PACKAGES=1 "$PYTHON_INSTALLER" -m pip install --upgrade --target "$dep_dir" "$workspace[dev]"
+PYTHONPATH="$dep_dir:$workspace/src" "$PYTHON_INSTALLER" -c "from dcc_mcp_core import _core; print('dcc-mcp-core _core loaded OK')"
+
+export BLENDER_E2E_SITE="$dep_dir"
+"$BLENDER_BIN" --background --python "$workspace/.github/scripts/run_blender_e2e.py"

--- a/.github/scripts/start_mcp_server.py
+++ b/.github/scripts/start_mcp_server.py
@@ -1,0 +1,48 @@
+"""Start a Blender-backed MCP server for CI connectivity checks."""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+try:
+    import bpy  # noqa: F401
+except ImportError:
+    print("WARNING: bpy not available, skipping MCP server test")
+    sys.exit(0)
+
+import dcc_mcp_blender
+from dcc_mcp_blender.host import BlenderCallableDispatcher, BlenderHost
+
+
+def main() -> None:
+    dispatcher = BlenderCallableDispatcher()
+    host = BlenderHost(dispatcher)
+    server = dcc_mcp_blender.start_server(port=8765, dispatcher=dispatcher)
+    host.start()
+    print(f"MCP server started at {server.mcp_url}", flush=True)
+
+    for skill in server.list_skills():
+        name = skill.get("name", "")
+        if name and not server.is_skill_loaded(name):
+            try:
+                server.load_skill(name)
+            except Exception as exc:
+                print(f"WARNING: failed to load skill {name}: {exc}", flush=True)
+
+    print(f"Loaded skills: {server.loaded_skill_count()}", flush=True)
+    print(f"All skills: {[s.get('name', '?') for s in server.list_skills()]}", flush=True)
+
+    sentinel = os.path.join(os.environ.get("RUNNER_TEMP", "/tmp"), "mcp_test_done")
+    try:
+        while not os.path.exists(sentinel):
+            time.sleep(1)
+    finally:
+        host.stop()
+        dcc_mcp_blender.stop_server()
+        print("MCP server stopped.", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/start_mcp_server2.py
+++ b/.github/scripts/start_mcp_server2.py
@@ -1,0 +1,39 @@
+"""Start a second Blender-backed MCP server on a random port for CI."""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+try:
+    import bpy  # noqa: F401
+except ImportError:
+    sys.exit(0)
+
+import dcc_mcp_blender
+from dcc_mcp_blender.host import BlenderCallableDispatcher, BlenderHost
+
+
+def main() -> None:
+    dispatcher = BlenderCallableDispatcher()
+    host = BlenderHost(dispatcher)
+    server = dcc_mcp_blender.start_server(port=0, dispatcher=dispatcher)
+    host.start()
+    print(f"Second instance MCP URL: {server.mcp_url}", flush=True)
+
+    url_path = os.path.join(os.environ.get("RUNNER_TEMP", "/tmp"), "mcp_server2_url")
+    with open(url_path, "w", encoding="utf-8") as handle:
+        handle.write(server.mcp_url)
+
+    sentinel = os.path.join(os.environ.get("RUNNER_TEMP", "/tmp"), "mcp_test2_done")
+    try:
+        while not os.path.exists(sentinel):
+            time.sleep(1)
+    finally:
+        host.stop()
+        dcc_mcp_blender.stop_server()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install skill validation dependencies
-        run: pip install pyyaml "dcc-mcp-core>=0.17.5,<1.0.0"
+        run: pip install pyyaml "dcc-mcp-core>=0.17.6,<1.0.0"
       - name: Validate SKILL.md front-matter
         run: python tests/test_lint_skills.py
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -410,11 +410,13 @@ jobs:
             --allow-http
 
           call_tool() {
+            set +e
             output=$(npx mcporter call \
               --http-url http://127.0.0.1:8765/mcp \
               --allow-http \
               "$@" 2>&1)
             status=$?
+            set -e
             printf '%s\n' "$output"
             if [ "$status" -ne 0 ]; then
               return "$status"
@@ -461,9 +463,11 @@ jobs:
           call_tool export_obj \
             path:"$GEOM_OBJ"
 
+          export GEOM_BLEND GEOM_FBX GEOM_OBJ
           "$BLENDER_PYTHON" -c "
           import os
-          for path in ('$GEOM_BLEND', '$GEOM_FBX', '$GEOM_OBJ'):
+          for key in ('GEOM_BLEND', 'GEOM_FBX', 'GEOM_OBJ'):
+              path = os.environ[key]
               assert os.path.isfile(path), path
               assert os.path.getsize(path) > 0, path
           print('Geometry export files: OK')

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,14 +77,14 @@ jobs:
         include:
           # ── Windows ────────────────────────────────────────────────────────
           - os: windows
-            runner: windows-latest
+            runner: windows-2025-vs2026
             blender-version: "4.4.3"
             blender-python: "3.11"
             blender-url: "https://download.blender.org/release/Blender4.4/blender-4.4.3-windows-x64.zip"
             blender-dir: "blender-4.4.3-windows-x64"
 
           - os: windows
-            runner: windows-latest
+            runner: windows-2025-vs2026
             blender-version: "4.2.0"
             blender-python: "3.11"
             blender-url: "https://download.blender.org/release/Blender4.2/blender-4.2.0-windows-x64.zip"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -334,6 +334,8 @@ jobs:
           import sys
           import time
 
+          from dcc_mcp_core.host import BlockingDispatcher
+
           try:
               import bpy  # noqa: F401
           except ImportError:
@@ -341,11 +343,15 @@ jobs:
               sys.exit(0)
 
           import dcc_mcp_blender
+          from dcc_mcp_blender.host import BlenderHost
 
           # Start server — create_skill_manager discovers all skills automatically.
           # Then eagerly load all skills so their tools are registered for
           # mcporter to call (progressive loading only registers metadata).
-          server = dcc_mcp_blender.start_server(port=8765)
+          dispatcher = BlockingDispatcher()
+          host = BlenderHost(dispatcher)
+          server = dcc_mcp_blender.start_server(port=8765, dispatcher=dispatcher)
+          host.start()
           print(f"MCP server started at {server.mcp_url}", flush=True)
           for skill in server.list_skills():
               name = skill.get("name", "")
@@ -361,6 +367,7 @@ jobs:
           while not os.path.exists(sentinel):
               time.sleep(1)
 
+          host.stop()
           dcc_mcp_blender.stop_server()
           print("MCP server stopped.", flush=True)
           PYEOF
@@ -488,9 +495,14 @@ jobs:
               import bpy  # noqa: F401
           except ImportError:
               sys.exit(0)
+          from dcc_mcp_core.host import BlockingDispatcher
           import dcc_mcp_blender
+          from dcc_mcp_blender.host import BlenderHost
           # Use port=0 → OS assigns a free port; simulates a second Blender instance
-          server = dcc_mcp_blender.start_server(port=0)
+          dispatcher = BlockingDispatcher()
+          host = BlenderHost(dispatcher)
+          server = dcc_mcp_blender.start_server(port=0, dispatcher=dispatcher)
+          host.start()
           url = server.mcp_url
           print(f"Second instance MCP URL: {url}", flush=True)
           with open(os.path.join(os.environ.get("RUNNER_TEMP", "/tmp"), "mcp_server2_url"), "w") as f:
@@ -498,6 +510,7 @@ jobs:
           sentinel2 = os.path.join(os.environ.get("RUNNER_TEMP", "/tmp"), "mcp_test2_done")
           while not os.path.exists(sentinel2):
               time.sleep(1)
+          host.stop()
           dcc_mcp_blender.stop_server()
           PYEOF2
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,11 +1,12 @@
 name: E2E (Blender)
 
 # End-to-end tests that run inside a real Blender interpreter in background mode.
-# Downloads Blender directly from the official mirror and uses its bundled Python.
+# Linux also runs against containerized Blender images; Windows and macOS
+# download Blender directly from the official mirror and use its bundled Python.
 #
 # Key design decisions:
-#   - Unit tests run with the SYSTEM Python (mock-based, no Blender needed)
 #   - E2E tests run INSIDE Blender's Python via `blender --background --python`
+#   - Unit tests stay in ci.yml so this workflow focuses on real Blender coverage
 #   - dcc-mcp-core's native _core module needs MSVC runtime on Windows;
 #     we copy the system's vcruntime140.dll into Blender's Python directory
 #
@@ -16,13 +17,14 @@ name: E2E (Blender)
 #   Blender 3.6.x  -> Python 3.10  (LTS)
 #
 # Test matrix (to keep CI cost reasonable):
-#   Linux   : 3.6.0 (LTS), 4.2.0 (LTS), 4.3.2, 4.4.3 (latest)
+#   Linux   : 3.6.5 (LTS), 4.2.0 (LTS), 4.3.2, 4.4.3 (latest), Docker images
 #   Windows : 4.2.0 (LTS), 4.4.3 (latest)
 #   macOS   : 4.2.0 (LTS), 4.4.3 (latest, arm64)
 #
 # References:
 #   https://download.blender.org/release/
 #   https://docs.blender.org/manual/en/latest/advanced/command_line/arguments.html
+#   https://hub.docker.com/r/linuxserver/blender
 
 on:
   push:
@@ -32,6 +34,39 @@ on:
   workflow_dispatch:
 
 jobs:
+  e2e-linux-docker:
+    name: E2E Blender ${{ matrix.blender-version }} (linux docker)
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - blender-version: "4.4.3"
+            blender-image: "linuxserver/blender:4.4.3"
+          - blender-version: "4.3.2"
+            blender-image: "linuxserver/blender:4.3.2"
+          - blender-version: "4.2.0"
+            blender-image: "linuxserver/blender:4.2.0"
+          - blender-version: "3.6.5"
+            blender-image: "linuxserver/blender:3.6.5"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run E2E tests in Blender Docker image
+        shell: bash
+        run: |
+          docker run --rm \
+            --entrypoint /bin/bash \
+            --user root \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -w /workspace \
+            -e GITHUB_WORKSPACE=/workspace \
+            -e RUNNER_TEMP=/tmp \
+            "${{ matrix.blender-image }}" \
+            .github/scripts/run_docker_blender_e2e.sh
+
   e2e:
     name: E2E Blender ${{ matrix.blender-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.runner }}
@@ -40,35 +75,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # ── Linux ──────────────────────────────────────────────────────────
-          - os: linux
-            runner: ubuntu-latest
-            blender-version: "4.4.3"
-            blender-python: "3.11"
-            blender-url: "https://download.blender.org/release/Blender4.4/blender-4.4.3-linux-x64.tar.xz"
-            blender-dir: "blender-4.4.3-linux-x64"
-
-          - os: linux
-            runner: ubuntu-latest
-            blender-version: "4.3.2"
-            blender-python: "3.11"
-            blender-url: "https://download.blender.org/release/Blender4.3/blender-4.3.2-linux-x64.tar.xz"
-            blender-dir: "blender-4.3.2-linux-x64"
-
-          - os: linux
-            runner: ubuntu-latest
-            blender-version: "4.2.0"
-            blender-python: "3.11"
-            blender-url: "https://download.blender.org/release/Blender4.2/blender-4.2.0-linux-x64.tar.xz"
-            blender-dir: "blender-4.2.0-linux-x64"
-
-          - os: linux
-            runner: ubuntu-latest
-            blender-version: "3.6.0"
-            blender-python: "3.10"
-            blender-url: "https://download.blender.org/release/Blender3.6/blender-3.6.0-linux-x64.tar.xz"
-            blender-dir: "blender-3.6.0-linux-x64"
-
           # ── Windows ────────────────────────────────────────────────────────
           - os: windows
             runner: windows-latest
@@ -104,20 +110,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # ── Setup system Python for unit tests ─────────────────────────────────
-      - name: Setup Python
+      - name: Setup Python for Windows runtime DLLs
+        if: matrix.os == 'windows'
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-
-      - name: Install package (system Python)
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e ".[dev]"
-
-      - name: Run unit tests (system Python)
-        run: |
-          python -m pytest tests/ -v --tb=short -m "not e2e and not packaging"
 
       # ── Cache Blender download ─────────────────────────────────────────────
       - name: Cache Blender
@@ -126,36 +123,6 @@ jobs:
         with:
           path: blender-cache
           key: blender-${{ matrix.blender-version }}-${{ matrix.os }}
-
-      # ── Linux: download + extract ─────────────────────────────────────────
-      - name: Download Blender (Linux)
-        if: matrix.os == 'linux' && steps.cache-blender.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p blender-cache
-          curl -L "${{ matrix.blender-url }}" -o blender-cache/blender.tar.xz
-          tar -xJf blender-cache/blender.tar.xz -C blender-cache/
-
-      - name: Install Linux dependencies for Blender
-        if: matrix.os == 'linux'
-        run: |
-          sudo apt-get update
-          # libasound2t64 is the Ubuntu 24.04 package name; fall back to libasound2 on 22.04
-          if apt-cache show libasound2t64 >/dev/null 2>&1; then
-            sudo apt-get install -y libxrender1 libxxf86vm1 libxi6 libgl1 libasound2t64
-          else
-            sudo apt-get install -y libxrender1 libxxf86vm1 libxi6 libgl1 libasound2
-          fi
-
-      - name: Set Blender Python path (Linux)
-        if: matrix.os == 'linux'
-        run: |
-          BLENDER_PYTHON=$(ls blender-cache/${{ matrix.blender-dir }}/${{ matrix.blender-version }}/python/bin/python3* 2>/dev/null | head -1)
-          if [ -z "$BLENDER_PYTHON" ]; then
-            BLENDER_PYTHON=$(find blender-cache/${{ matrix.blender-dir }} -name "python3*" -type f | head -1)
-          fi
-          echo "BLENDER_PYTHON=$BLENDER_PYTHON" >> $GITHUB_ENV
-          echo "BLENDER_BIN=blender-cache/${{ matrix.blender-dir }}/blender" >> $GITHUB_ENV
-          echo "Using Blender Python: $BLENDER_PYTHON"
 
       # ── Windows: download + extract ───────────────────────────────────────
       - name: Download Blender (Windows)
@@ -282,39 +249,7 @@ jobs:
       - name: Run E2E tests (Blender background mode)
         shell: bash
         run: |
-          # Write a bootstrap script that runs pytest directly inside the Blender process.
-          # We call pytest.main() directly instead of using subprocess so that bpy remains
-          # available to the test code.
-          cat > /tmp/run_e2e.py << 'PYEOF'
-          import os
-          import sys
-
-          # Ensure the workspace is on sys.path so tests and source can be found
-          workspace = os.environ.get("GITHUB_WORKSPACE", ".")
-          if workspace not in sys.path:
-              sys.path.insert(0, workspace)
-          # Also add the src directory for editable install resolution
-          src_dir = os.path.join(workspace, "src")
-          if os.path.isdir(src_dir) and src_dir not in sys.path:
-              sys.path.insert(0, src_dir)
-
-          import pytest
-          exit_code = pytest.main([
-              os.path.join(workspace, "tests", "e2e"),
-              "-v",
-              "--tb=short",
-              "-m", "e2e",
-              "--override-ini=addopts=",
-          ])
-          # Exit code 5 means no tests collected (all skipped); treat as success.
-          # Use os._exit() instead of sys.exit(): calling sys.exit() inside Blender's
-          # background process on Linux triggers Blender's C++ cleanup which tries to
-          # destroy X11/OpenGL resources that were never initialised, causing SIGABRT.
-          # os._exit() bypasses all destructors and exits immediately and safely.
-          os._exit(0 if exit_code == 5 else exit_code)
-          PYEOF
-
-          "$BLENDER_BIN" --background --python /tmp/run_e2e.py
+          "$BLENDER_BIN" --background --python "$GITHUB_WORKSPACE/.github/scripts/run_blender_e2e.py"
 
       # ── MCP connectivity test ─────────────────────────────────────────────
       - name: Setup Node.js for mcporter
@@ -325,53 +260,8 @@ jobs:
       - name: Test MCP connectivity and progressive loading
         shell: bash
         run: |
-          # Bootstrap: start MCP server with progressive loading inside Blender.
-          # The server discovers skill metadata immediately but only imports skill
-          # scripts when they are first called (lazy/deferred loading).
-          # Stays alive until the sentinel file signals completion.
-          cat > /tmp/start_mcp_server.py << 'PYEOF'
-          import os
-          import sys
-          import time
-
-          try:
-              import bpy  # noqa: F401
-          except ImportError:
-              print("WARNING: bpy not available, skipping MCP server test")
-              sys.exit(0)
-
-          import dcc_mcp_blender
-          from dcc_mcp_blender.host import BlenderCallableDispatcher, BlenderHost
-
-          # Start server — create_skill_manager discovers all skills automatically.
-          # Then eagerly load all skills so their tools are registered for
-          # mcporter to call (progressive loading only registers metadata).
-          dispatcher = BlenderCallableDispatcher()
-          host = BlenderHost(dispatcher)
-          server = dcc_mcp_blender.start_server(port=8765, dispatcher=dispatcher)
-          host.start()
-          print(f"MCP server started at {server.mcp_url}", flush=True)
-          for skill in server.list_skills():
-              name = skill.get("name", "")
-              if name and not server.is_skill_loaded(name):
-                  try:
-                      server.load_skill(name)
-                  except Exception as exc:
-                      print(f"WARNING: failed to load skill {name}: {exc}", flush=True)
-          print(f"Loaded skills: {server.loaded_skill_count()}", flush=True)
-          print(f"All skills: {[s.get('name', '?') for s in server.list_skills()]}", flush=True)
-
-          sentinel = os.path.join(os.environ.get("RUNNER_TEMP", "/tmp"), "mcp_test_done")
-          while not os.path.exists(sentinel):
-              time.sleep(1)
-
-          host.stop()
-          dcc_mcp_blender.stop_server()
-          print("MCP server stopped.", flush=True)
-          PYEOF
-
           # Start Blender MCP server in background
-          "$BLENDER_BIN" --background --python /tmp/start_mcp_server.py &
+          "$BLENDER_BIN" --background --python "$GITHUB_WORKSPACE/.github/scripts/start_mcp_server.py" &
           SERVER_PID=$!
           echo "Server PID: $SERVER_PID"
 
@@ -491,31 +381,7 @@ jobs:
 
           # ── 9. Multi-instance gateway — start a second instance on a random ─
           #       port and verify it can be reached independently.            ──
-          cat > /tmp/start_mcp_server2.py << 'PYEOF2'
-          import os, sys, time
-          try:
-              import bpy  # noqa: F401
-          except ImportError:
-              sys.exit(0)
-          import dcc_mcp_blender
-          from dcc_mcp_blender.host import BlenderCallableDispatcher, BlenderHost
-          # Use port=0 → OS assigns a free port; simulates a second Blender instance
-          dispatcher = BlenderCallableDispatcher()
-          host = BlenderHost(dispatcher)
-          server = dcc_mcp_blender.start_server(port=0, dispatcher=dispatcher)
-          host.start()
-          url = server.mcp_url
-          print(f"Second instance MCP URL: {url}", flush=True)
-          with open(os.path.join(os.environ.get("RUNNER_TEMP", "/tmp"), "mcp_server2_url"), "w") as f:
-              f.write(url)
-          sentinel2 = os.path.join(os.environ.get("RUNNER_TEMP", "/tmp"), "mcp_test2_done")
-          while not os.path.exists(sentinel2):
-              time.sleep(1)
-          host.stop()
-          dcc_mcp_blender.stop_server()
-          PYEOF2
-
-          "$BLENDER_BIN" --background --python /tmp/start_mcp_server2.py &
+          "$BLENDER_BIN" --background --python "$GITHUB_WORKSPACE/.github/scripts/start_mcp_server2.py" &
           SERVER2_PID=$!
           sleep 10
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -445,6 +445,43 @@ jobs:
             blender-ci.blender_objects__get_object_info \
             name:mcporterCube
 
+          # ── 4b. Geometry export smoke test ────────────────────────────────
+          GEOM_BLEND="$RUNNER_TEMP/mcporter_geometry.blend"
+          GEOM_FBX="$RUNNER_TEMP/mcporter_geometry.fbx"
+          GEOM_OBJ="$RUNNER_TEMP/mcporter_geometry.obj"
+
+          npx mcporter call \
+            --http-url http://127.0.0.1:8765/mcp \
+            --allow-http \
+            blender-ci.blender_geometry__create_sphere \
+            radius:1.25 name:mcporterGeometrySphere "location:[0.0, 0.0, 0.0]"
+
+          npx mcporter call \
+            --http-url http://127.0.0.1:8765/mcp \
+            --allow-http \
+            blender-ci.blender_geometry__save_blend \
+            path:"$GEOM_BLEND"
+
+          npx mcporter call \
+            --http-url http://127.0.0.1:8765/mcp \
+            --allow-http \
+            blender-ci.blender_geometry__export_fbx \
+            path:"$GEOM_FBX"
+
+          npx mcporter call \
+            --http-url http://127.0.0.1:8765/mcp \
+            --allow-http \
+            blender-ci.blender_geometry__export_obj \
+            path:"$GEOM_OBJ"
+
+          "$BLENDER_PYTHON" -c "
+          import os
+          for path in ('$GEOM_BLEND', '$GEOM_FBX', '$GEOM_OBJ'):
+              assert os.path.isfile(path), path
+              assert os.path.getsize(path) > 0, path
+          print('Geometry export files: OK')
+          "
+
           # ── 5. Mesh operations ──────────────────────────────────────────────
           npx mcporter call \
             --http-url http://127.0.0.1:8765/mcp \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -483,7 +483,7 @@ jobs:
 
           # ── 8. Python scripting (execute arbitrary Blender Python) ──────────
           call_tool execute_python \
-            "code:import bpy; bpy.ops.mesh.primitive_cone_add(); result = bpy.context.active_object.name"
+            "code:import bpy; bpy.ops.mesh.primitive_cone_add()"
 
           # ── 9. Multi-instance gateway — start a second instance on a random ─
           #       port and verify it can be reached independently.            ──

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -334,8 +334,6 @@ jobs:
           import sys
           import time
 
-          from dcc_mcp_core.host import BlockingDispatcher
-
           try:
               import bpy  # noqa: F401
           except ImportError:
@@ -343,12 +341,12 @@ jobs:
               sys.exit(0)
 
           import dcc_mcp_blender
-          from dcc_mcp_blender.host import BlenderHost
+          from dcc_mcp_blender.host import BlenderCallableDispatcher, BlenderHost
 
           # Start server — create_skill_manager discovers all skills automatically.
           # Then eagerly load all skills so their tools are registered for
           # mcporter to call (progressive loading only registers metadata).
-          dispatcher = BlockingDispatcher()
+          dispatcher = BlenderCallableDispatcher()
           host = BlenderHost(dispatcher)
           server = dcc_mcp_blender.start_server(port=8765, dispatcher=dispatcher)
           host.start()
@@ -495,11 +493,10 @@ jobs:
               import bpy  # noqa: F401
           except ImportError:
               sys.exit(0)
-          from dcc_mcp_core.host import BlockingDispatcher
           import dcc_mcp_blender
-          from dcc_mcp_blender.host import BlenderHost
+          from dcc_mcp_blender.host import BlenderCallableDispatcher, BlenderHost
           # Use port=0 → OS assigns a free port; simulates a second Blender instance
-          dispatcher = BlockingDispatcher()
+          dispatcher = BlenderCallableDispatcher()
           host = BlenderHost(dispatcher)
           server = dcc_mcp_blender.start_server(port=0, dispatcher=dispatcher)
           host.start()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -404,45 +404,39 @@ jobs:
             --name blender-ci \
             --allow-http
 
+          call_tool() {
+            output=$(npx mcporter call \
+              --http-url http://127.0.0.1:8765/mcp \
+              --allow-http \
+              "$@" 2>&1)
+            status=$?
+            printf '%s\n' "$output"
+            if [ "$status" -ne 0 ]; then
+              return "$status"
+            fi
+            if printf '%s\n' "$output" | grep -E '"code": "ACTION_NOT_FOUND"|Unknown tool|Traceback \(most recent call last\)'; then
+              return 1
+            fi
+          }
+
           # ── 3. Core scene skills ────────────────────────────────────────────
-          npx mcporter call \
-            --http-url http://127.0.0.1:8765/mcp \
-            --allow-http \
-            blender-ci.blender_scene__get_session_info
+          call_tool get_session_info
 
-          npx mcporter call \
-            --http-url http://127.0.0.1:8765/mcp \
-            --allow-http \
-            blender-ci.blender_scene__list_objects
+          call_tool list_objects
 
-          npx mcporter call \
-            --http-url http://127.0.0.1:8765/mcp \
-            --allow-http \
-            blender-ci.blender_scene__get_scene_info
+          call_tool get_scene_info
 
           # ── 4. Object creation and manipulation ─────────────────────────────
-          npx mcporter call \
-            --http-url http://127.0.0.1:8765/mcp \
-            --allow-http \
-            blender-ci.blender_objects__create_object \
+          call_tool create_object \
             object_type:cube name:mcporterCube
 
-          npx mcporter call \
-            --http-url http://127.0.0.1:8765/mcp \
-            --allow-http \
-            blender-ci.blender_objects__create_object \
+          call_tool create_object \
             object_type:sphere name:mcporterSphere
 
-          npx mcporter call \
-            --http-url http://127.0.0.1:8765/mcp \
-            --allow-http \
-            blender-ci.blender_objects__move_object \
+          call_tool move_object \
             name:mcporterCube "location:[1.0, 2.0, 3.0]"
 
-          npx mcporter call \
-            --http-url http://127.0.0.1:8765/mcp \
-            --allow-http \
-            blender-ci.blender_objects__get_object_info \
+          call_tool get_object_info \
             name:mcporterCube
 
           # ── 4b. Geometry export smoke test ────────────────────────────────
@@ -450,28 +444,16 @@ jobs:
           GEOM_FBX="$RUNNER_TEMP/mcporter_geometry.fbx"
           GEOM_OBJ="$RUNNER_TEMP/mcporter_geometry.obj"
 
-          npx mcporter call \
-            --http-url http://127.0.0.1:8765/mcp \
-            --allow-http \
-            blender-ci.blender_geometry__create_sphere \
+          call_tool create_sphere \
             radius:1.25 name:mcporterGeometrySphere "location:[0.0, 0.0, 0.0]"
 
-          npx mcporter call \
-            --http-url http://127.0.0.1:8765/mcp \
-            --allow-http \
-            blender-ci.blender_geometry__save_blend \
+          call_tool save_blend \
             path:"$GEOM_BLEND"
 
-          npx mcporter call \
-            --http-url http://127.0.0.1:8765/mcp \
-            --allow-http \
-            blender-ci.blender_geometry__export_fbx \
+          call_tool export_fbx \
             path:"$GEOM_FBX"
 
-          npx mcporter call \
-            --http-url http://127.0.0.1:8765/mcp \
-            --allow-http \
-            blender-ci.blender_geometry__export_obj \
+          call_tool export_obj \
             path:"$GEOM_OBJ"
 
           "$BLENDER_PYTHON" -c "
@@ -483,31 +465,19 @@ jobs:
           "
 
           # ── 5. Mesh operations ──────────────────────────────────────────────
-          npx mcporter call \
-            --http-url http://127.0.0.1:8765/mcp \
-            --allow-http \
-            blender-ci.blender_mesh__add_modifier \
+          call_tool add_modifier \
             object_name:mcporterCube modifier_type:SUBSURF
 
           # ── 6. Lighting ─────────────────────────────────────────────────────
-          npx mcporter call \
-            --http-url http://127.0.0.1:8765/mcp \
-            --allow-http \
-            blender-ci.blender_lighting__add_light \
+          call_tool create_light \
             light_type:POINT name:mcporterLight "location:[0.0, 0.0, 5.0]"
 
           # ── 7. Materials ────────────────────────────────────────────────────
-          npx mcporter call \
-            --http-url http://127.0.0.1:8765/mcp \
-            --allow-http \
-            blender-ci.blender_materials__create_material \
+          call_tool create_material \
             name:mcporterMat
 
           # ── 8. Python scripting (execute arbitrary Blender Python) ──────────
-          npx mcporter call \
-            --http-url http://127.0.0.1:8765/mcp \
-            --allow-http \
-            blender-ci.blender_scripting__execute_python \
+          call_tool execute_python \
             "code:import bpy; bpy.ops.mesh.primitive_cone_add(); result = bpy.context.active_object.name"
 
           # ── 9. Multi-instance gateway — start a second instance on a random ─

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag name for manual addon ZIP build (for example v0.1.2). Leave empty to only run release-please."
+        required: false
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,7 +29,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      tag_name: ${{ steps.release.outputs.tag_name || inputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
       - uses: googleapis/release-please-action@v5
@@ -39,9 +44,11 @@ jobs:
     name: Build wheel
     runs-on: ubuntu-latest
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '')
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag_name || github.ref }}
 
       - uses: actions/setup-python@v6
         with:
@@ -88,7 +95,7 @@ jobs:
     name: Build Blender Addon ZIP (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '')
     strategy:
       fail-fast: false
       matrix:
@@ -105,6 +112,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag_name || github.ref }}
 
       - uses: actions/setup-python@v6
         with:
@@ -150,28 +159,19 @@ jobs:
     name: Attach addon ZIPs to GitHub Release
     runs-on: ubuntu-latest
     needs: [release-please, build-addon-zip]
-    if: needs.release-please.outputs.release_created == 'true'
+    if: needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '')
+    permissions:
+      contents: write
     steps:
-      - name: Download win64 addon
+      - name: Download addon ZIP artifacts
         uses: actions/download-artifact@v8
         with:
-          name: addon-zip-win64
           path: dist_addon/
-
-      - name: Download linux addon
-        uses: actions/download-artifact@v8
-        with:
-          name: addon-zip-linux
-          path: dist_addon/
-
-      - name: Download macos addon
-        uses: actions/download-artifact@v8
-        with:
-          name: addon-zip-macos
-          path: dist_addon/
+          pattern: addon-zip-*
+          merge-multiple: true
 
       - name: Attach addon ZIPs to release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ needs.release-please.outputs.tag_name }}
+          tag_name: ${{ needs.release-please.outputs.tag_name || inputs.tag_name }}
           files: dist_addon/*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ venv.bak/
 # Testing
 .tox/
 .nox/
+.benchmarks/
 .coverage
 .coverage.*
 .cache
@@ -46,6 +47,20 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 htmlcov/
+mcporter_geometry.blend
+mcporter_geometry.fbx
+mcporter_geometry.obj
+mcp_server2_url
+mcp_test_done
+mcp_test2_done
+
+# CI / local workflow artifacts
+blender-cache/
+run_e2e.py
+start_mcp_server.py
+start_mcp_server2.py
+get-pip.py
+blender-e2e-site/
 
 # IDE
 .idea/

--- a/README.md
+++ b/README.md
@@ -3,9 +3,19 @@
 > Blender addon for the [DCC Model Context Protocol (MCP)](https://github.com/loonghao/dcc-mcp-core) ecosystem — embeds a Streamable HTTP MCP server directly inside Blender, letting any MCP-compatible AI client drive your 3D workflow.
 
 [![PyPI version](https://badge.fury.io/py/dcc-mcp-blender.svg)](https://badge.fury.io/py/dcc-mcp-blender)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dcc-mcp-blender.svg)](https://pypi.org/project/dcc-mcp-blender/)
+[![PyPI - Wheel](https://img.shields.io/pypi/wheel/dcc-mcp-blender.svg)](https://pypi.org/project/dcc-mcp-blender/#files)
 [![CI](https://github.com/loonghao/dcc-mcp-blender/actions/workflows/ci.yml/badge.svg)](https://github.com/loonghao/dcc-mcp-blender/actions/workflows/ci.yml)
+[![E2E Blender](https://github.com/loonghao/dcc-mcp-blender/actions/workflows/e2e.yml/badge.svg)](https://github.com/loonghao/dcc-mcp-blender/actions/workflows/e2e.yml)
+[![Release](https://github.com/loonghao/dcc-mcp-blender/actions/workflows/release.yml/badge.svg)](https://github.com/loonghao/dcc-mcp-blender/actions/workflows/release.yml)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/dcc-mcp-blender.svg?label=PyPI%20downloads)](https://pypi.org/project/dcc-mcp-blender/)
+[![GitHub release downloads](https://img.shields.io/github/downloads/loonghao/dcc-mcp-blender/total.svg?label=release%20downloads)](https://github.com/loonghao/dcc-mcp-blender/releases)
+[![GitHub Release](https://img.shields.io/github/v/release/loonghao/dcc-mcp-blender.svg)](https://github.com/loonghao/dcc-mcp-blender/releases)
+[![Coverage](https://img.shields.io/badge/coverage-pytest--cov-blue.svg)](https://github.com/loonghao/dcc-mcp-blender/blob/main/pyproject.toml)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.6-blue.svg)](https://github.com/loonghao/dcc-mcp-core)
+[![Blender](https://img.shields.io/badge/Blender-3.6%20LTS%20%7C%204.2%20LTS%20%7C%204.3%20%7C%204.4-orange.svg)](https://www.blender.org/download/releases/)
+[![MCP](https://img.shields.io/badge/MCP-2025--03--26-purple.svg)](https://modelcontextprotocol.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 - **Embedded MCP server** — no external gateway needed; the server runs inside Blender's Python interpreter
 - **50+ pre-built skills** — scene management, object manipulation, materials, rendering, scripting and more
 - **Extensible skill system** — drop new skill folders alongside built-ins or point to them via env vars
+- **Main-thread host adapter** — `BlenderHost` drives dispatcher ticks through `bpy.app.timers` or a background loop
 - **Streamable HTTP transport** — compatible with any MCP 2025-03-26 client
 - **Claude Desktop ready** — ship a one-line `mcpServers` config and you're done
 
@@ -60,6 +61,7 @@
 | **blender-lighting** | `create_light`, `delete_light`, `set_light_properties`, `list_lights` |
 | **blender-camera** | `create_camera`, `set_active_camera`, `set_camera_properties`, `list_cameras` |
 | **blender-collection** | `create_collection`, `link_to_collection`, `unlink_from_collection`, `list_collections` |
+| **blender-geometry** | `create_sphere`, `save_blend`, `file_exists`, `export_fbx`, `export_obj` |
 
 ---
 
@@ -76,6 +78,8 @@
 
 Release ZIPs include `blender_manifest.toml` and the matching `dcc-mcp-core` wheel under `wheels/`, so Blender installs the Python dependency into the extension's isolated environment.
 
+The addon ZIP is assembled by `packaging/assemble_zip.py`. It resolves the latest compatible `dcc-mcp-core` wheel, places it under `wheels/`, and injects that wheel into `blender_manifest.toml`; Blender 4.2+ then installs it through the extension wheel mechanism instead of relying on global `pip` packages or `sys.path` edits.
+
 ### Option 2 — Install via pip (for scripts / CI)
 
 ```bash
@@ -88,6 +92,16 @@ Then in Blender's Python console:
 import dcc_mcp_blender
 dcc_mcp_blender.start_server()
 ```
+
+### Headless Bootstrap
+
+For CI or automation that needs Blender's main thread dispatcher:
+
+```bash
+blender --background --python src/dcc_mcp_blender/blender_bootstrap.py
+```
+
+The bootstrap prints `MCP_URL=...`, discovers bundled skills, and drives `BlenderHost` in headless mode until the process is stopped.
 
 ---
 

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -45,7 +45,7 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.17.5"
+MIN_CORE_VERSION = "0.17.6"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ classifiers = [
 ]
 
 dependencies = [
-    # Align with dcc-mcp-core 0.17.5: DccServerOptions composition root,
+    # Align with dcc-mcp-core 0.17.6: DccServerOptions composition root,
     # HostExecutionBridge, diagnostics/resources contracts, gateway capability
     # index expectations, and current skill-management/search contracts.
-    "dcc-mcp-core>=0.17.5,<1.0.0",
+    "dcc-mcp-core>=0.17.6,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,11 @@
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [
         {
+          "type": "toml",
+          "path": "pyproject.toml",
+          "jsonpath": "$.project.version"
+        },
+        {
           "type": "generic",
           "path": "src/dcc_mcp_blender/__version__.py"
         },

--- a/src/dcc_mcp_blender/__init__.py
+++ b/src/dcc_mcp_blender/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dcc_mcp_blender.__version__ import __version__
 from dcc_mcp_blender.api import skill_entry, skill_error, skill_exception, skill_success
 from dcc_mcp_blender.capabilities import blender_capabilities, blender_capabilities_dict
+from dcc_mcp_blender.host import BlenderHost
 from dcc_mcp_blender.server import (
     DEFAULT_PORT,
     SERVER_NAME,
@@ -23,6 +24,7 @@ __all__ = [
     "skill_success",
     "blender_capabilities",
     "blender_capabilities_dict",
+    "BlenderHost",
     "BlenderMcpServer",
     "BlenderServerOptions",
     "DEFAULT_PORT",

--- a/src/dcc_mcp_blender/blender_bootstrap.py
+++ b/src/dcc_mcp_blender/blender_bootstrap.py
@@ -1,0 +1,29 @@
+"""Headless Blender bootstrap for the MCP server.
+
+Run with:
+    blender --background --python src/dcc_mcp_blender/blender_bootstrap.py
+"""
+
+from __future__ import annotations
+
+from dcc_mcp_core.host import BlockingDispatcher
+
+from dcc_mcp_blender.host import BlenderHost
+from dcc_mcp_blender.server import BlenderMcpServer
+
+
+def main(port: int = 18765) -> None:
+    """Start the MCP server and block while Blender services dispatcher ticks."""
+    dispatcher = BlockingDispatcher()
+    server = BlenderMcpServer(port=port, dispatcher=dispatcher)
+    server.start()
+    server.discover_skills()
+    print(f"MCP_URL={server.mcp_url}", flush=True)
+    try:
+        BlenderHost(dispatcher).run_headless()
+    finally:
+        server.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dcc_mcp_blender/host.py
+++ b/src/dcc_mcp_blender/host.py
@@ -3,11 +3,55 @@
 from __future__ import annotations
 
 import threading
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
-from dcc_mcp_core.host import HostAdapter
+from dcc_mcp_core.host import BlockingDispatcher, HostAdapter
 
 TickFn = Callable[[], Optional[float]]
+
+
+class BlenderCallableDispatcher:
+    """Callable dispatcher driven by Blender's host tick loop."""
+
+    def __init__(self, dispatcher: Optional[BlockingDispatcher] = None) -> None:
+        self._dispatcher = dispatcher or BlockingDispatcher()
+
+    def dispatch_callable(
+        self,
+        func: Callable[..., Any],
+        *args: Any,
+        affinity: str = "main",
+        context: Any = None,
+        action_name: str = "",
+        skill_name: Optional[str] = None,
+        execution: str = "sync",
+        timeout_hint_secs: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Post ``func`` to Blender's main-thread queue and wait for its result."""
+        _ = (affinity, context, action_name, skill_name, execution)
+
+        def _invoke() -> Any:
+            return func(*args, **kwargs)
+
+        handle = self._dispatcher.post(_invoke)
+        return handle.wait(timeout_hint_secs)
+
+    def tick(self, max_jobs: int):
+        """Drain queued callables from Blender's main thread."""
+        return self._dispatcher.tick(max_jobs)
+
+    def tick_blocking(self, max_jobs: int, timeout_ms: int):
+        """Drain queued callables, blocking briefly while headless."""
+        return self._dispatcher.tick_blocking(max_jobs, timeout_ms)
+
+    def shutdown(self) -> None:
+        """Stop accepting queued work."""
+        self._dispatcher.shutdown()
+
+    def is_shutdown(self) -> bool:
+        """Return whether the underlying dispatcher is shut down."""
+        return bool(self._dispatcher.is_shutdown())
 
 
 class BlenderHost(HostAdapter):

--- a/src/dcc_mcp_blender/host.py
+++ b/src/dcc_mcp_blender/host.py
@@ -1,0 +1,55 @@
+"""Blender host adapter for dcc-mcp-core main-thread dispatch."""
+
+from __future__ import annotations
+
+import threading
+from typing import Callable, Optional
+
+from dcc_mcp_core.host import HostAdapter
+
+TickFn = Callable[[], Optional[float]]
+
+
+class BlenderHost(HostAdapter):
+    """Drive a dcc-mcp-core dispatcher from Blender's main thread.
+
+    Blender exposes ``bpy.app.timers`` as its native idle primitive. In
+    interactive mode this adapter registers the core dispatcher tick with that
+    timer API; in background mode it uses :class:`HostAdapter`'s blocking loop.
+    """
+
+    def __init__(self, dispatcher, **kwargs) -> None:
+        super().__init__(dispatcher, name=kwargs.pop("name", "blender-host"), **kwargs)
+        self._tick_fn: Optional[TickFn] = None
+        self._tick_thread_ident: Optional[int] = None
+
+    @property
+    def tick_thread_ident(self) -> Optional[int]:
+        """Thread id of the most recent Blender timer tick."""
+        return self._tick_thread_ident
+
+    def is_background(self) -> bool:
+        """Return whether Blender is running in background mode."""
+        import bpy
+
+        return bool(bpy.app.background)
+
+    def attach_tick(self, tick_fn: TickFn) -> None:
+        """Register ``tick_fn`` with ``bpy.app.timers``."""
+        import bpy
+
+        def _tick_wrapper() -> Optional[float]:
+            self._tick_thread_ident = threading.get_ident()
+            return tick_fn()
+
+        self._tick_fn = _tick_wrapper
+        bpy.app.timers.register(_tick_wrapper, first_interval=0.0, persistent=True)
+
+    def detach_tick(self) -> None:
+        """Unregister the Blender timer tick, if it is still registered."""
+        import bpy
+
+        tick_fn = self._tick_fn
+        if tick_fn is not None and bpy.app.timers.is_registered(tick_fn):
+            bpy.app.timers.unregister(tick_fn)
+        self._tick_fn = None

--- a/src/dcc_mcp_blender/server.py
+++ b/src/dcc_mcp_blender/server.py
@@ -158,6 +158,8 @@ class BlenderMcpServer(DccServerBase):
         metrics_enabled: Optional[bool] = None,
         job_storage_path: Optional[str] = None,
         enable_workflows: Optional[bool] = None,
+        dispatcher: Optional[Any] = None,
+        execution_bridge: Optional[Any] = None,
         options: Optional[BlenderServerOptions] = None,
     ) -> None:
         if options is None:
@@ -174,6 +176,8 @@ class BlenderMcpServer(DccServerBase):
                 metrics_enabled=metrics_enabled,
                 job_storage_path=job_storage_path,
                 enable_workflows=enable_workflows,
+                dispatcher=dispatcher,
+                execution_bridge=execution_bridge,
             )
 
         super().__init__(options=options.to_core_options())
@@ -403,6 +407,8 @@ def start_server(
     metrics_enabled: Optional[bool] = None,
     job_storage_path: Optional[str] = None,
     enable_workflows: Optional[bool] = None,
+    dispatcher: Optional[Any] = None,
+    execution_bridge: Optional[Any] = None,
 ) -> BlenderMcpServer:
     """Start the Blender MCP server (creates a process-level singleton).
 
@@ -429,6 +435,8 @@ def start_server(
         metrics_enabled: Force Prometheus ``/metrics`` (``None`` = env ``DCC_MCP_BLENDER_METRICS``).
         job_storage_path: SQLite job DB path (``None`` = env / default).
         enable_workflows: Enable workflow MCP tools (``None`` = env).
+        dispatcher: Optional host dispatcher for main-thread execution.
+        execution_bridge: Optional execution bridge supplied by dcc-mcp-core.
 
     Returns:
         The running :class:`BlenderMcpServer` instance.
@@ -448,6 +456,8 @@ def start_server(
         metrics_enabled=metrics_enabled,
         job_storage_path=job_storage_path,
         enable_workflows=enable_workflows,
+        dispatcher=dispatcher,
+        execution_bridge=execution_bridge,
     )
     if register_builtins:
         _server_instance.register_builtin_actions(include_bundled=include_bundled)

--- a/src/dcc_mcp_blender/skills/blender-geometry/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-geometry/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: blender-geometry
+description: "Blender geometry creation and export tools for real bpy workflows"
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, geometry, export, mesh]
+    search-hint: "create sphere, save blend, export fbx, export obj, file exists"
+    depends: []
+    tools: tools.yaml
+---
+
+# blender-geometry
+
+Geometry tools for Blender main-thread execution and export validation.

--- a/src/dcc_mcp_blender/skills/blender-geometry/scripts/create_sphere.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry/scripts/create_sphere.py
@@ -1,0 +1,52 @@
+"""Create a UV sphere in Blender."""
+
+from __future__ import annotations
+
+import threading
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def create_sphere(
+    radius: float = 1.0,
+    name: Optional[str] = None,
+    location: Optional[List[float]] = None,
+) -> dict:
+    """Create a UV sphere using ``bpy.ops.mesh.primitive_uv_sphere_add``."""
+    try:
+        import bpy
+
+        loc = location or [0.0, 0.0, 0.0]
+        bpy.ops.mesh.primitive_uv_sphere_add(radius=radius, location=loc)
+        obj = bpy.context.active_object
+        if obj is not None and name:
+            obj.name = name
+            if getattr(obj, "data", None) is not None:
+                obj.data.name = name
+
+        object_name = getattr(obj, "name", name or "Sphere")
+        return skill_success(
+            f"Created sphere: {object_name}",
+            object_name=object_name,
+            radius=radius,
+            location=loc,
+            thread_ident=threading.get_ident(),
+            prompt="Sphere created.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create sphere")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_sphere`."""
+    return create_sphere(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-geometry/scripts/create_sphere.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry/scripts/create_sphere.py
@@ -8,6 +8,14 @@ from typing import List, Optional
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 
+def _get_active_object(bpy):
+    return (
+        getattr(bpy.context, "active_object", None)
+        or getattr(bpy.context, "object", None)
+        or getattr(getattr(getattr(bpy.context, "view_layer", None), "objects", None), "active", None)
+    )
+
+
 def create_sphere(
     radius: float = 1.0,
     name: Optional[str] = None,
@@ -19,7 +27,7 @@ def create_sphere(
 
         loc = location or [0.0, 0.0, 0.0]
         bpy.ops.mesh.primitive_uv_sphere_add(radius=radius, location=loc)
-        obj = bpy.context.active_object
+        obj = _get_active_object(bpy)
         if obj is not None and name:
             obj.name = name
             if getattr(obj, "data", None) is not None:

--- a/src/dcc_mcp_blender/skills/blender-geometry/scripts/export_fbx.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry/scripts/export_fbx.py
@@ -1,0 +1,30 @@
+"""Export the current Blender scene to FBX."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def export_fbx(path: str) -> dict:
+    """Export the current scene using ``bpy.ops.export_scene.fbx``."""
+    try:
+        import bpy
+
+        bpy.ops.export_scene.fbx(filepath=path)
+        return skill_success(f"Exported FBX: {path}", filepath=path, prompt="FBX exported.")
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to export FBX: {path}")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`export_fbx`."""
+    return export_fbx(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-geometry/scripts/export_obj.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry/scripts/export_obj.py
@@ -1,0 +1,34 @@
+"""Export the current Blender scene to OBJ."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def export_obj(path: str) -> dict:
+    """Export OBJ using Blender 3.x/4.x compatible operators."""
+    try:
+        import bpy
+
+        wm_export = getattr(bpy.ops.wm, "obj_export", None)
+        if callable(wm_export):
+            wm_export(filepath=path)
+        else:
+            bpy.ops.export_scene.obj(filepath=path)
+        return skill_success(f"Exported OBJ: {path}", filepath=path, prompt="OBJ exported.")
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to export OBJ: {path}")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`export_obj`."""
+    return export_obj(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-geometry/scripts/export_obj.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry/scripts/export_obj.py
@@ -2,7 +2,60 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def _call_blender_exporter(bpy, path: str) -> None:
+    wm_export = getattr(bpy.ops.wm, "obj_export", None)
+    if callable(wm_export):
+        wm_export(filepath=path)
+        return
+
+    scene_export = getattr(getattr(bpy.ops, "export_scene", None), "obj", None)
+    if callable(scene_export):
+        scene_export(filepath=path)
+        return
+
+    raise RuntimeError("No OBJ export operator is available")
+
+
+def _iter_mesh_objects(bpy):
+    for obj in getattr(getattr(bpy, "data", None), "objects", []):
+        if getattr(obj, "type", None) == "MESH" and getattr(obj, "data", None) is not None:
+            yield obj
+
+
+def _coordinate(obj, vertex):
+    co = getattr(vertex, "co", vertex)
+    matrix = getattr(obj, "matrix_world", None)
+    if matrix is not None:
+        try:
+            co = matrix @ co
+        except Exception:
+            pass
+    return (float(co[0]), float(co[1]), float(co[2]))
+
+
+def _write_basic_obj(bpy, path: str) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    vertex_offset = 1
+    with open(path, "w", encoding="utf-8", newline="\n") as handle:
+        handle.write("# Exported by dcc-mcp-blender\n")
+        for obj in _iter_mesh_objects(bpy):
+            mesh = obj.data
+            vertices = list(getattr(mesh, "vertices", []))
+            polygons = list(getattr(mesh, "polygons", []))
+            handle.write(f"o {getattr(obj, 'name', 'Object')}\n")
+            for vertex in vertices:
+                x, y, z = _coordinate(obj, vertex)
+                handle.write(f"v {x:.9g} {y:.9g} {z:.9g}\n")
+            for polygon in polygons:
+                indices = [str(vertex_offset + int(index)) for index in getattr(polygon, "vertices", [])]
+                if len(indices) >= 3:
+                    handle.write(f"f {' '.join(indices)}\n")
+            vertex_offset += len(vertices)
 
 
 def export_obj(path: str) -> dict:
@@ -10,11 +63,10 @@ def export_obj(path: str) -> dict:
     try:
         import bpy
 
-        wm_export = getattr(bpy.ops.wm, "obj_export", None)
-        if callable(wm_export):
-            wm_export(filepath=path)
-        else:
-            bpy.ops.export_scene.obj(filepath=path)
+        try:
+            _call_blender_exporter(bpy, path)
+        except Exception:
+            _write_basic_obj(bpy, path)
         return skill_success(f"Exported OBJ: {path}", filepath=path, prompt="OBJ exported.")
     except ImportError:
         return skill_error("Blender not available", "bpy could not be imported")

--- a/src/dcc_mcp_blender/skills/blender-geometry/scripts/export_obj.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry/scripts/export_obj.py
@@ -7,16 +7,23 @@ from pathlib import Path
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 
+def _has_nonempty_file(path: str) -> bool:
+    target = Path(path)
+    return target.is_file() and target.stat().st_size > 0
+
+
 def _call_blender_exporter(bpy, path: str) -> None:
     wm_export = getattr(bpy.ops.wm, "obj_export", None)
     if callable(wm_export):
         wm_export(filepath=path)
-        return
+        if _has_nonempty_file(path):
+            return
 
     scene_export = getattr(getattr(bpy.ops, "export_scene", None), "obj", None)
     if callable(scene_export):
         scene_export(filepath=path)
-        return
+        if _has_nonempty_file(path):
+            return
 
     raise RuntimeError("No OBJ export operator is available")
 

--- a/src/dcc_mcp_blender/skills/blender-geometry/scripts/file_exists.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry/scripts/file_exists.py
@@ -1,0 +1,32 @@
+"""Check whether a file exists."""
+
+from __future__ import annotations
+
+import os
+
+from dcc_mcp_core.skill import skill_entry, skill_success
+
+
+def file_exists(path: str) -> dict:
+    """Return whether *path* exists and its size in bytes."""
+    exists = os.path.isfile(path)
+    size = os.path.getsize(path) if exists else 0
+    return skill_success(
+        f"File {'exists' if exists else 'does not exist'}: {path}",
+        filepath=path,
+        exists=exists,
+        size=size,
+        prompt="File check complete.",
+    )
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`file_exists`."""
+    return file_exists(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-geometry/scripts/save_blend.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry/scripts/save_blend.py
@@ -1,0 +1,30 @@
+"""Save the current Blender file."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def save_blend(path: str) -> dict:
+    """Save the current file using ``bpy.ops.wm.save_as_mainfile``."""
+    try:
+        import bpy
+
+        bpy.ops.wm.save_as_mainfile(filepath=path)
+        return skill_success(f"Saved blend file: {path}", filepath=path, prompt="Blend file saved.")
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to save blend file: {path}")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`save_blend`."""
+    return save_blend(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-geometry/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-geometry/tools.yaml
@@ -1,0 +1,36 @@
+tools:
+  - name: create_sphere
+    description: "Create a UV sphere in the Blender scene"
+    source_file: scripts/create_sphere.py
+    execution: sync
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: save_blend
+    description: "Save the current Blender file"
+    source_file: scripts/save_blend.py
+    execution: sync
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: file_exists
+    description: "Check whether a file exists and report its size"
+    source_file: scripts/file_exists.py
+    execution: sync
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: export_fbx
+    description: "Export the current scene to FBX"
+    source_file: scripts/export_fbx.py
+    execution: sync
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: export_obj
+    description: "Export the current scene to OBJ"
+    source_file: scripts/export_obj.py
+    execution: sync
+    read_only: false
+    destructive: false
+    idempotent: false

--- a/src/dcc_mcp_blender/skills/blender-lighting/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-lighting/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: blender-lighting
-description: "Blender lighting — create, configure and manage lights"
+description: "Blender lighting — create, configure and manage lights and world background"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
 metadata:
   dcc-mcp:
     dcc: blender
     version: "1.0.0"
-    tags: [blender, lighting, lights]
-    search-hint: "create light, point, sun, area, spot, energy, color"
+    tags: [blender, lighting, lights, world]
+    search-hint: "create light, point, sun, area, spot, energy, color, world background, environment lighting"
     depends: []
     tools: tools.yaml
 ---

--- a/src/dcc_mcp_blender/skills/blender-lighting/scripts/set_world_background.py
+++ b/src/dcc_mcp_blender/skills/blender-lighting/scripts/set_world_background.py
@@ -1,0 +1,80 @@
+"""Set the scene world background color and optional strength."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def _coerce_color(color: List[float]) -> List[float]:
+    if len(color) not in (3, 4):
+        raise ValueError("color must contain 3 or 4 values")
+    rgba = list(color[:4])
+    if len(rgba) == 3:
+        rgba.append(1.0)
+    return rgba
+
+
+def set_world_background(
+    color: List[float],
+    strength: Optional[float] = None,
+) -> dict:
+    """Set scene world background color.
+
+    Args:
+        color: RGB or RGBA values in the 0-1 range.
+        strength: Optional world shader strength when nodes are available.
+
+    Returns:
+        ActionResultModel dict.
+    """
+    try:
+        import bpy
+
+        rgba = _coerce_color(color)
+        scene = bpy.context.scene
+        world = scene.world
+        if world is None:
+            world = bpy.data.worlds.new(name="World")
+            scene.world = world
+
+        world.color = rgba[:3]
+
+        if strength is not None:
+            world.use_nodes = True
+            nodes = getattr(getattr(world, "node_tree", None), "nodes", [])
+            background = None
+            for node in nodes:
+                if getattr(node, "type", None) == "BACKGROUND":
+                    background = node
+                    break
+            if background is not None and "Strength" in background.inputs:
+                background.inputs["Strength"].default_value = float(strength)
+            else:
+                world.strength = float(strength)
+
+        return skill_success(
+            "World background updated",
+            color=rgba,
+            strength=strength,
+            prompt="World background updated. Render the scene to review environment lighting.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except ValueError as exc:
+        return skill_error("Invalid world background color", str(exc))
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set world background")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_world_background`."""
+    return set_world_background(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-lighting/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-lighting/tools.yaml
@@ -17,3 +17,9 @@ tools:
     read_only: true
     destructive: false
     idempotent: true
+  - name: set_world_background
+    description: "Set the scene world background color and optional strength"
+    source_file: scripts/set_world_background.py
+    read_only: false
+    destructive: false
+    idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-objects/scripts/create_object.py
+++ b/src/dcc_mcp_blender/skills/blender-objects/scripts/create_object.py
@@ -20,6 +20,14 @@ PRIMITIVE_TYPES = {
 }
 
 
+def _get_active_object(bpy):
+    return (
+        getattr(bpy.context, "active_object", None)
+        or getattr(bpy.context, "object", None)
+        or getattr(getattr(getattr(bpy.context, "view_layer", None), "objects", None), "active", None)
+    )
+
+
 def create_object(
     object_type: str = "cube",
     name: Optional[str] = None,
@@ -79,7 +87,7 @@ def create_object(
         elif object_type == "circle":
             bpy.ops.mesh.primitive_circle_add(radius=size / 2, **kwargs)
 
-        obj = bpy.context.active_object
+        obj = _get_active_object(bpy)
         if obj and name:
             obj.name = name
             if obj.data:

--- a/src/dcc_mcp_blender/skills/blender-objects/scripts/duplicate_object.py
+++ b/src/dcc_mcp_blender/skills/blender-objects/scripts/duplicate_object.py
@@ -7,6 +7,14 @@ from typing import List, Optional
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 
+def _get_active_object(bpy):
+    return (
+        getattr(bpy.context, "active_object", None)
+        or getattr(bpy.context, "object", None)
+        or getattr(getattr(getattr(bpy.context, "view_layer", None), "objects", None), "active", None)
+    )
+
+
 def duplicate_object(
     name: str,
     new_name: Optional[str] = None,
@@ -35,7 +43,9 @@ def duplicate_object(
         bpy.context.view_layer.objects.active = source
 
         bpy.ops.object.duplicate(linked=False)
-        new_obj = bpy.context.active_object
+        new_obj = _get_active_object(bpy)
+        if new_obj is None:
+            return skill_error("Duplicate failed", "Blender did not report an active duplicated object.")
 
         if new_name:
             new_obj.name = new_name

--- a/src/dcc_mcp_blender/skills/blender-render/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-render/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: blender-render
-description: "Blender rendering — render scenes, set render settings, manage cameras"
+description: "Blender rendering — render scenes, capture viewport images, set render settings, manage cameras"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
 metadata:
   dcc-mcp:
     dcc: blender
     version: "1.0.0"
-    tags: [blender, render, camera]
-    search-hint: "render, output, resolution, camera, cycles, eevee"
+    tags: [blender, render, viewport, camera]
+    search-hint: "render, viewport screenshot, output, resolution, camera, cycles, eevee"
     depends: []
     tools: tools.yaml
 ---

--- a/src/dcc_mcp_blender/skills/blender-render/scripts/capture_viewport.py
+++ b/src/dcc_mcp_blender/skills/blender-render/scripts/capture_viewport.py
@@ -1,0 +1,75 @@
+"""Capture the active Blender viewport to an image file."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def capture_viewport(
+    filepath: str,
+    resolution_x: Optional[int] = None,
+    resolution_y: Optional[int] = None,
+) -> dict:
+    """Capture the active viewport.
+
+    Args:
+        filepath: Destination image path.
+        resolution_x: Optional temporary output width.
+        resolution_y: Optional temporary output height.
+
+    Returns:
+        ActionResultModel dict with the written filepath.
+    """
+    try:
+        import bpy
+
+        if not filepath:
+            return skill_error("Missing filepath", "Provide a filepath for the viewport image.")
+
+        scene = bpy.context.scene
+        old_filepath = scene.render.filepath
+        old_x = scene.render.resolution_x
+        old_y = scene.render.resolution_y
+
+        try:
+            scene.render.filepath = filepath
+            if resolution_x is not None:
+                scene.render.resolution_x = int(resolution_x)
+            if resolution_y is not None:
+                scene.render.resolution_y = int(resolution_y)
+
+            try:
+                bpy.ops.screen.screenshot(filepath=filepath)
+                method = "screen"
+            except Exception:
+                bpy.ops.render.opengl(write_still=True, view_context=True)
+                method = "opengl"
+        finally:
+            scene.render.filepath = old_filepath
+            scene.render.resolution_x = old_x
+            scene.render.resolution_y = old_y
+
+        return skill_success(
+            "Viewport captured",
+            filepath=filepath,
+            method=method,
+            prompt="Viewport image saved. Use the file path to inspect the current view.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to capture viewport")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`capture_viewport`."""
+    return capture_viewport(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-render/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-render/tools.yaml
@@ -17,3 +17,9 @@ tools:
     read_only: true
     destructive: false
     idempotent: true
+  - name: capture_viewport
+    description: "Capture the active viewport to an image file"
+    source_file: scripts/capture_viewport.py
+    read_only: false
+    destructive: false
+    idempotent: false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,9 @@ def make_mock_bpy(
     mock_scene.render.engine = "CYCLES"
     mock_scene.render.image_settings.file_format = "PNG"
     mock_scene.camera = None
+    mock_scene.world = MagicMock()
+    mock_scene.world.color = [0.0, 0.0, 0.0]
+    mock_scene.world.use_nodes = False
     mock_bpy.context.scene = mock_scene
     mock_bpy.context.active_object = None
     mock_bpy.context.view_layer.objects.active = None
@@ -106,6 +109,7 @@ def make_mock_bpy(
     mock_bpy.data.collections = MagicMock()
     mock_bpy.data.lights = MagicMock()
     mock_bpy.data.cameras = MagicMock()
+    mock_bpy.data.worlds = MagicMock()
     if data_attrs:
         for k, v in data_attrs.items():
             getattr(mock_bpy.data, k)
@@ -126,6 +130,7 @@ def make_mock_bpy(
     mock_bpy.ops.object = MagicMock()
     mock_bpy.ops.wm = MagicMock()
     mock_bpy.ops.render = MagicMock()
+    mock_bpy.ops.screen = MagicMock()
     if ops_attrs:
         for k, v in ops_attrs.items():
             setattr(mock_bpy.ops, k, v)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -14,8 +14,8 @@ Or via the installed blender Python directly::
 
 CI::
 
-    Uses the ``docker://linuxserver/blender`` image or downloads Blender
-    directly, then runs blender --background to execute tests.
+    Linux uses Blender container images. Windows and macOS download Blender
+    directly. All variants run blender --background to execute tests.
 """
 
 from __future__ import annotations
@@ -41,7 +41,7 @@ def pytest_collection_modifyitems(items, config):
     except Exception:
         skip_marker = pytest.mark.skip(reason="bpy not available — run inside Blender Python interpreter")
         for item in items:
-            if "e2e" in item.nodeid:
+            if "tests/e2e" in item.path.as_posix():
                 item.add_marker(skip_marker)
 
 

--- a/tests/e2e/test_geometry_e2e.py
+++ b/tests/e2e/test_geometry_e2e.py
@@ -1,0 +1,53 @@
+"""E2E tests for blender-geometry inside a real Blender interpreter."""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+
+bpy = pytest.importorskip("bpy", reason="bpy not available - run inside Blender Python interpreter")
+
+pytestmark = pytest.mark.e2e
+
+from tests.e2e.conftest import load_skill  # noqa: E402
+
+
+def _new_scene():
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+
+
+class TestGeometrySkillsE2E:
+    def setup_method(self):
+        _new_scene()
+
+    def test_create_sphere_reports_main_thread(self):
+        mod = load_skill("blender-geometry", "create_sphere")
+
+        result = mod.create_sphere(radius=1.25, name="E2E Sphere", location=[1.0, 2.0, 3.0])
+
+        assert result["success"] is True
+        assert "E2E Sphere" in bpy.data.objects
+        assert result["context"]["thread_ident"] == threading.get_ident()
+
+    def test_save_and_export_files_exist(self):
+        load_skill("blender-geometry", "create_sphere").create_sphere(name="Export Sphere")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            blend_path = tmp_path / "scene.blend"
+            fbx_path = tmp_path / "scene.fbx"
+            obj_path = tmp_path / "scene.obj"
+
+            assert load_skill("blender-geometry", "save_blend").save_blend(str(blend_path))["success"] is True
+            assert load_skill("blender-geometry", "export_fbx").export_fbx(str(fbx_path))["success"] is True
+            assert load_skill("blender-geometry", "export_obj").export_obj(str(obj_path))["success"] is True
+
+            exists_mod = load_skill("blender-geometry", "file_exists")
+            for path in (blend_path, fbx_path, obj_path):
+                result = exists_mod.file_exists(str(path))
+                assert result["success"] is True
+                assert result["context"]["exists"] is True
+                assert result["context"]["size"] > 0

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -1,0 +1,31 @@
+"""Tests for the dcc-mcp-core dependency floor."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).parent.parent
+
+
+def _load_assemble_zip_module():
+    path = ROOT / "packaging" / "assemble_zip.py"
+    spec = importlib.util.spec_from_file_location("assemble_zip_for_tests", str(path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_core_dependency_floor_is_0176():
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert '"dcc-mcp-core>=0.17.6,<1.0.0"' in pyproject
+
+
+def test_packaging_core_floor_matches_pyproject():
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'"dcc-mcp-core>=(?P<version>[^,]+),<1\.0\.0"', pyproject)
+
+    assert match is not None
+    assert _load_assemble_zip_module().MIN_CORE_VERSION == match.group("version")

--- a/tests/test_gateway_failover.py
+++ b/tests/test_gateway_failover.py
@@ -1,0 +1,45 @@
+"""Gateway failover smoke tests."""
+
+from __future__ import annotations
+
+import socket
+import time
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def test_non_gateway_instance_survives_gateway_shutdown(tmp_path):
+    from dcc_mcp_blender.server import BlenderMcpServer
+
+    gateway_port = _free_port()
+    s1 = BlenderMcpServer(
+        port=0,
+        gateway_port=gateway_port,
+        registry_dir=str(tmp_path),
+        enable_gateway_failover=True,
+    )
+    s2 = BlenderMcpServer(
+        port=0,
+        gateway_port=gateway_port,
+        registry_dir=str(tmp_path),
+        enable_gateway_failover=True,
+    )
+
+    s1.start()
+    time.sleep(0.1)
+    s2.start()
+    time.sleep(0.1)
+
+    try:
+        assert s1.is_running
+        assert s2.is_running
+        s1.stop()
+        time.sleep(0.2)
+        assert s2.is_running
+        assert s2.port > 0
+    finally:
+        s2.stop()

--- a/tests/test_gateway_integration.py
+++ b/tests/test_gateway_integration.py
@@ -1,0 +1,32 @@
+"""Gateway configuration tests for BlenderMcpServer."""
+
+from __future__ import annotations
+
+import socket
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def test_gateway_params_start_server_with_failover_enabled(tmp_path):
+    from dcc_mcp_blender.server import BlenderMcpServer
+
+    gateway_port = _free_port()
+    server = BlenderMcpServer(
+        port=0,
+        gateway_port=gateway_port,
+        registry_dir=str(tmp_path),
+        enable_gateway_failover=True,
+        dcc_version="4.2.0",
+        scene="/tmp/scene.blend",
+    )
+    server.start()
+    try:
+        assert server.is_running
+        assert server.port > 0
+        assert server.get_gateway_election_status() is not None
+    finally:
+        server.stop()

--- a/tests/test_host_adapter.py
+++ b/tests/test_host_adapter.py
@@ -79,3 +79,22 @@ def test_blender_host_attaches_and_detaches_timer():
         assert not host.is_running
         assert registered == []
         assert dispatcher.shutdown_called is True
+
+
+def test_blender_callable_dispatcher_posts_work_to_tick_loop():
+    from dcc_mcp_blender.host import BlenderCallableDispatcher
+
+    dispatcher = BlenderCallableDispatcher()
+    result = []
+
+    def worker():
+        result.append(dispatcher.dispatch_callable(lambda: "done"))
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+
+    while thread.is_alive() and not result:
+        dispatcher.tick(1)
+
+    thread.join(timeout=1)
+    assert result == ["done"]

--- a/tests/test_host_adapter.py
+++ b/tests/test_host_adapter.py
@@ -1,0 +1,81 @@
+"""Tests for the BlenderHost adapter."""
+
+from __future__ import annotations
+
+import sys
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+class _TickOutcome:
+    more_pending = False
+
+
+class _Dispatcher:
+    def __init__(self) -> None:
+        self.shutdown_called = False
+        self.tick_calls = 0
+
+    def tick(self, max_jobs):
+        self.tick_calls += 1
+        return _TickOutcome()
+
+    def shutdown(self):
+        self.shutdown_called = True
+
+    def is_shutdown(self):
+        return self.shutdown_called
+
+
+def _mock_bpy(background: bool = False):
+    registered = []
+
+    timers = MagicMock()
+    timers.register.side_effect = lambda fn, **kwargs: registered.append((fn, kwargs))
+    timers.is_registered.side_effect = lambda fn: any(item[0] is fn for item in registered)
+
+    def unregister(fn):
+        registered[:] = [item for item in registered if item[0] is not fn]
+
+    timers.unregister.side_effect = unregister
+
+    bpy = SimpleNamespace(
+        app=SimpleNamespace(
+            background=background,
+            timers=timers,
+        )
+    )
+    return bpy, registered
+
+
+def test_blender_host_uses_bpy_background_flag():
+    from dcc_mcp_blender.host import BlenderHost
+
+    bpy, _registered = _mock_bpy(background=True)
+    with patch.dict(sys.modules, {"bpy": bpy}):
+        assert BlenderHost(_Dispatcher()).is_background() is True
+
+
+def test_blender_host_attaches_and_detaches_timer():
+    from dcc_mcp_blender.host import BlenderHost
+
+    bpy, registered = _mock_bpy(background=False)
+    dispatcher = _Dispatcher()
+    host = BlenderHost(dispatcher)
+
+    with patch.dict(sys.modules, {"bpy": bpy}):
+        host.start()
+        assert host.is_running
+        assert len(registered) == 1
+        tick_fn, kwargs = registered[0]
+        assert kwargs == {"first_interval": 0.0, "persistent": True}
+
+        tick_fn()
+        assert dispatcher.tick_calls == 1
+        assert host.tick_thread_ident == threading.get_ident()
+
+        host.stop()
+        assert not host.is_running
+        assert registered == []
+        assert dispatcher.shutdown_called is True

--- a/tests/test_hotreload.py
+++ b/tests/test_hotreload.py
@@ -1,0 +1,19 @@
+"""Hot-reload integration tests for BlenderMcpServer."""
+
+from __future__ import annotations
+
+
+def test_hot_reload_enable_disable_round_trip():
+    from dcc_mcp_blender.server import BlenderMcpServer
+
+    server = BlenderMcpServer(port=0)
+    try:
+        assert server.is_hot_reload_enabled is False
+        server.enable_hot_reload()
+        assert server.is_hot_reload_enabled is True
+        stats = server.hot_reload_stats
+        assert isinstance(stats, dict)
+        server.disable_hot_reload()
+        assert server.is_hot_reload_enabled is False
+    finally:
+        server.stop()

--- a/tests/test_multi_instance_discovery.py
+++ b/tests/test_multi_instance_discovery.py
@@ -1,0 +1,76 @@
+"""Multi-instance gateway competition tests."""
+
+from __future__ import annotations
+
+import json
+import socket
+import time
+import urllib.request
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _post_mcp(url: str, body: dict) -> dict:
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        return json.loads(resp.read())
+
+
+def test_two_blender_servers_can_compete_for_gateway(tmp_path):
+    from dcc_mcp_blender.server import BlenderMcpServer
+
+    gateway_port = _free_port()
+    s1 = BlenderMcpServer(
+        port=0,
+        gateway_port=gateway_port,
+        registry_dir=str(tmp_path),
+        enable_gateway_failover=True,
+    )
+    s2 = BlenderMcpServer(
+        port=0,
+        gateway_port=gateway_port,
+        registry_dir=str(tmp_path),
+        enable_gateway_failover=True,
+    )
+
+    s1.start()
+    time.sleep(0.1)
+    s2.start()
+    time.sleep(0.1)
+
+    try:
+        assert s1.is_running
+        assert s2.is_running
+        assert s1.port != s2.port
+
+        for idx, server in enumerate((s1, s2), start=1):
+            response = _post_mcp(
+                server.mcp_url,
+                {
+                    "jsonrpc": "2.0",
+                    "id": idx,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": {"name": "pytest", "version": "1.0"},
+                    },
+                },
+            )
+            assert response["result"]["serverInfo"]["name"] == "dcc-mcp-blender"
+    finally:
+        s2.stop()
+        s1.stop()

--- a/tests/test_skills_geometry.py
+++ b/tests/test_skills_geometry.py
@@ -72,13 +72,15 @@ def test_export_fbx_calls_export_scene():
     mock_bpy.ops.export_scene.fbx.assert_called_once_with(filepath="/tmp/out.fbx")
 
 
-def test_export_obj_prefers_blender_3_plus_operator():
+def test_export_obj_prefers_blender_3_plus_operator(tmp_path):
     mock_bpy = make_mock_bpy()
+    mock_bpy.ops.wm.obj_export.side_effect = lambda filepath: open(filepath, "w", encoding="utf-8").write("obj")
+    out_path = tmp_path / "out.obj"
 
-    result = load_and_call("blender-geometry/scripts/export_obj.py", mock_bpy, path="/tmp/out.obj")
+    result = load_and_call("blender-geometry/scripts/export_obj.py", mock_bpy, path=str(out_path))
 
     assert result["success"] is True
-    mock_bpy.ops.wm.obj_export.assert_called_once_with(filepath="/tmp/out.obj")
+    mock_bpy.ops.wm.obj_export.assert_called_once_with(filepath=str(out_path))
 
 
 def test_export_obj_writes_basic_obj_when_operator_context_fails(tmp_path):
@@ -106,3 +108,22 @@ def test_export_obj_writes_basic_obj_when_operator_context_fails(tmp_path):
         "v 0 1 0",
         "f 1 2 3",
     ]
+
+
+def test_export_obj_writes_basic_obj_when_operator_creates_no_file(tmp_path):
+    mock_bpy = make_mock_bpy()
+    mesh = SimpleNamespace(
+        vertices=[
+            SimpleNamespace(co=(0.0, 0.0, 0.0)),
+            SimpleNamespace(co=(1.0, 0.0, 0.0)),
+            SimpleNamespace(co=(0.0, 1.0, 0.0)),
+        ],
+        polygons=[SimpleNamespace(vertices=[0, 1, 2])],
+    )
+    mock_bpy.data.objects = [SimpleNamespace(name="Triangle", type="MESH", data=mesh)]
+    out_path = tmp_path / "fallback.obj"
+
+    result = load_and_call("blender-geometry/scripts/export_obj.py", mock_bpy, path=str(out_path))
+
+    assert result["success"] is True
+    assert "f 1 2 3" in out_path.read_text(encoding="utf-8")

--- a/tests/test_skills_geometry.py
+++ b/tests/test_skills_geometry.py
@@ -79,3 +79,30 @@ def test_export_obj_prefers_blender_3_plus_operator():
 
     assert result["success"] is True
     mock_bpy.ops.wm.obj_export.assert_called_once_with(filepath="/tmp/out.obj")
+
+
+def test_export_obj_writes_basic_obj_when_operator_context_fails(tmp_path):
+    mock_bpy = make_mock_bpy()
+    mock_bpy.ops.wm.obj_export.side_effect = RuntimeError("context is incorrect")
+    mesh = SimpleNamespace(
+        vertices=[
+            SimpleNamespace(co=(0.0, 0.0, 0.0)),
+            SimpleNamespace(co=(1.0, 0.0, 0.0)),
+            SimpleNamespace(co=(0.0, 1.0, 0.0)),
+        ],
+        polygons=[SimpleNamespace(vertices=[0, 1, 2])],
+    )
+    mock_bpy.data.objects = [SimpleNamespace(name="Triangle", type="MESH", data=mesh)]
+    out_path = tmp_path / "fallback.obj"
+
+    result = load_and_call("blender-geometry/scripts/export_obj.py", mock_bpy, path=str(out_path))
+
+    assert result["success"] is True
+    assert out_path.read_text(encoding="utf-8").splitlines() == [
+        "# Exported by dcc-mcp-blender",
+        "o Triangle",
+        "v 0 0 0",
+        "v 1 0 0",
+        "v 0 1 0",
+        "f 1 2 3",
+    ]

--- a/tests/test_skills_geometry.py
+++ b/tests/test_skills_geometry.py
@@ -26,6 +26,21 @@ def test_create_sphere_calls_bpy_operator():
     mock_bpy.ops.mesh.primitive_uv_sphere_add.assert_called_once_with(radius=2.5, location=[1.0, 2.0, 3.0])
 
 
+def test_create_sphere_uses_context_object_fallback():
+    active = SimpleNamespace(name="Sphere", data=SimpleNamespace(name="Sphere"))
+    mock_bpy = make_mock_bpy(context_attrs={"active_object": None, "object": active})
+
+    result = load_and_call(
+        "blender-geometry/scripts/create_sphere.py",
+        mock_bpy,
+        radius=1.5,
+        name="Fallback Sphere",
+    )
+
+    assert result["success"] is True
+    assert result["context"]["object_name"] == "Fallback Sphere"
+
+
 def test_save_blend_calls_save_as_mainfile():
     mock_bpy = make_mock_bpy()
 

--- a/tests/test_skills_geometry.py
+++ b/tests/test_skills_geometry.py
@@ -1,0 +1,66 @@
+"""Tests for the blender-geometry skill."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from conftest import load_and_call, make_mock_bpy
+
+
+def test_create_sphere_calls_bpy_operator():
+    active = SimpleNamespace(name="Sphere", data=SimpleNamespace(name="Sphere"))
+    mock_bpy = make_mock_bpy(context_attrs={"active_object": active})
+
+    result = load_and_call(
+        "blender-geometry/scripts/create_sphere.py",
+        mock_bpy,
+        radius=2.5,
+        name="CI Sphere",
+        location=[1.0, 2.0, 3.0],
+    )
+
+    assert result["success"] is True
+    assert result["context"]["object_name"] == "CI Sphere"
+    assert result["context"]["thread_ident"] > 0
+    mock_bpy.ops.mesh.primitive_uv_sphere_add.assert_called_once_with(radius=2.5, location=[1.0, 2.0, 3.0])
+
+
+def test_save_blend_calls_save_as_mainfile():
+    mock_bpy = make_mock_bpy()
+
+    result = load_and_call("blender-geometry/scripts/save_blend.py", mock_bpy, path="/tmp/out.blend")
+
+    assert result["success"] is True
+    assert result["context"]["filepath"] == "/tmp/out.blend"
+    mock_bpy.ops.wm.save_as_mainfile.assert_called_once_with(filepath="/tmp/out.blend")
+
+
+def test_file_exists_reports_size(tmp_path):
+    target = tmp_path / "asset.fbx"
+    target.write_bytes(b"fbx")
+
+    result = load_and_call("blender-geometry/scripts/file_exists.py", None, path=str(target))
+
+    assert result["success"] is True
+    assert result["context"]["exists"] is True
+    assert result["context"]["size"] == 3
+
+
+def test_export_fbx_calls_export_scene():
+    mock_bpy = make_mock_bpy()
+    mock_bpy.ops.export_scene = MagicMock()
+
+    result = load_and_call("blender-geometry/scripts/export_fbx.py", mock_bpy, path="/tmp/out.fbx")
+
+    assert result["success"] is True
+    mock_bpy.ops.export_scene.fbx.assert_called_once_with(filepath="/tmp/out.fbx")
+
+
+def test_export_obj_prefers_blender_3_plus_operator():
+    mock_bpy = make_mock_bpy()
+
+    result = load_and_call("blender-geometry/scripts/export_obj.py", mock_bpy, path="/tmp/out.obj")
+
+    assert result["success"] is True
+    mock_bpy.ops.wm.obj_export.assert_called_once_with(filepath="/tmp/out.obj")

--- a/tests/test_skills_lighting.py
+++ b/tests/test_skills_lighting.py
@@ -112,3 +112,44 @@ class TestListLights:
         result = load_and_call("blender-lighting/scripts/list_lights.py", bpy)
         assert result["success"] is True
         assert result["context"]["count"] == 0
+
+
+class TestSetWorldBackground:
+    def test_sets_existing_world_color(self):
+        bpy = make_mock_bpy()
+
+        result = load_and_call(
+            "blender-lighting/scripts/set_world_background.py",
+            bpy,
+            color=[0.1, 0.2, 0.3],
+        )
+
+        assert result["success"] is True
+        assert bpy.context.scene.world.color == [0.1, 0.2, 0.3]
+        assert result["context"]["color"] == [0.1, 0.2, 0.3, 1.0]
+
+    def test_creates_world_when_missing(self):
+        bpy = make_mock_bpy()
+        bpy.context.scene.world = None
+        new_world = MagicMock()
+        bpy.data.worlds.new.return_value = new_world
+
+        result = load_and_call(
+            "blender-lighting/scripts/set_world_background.py",
+            bpy,
+            color=[0.4, 0.5, 0.6, 0.7],
+            strength=2.5,
+        )
+
+        assert result["success"] is True
+        bpy.data.worlds.new.assert_called_once_with(name="World")
+        assert bpy.context.scene.world is new_world
+        assert new_world.color == [0.4, 0.5, 0.6]
+        assert new_world.strength == 2.5
+
+    def test_rejects_invalid_color_length(self):
+        bpy = make_mock_bpy()
+
+        result = load_and_call("blender-lighting/scripts/set_world_background.py", bpy, color=[1.0, 0.5])
+
+        assert result["success"] is False

--- a/tests/test_skills_objects.py
+++ b/tests/test_skills_objects.py
@@ -176,6 +176,38 @@ class TestGetObjectInfo:
         assert ctx["vertex_count"] == 8
         assert ctx["face_count"] == 6
 
+    def test_returns_relationships_and_material_slots(self):
+        bpy = make_mock_bpy()
+        obj = _make_obj("Cube", "MESH")
+        obj.parent = MagicMock()
+        obj.parent.name = "Parent"
+        child = MagicMock()
+        child.name = "Child"
+        obj.children = [child]
+        collection = MagicMock()
+        collection.name = "Collection"
+        obj.users_collection = [collection]
+        mat = MagicMock()
+        mat.name = "Red"
+        slot_with_mat = MagicMock()
+        slot_with_mat.material = mat
+        empty_slot = MagicMock()
+        empty_slot.material = None
+        obj.material_slots = [slot_with_mat, empty_slot]
+        obj.data.vertices = []
+        obj.data.edges = []
+        obj.data.polygons = []
+        bpy.data.objects.get.return_value = obj
+
+        result = load_and_call("blender-objects/scripts/get_object_info.py", bpy, name="Cube")
+
+        assert result["success"] is True
+        ctx = result["context"]
+        assert ctx["parent"] == "Parent"
+        assert ctx["children"] == ["Child"]
+        assert ctx["collections"] == ["Collection"]
+        assert ctx["material_slots"] == ["Red", None]
+
     def test_nonexistent_object_returns_error(self):
         bpy = make_mock_bpy()
         bpy.data.objects.get.return_value = None

--- a/tests/test_skills_objects.py
+++ b/tests/test_skills_objects.py
@@ -51,6 +51,17 @@ class TestCreateObject:
         result = load_and_call("blender-objects/scripts/create_object.py", bpy, object_type="cube", name="MyCube")
         assert result["success"] is True
 
+    def test_create_uses_context_object_fallback(self):
+        bpy = make_mock_bpy()
+        obj = _make_obj("FallbackCube")
+        bpy.context.active_object = None
+        bpy.context.object = obj
+
+        result = load_and_call("blender-objects/scripts/create_object.py", bpy, object_type="cube", name="FallbackCube")
+
+        assert result["success"] is True
+        assert result["context"]["object_name"] == "FallbackCube"
+
     def test_invalid_type_returns_error(self):
         bpy = make_mock_bpy()
         result = load_and_call("blender-objects/scripts/create_object.py", bpy, object_type="invalid_type")
@@ -72,6 +83,27 @@ class TestCreateObject:
         result = load_and_call("blender-objects/scripts/create_object.py", bpy, object_type="empty")
         assert result["success"] is True
         bpy.ops.object.empty_add.assert_called_once()
+
+
+class TestDuplicateObject:
+    def test_duplicate_uses_context_object_fallback(self):
+        bpy = make_mock_bpy()
+        source = _make_obj("Cube")
+        duplicate = _make_obj("Cube.001", loc=[1.0, 2.0, 3.0])
+        bpy.data.objects.get.return_value = source
+        bpy.context.active_object = None
+        bpy.context.object = duplicate
+
+        result = load_and_call(
+            "blender-objects/scripts/duplicate_object.py",
+            bpy,
+            name="Cube",
+            new_name="Cube Copy",
+        )
+
+        assert result["success"] is True
+        assert duplicate.name == "Cube Copy"
+        assert result["context"]["new_name"] == "Cube Copy"
 
 
 class TestDeleteObject:

--- a/tests/test_skills_render.py
+++ b/tests/test_skills_render.py
@@ -89,3 +89,44 @@ class TestRenderScene:
         result = load_and_call("blender-render/scripts/render_scene.py", bpy, output_path="/custom/output.png")
         assert result["success"] is True
         assert bpy.context.scene.render.filepath == "/custom/output.png"
+
+
+class TestCaptureViewport:
+    def test_capture_viewport_uses_screen_screenshot_and_restores_settings(self):
+        bpy = make_mock_bpy()
+        bpy.context.scene.render.filepath = "/tmp/original.png"
+        bpy.context.scene.render.resolution_x = 1920
+        bpy.context.scene.render.resolution_y = 1080
+
+        result = load_and_call(
+            "blender-render/scripts/capture_viewport.py",
+            bpy,
+            filepath="/tmp/viewport.png",
+            resolution_x=800,
+            resolution_y=600,
+        )
+
+        assert result["success"] is True
+        assert result["context"]["filepath"] == "/tmp/viewport.png"
+        assert result["context"]["method"] == "screen"
+        bpy.ops.screen.screenshot.assert_called_once_with(filepath="/tmp/viewport.png")
+        assert bpy.context.scene.render.filepath == "/tmp/original.png"
+        assert bpy.context.scene.render.resolution_x == 1920
+        assert bpy.context.scene.render.resolution_y == 1080
+
+    def test_capture_viewport_falls_back_to_opengl(self):
+        bpy = make_mock_bpy()
+        bpy.ops.screen.screenshot.side_effect = RuntimeError("no screen area")
+
+        result = load_and_call("blender-render/scripts/capture_viewport.py", bpy, filepath="/tmp/viewport.png")
+
+        assert result["success"] is True
+        assert result["context"]["method"] == "opengl"
+        bpy.ops.render.opengl.assert_called_once_with(write_still=True, view_context=True)
+
+    def test_capture_viewport_requires_filepath(self):
+        bpy = make_mock_bpy()
+
+        result = load_and_call("blender-render/scripts/capture_viewport.py", bpy, filepath="")
+
+        assert result["success"] is False

--- a/tests/test_skills_scene.py
+++ b/tests/test_skills_scene.py
@@ -130,3 +130,33 @@ class TestGetSceneInfo:
         ctx = result["context"]
         assert "scene_name" in ctx
         assert "collections" in ctx
+
+    def test_counts_objects_by_type_and_recurses_collections(self):
+        mesh = MagicMock()
+        mesh.name = "Cube"
+        mesh.type = "MESH"
+        light = MagicMock()
+        light.name = "Key"
+        light.type = "LIGHT"
+
+        child_col = MagicMock()
+        child_col.name = "Props"
+        child_col.objects = [mesh]
+        child_col.children = []
+        root_col = MagicMock()
+        root_col.name = "Scene Collection"
+        root_col.objects = [light]
+        root_col.children = [child_col]
+
+        bpy = make_mock_bpy()
+        bpy.context.scene.collection = root_col
+        bpy.context.scene.objects = [mesh, light]
+
+        result = load_and_call("blender-scene/scripts/get_scene_info.py", bpy)
+
+        assert result["success"] is True
+        ctx = result["context"]
+        assert ctx["total_objects"] == 2
+        assert ctx["objects_by_type"] == {"MESH": 1, "LIGHT": 1}
+        assert ctx["collections"]["children"][0]["name"] == "Props"
+        assert ctx["collections"]["children"][0]["objects"] == ["Cube"]

--- a/tests/test_skills_scripting.py
+++ b/tests/test_skills_scripting.py
@@ -67,6 +67,29 @@ class TestExecutePython:
         assert result["success"] is True
         assert result["context"]["result"] == "42"
 
+    def test_stderr_captured_on_success(self):
+        bpy = make_mock_bpy()
+        result = load_and_call(
+            "blender-scripting/scripts/execute_python.py",
+            bpy,
+            code="import sys\nprint('warn', file=sys.stderr)\nresult = 'ok'",
+        )
+
+        assert result["success"] is True
+        assert result["context"]["stderr"] == "warn\n"
+        assert result["context"]["result"] == "ok"
+
+    def test_execution_namespace_exposes_bpy(self):
+        bpy = make_mock_bpy(app_attrs={"version_string": "4.3.2"})
+        result = load_and_call(
+            "blender-scripting/scripts/execute_python.py",
+            bpy,
+            code="result = bpy.app.version_string",
+        )
+
+        assert result["success"] is True
+        assert result["context"]["result"] == "4.3.2"
+
 
 class TestExecuteScriptFile:
     def test_executes_valid_script(self):

--- a/tests/test_skills_structure.py
+++ b/tests/test_skills_structure.py
@@ -17,6 +17,7 @@ EXPECTED_SKILLS = [
     "blender-lighting",
     "blender-camera",
     "blender-collection",
+    "blender-geometry",
 ]
 
 

--- a/tests/test_workflow_ci.py
+++ b/tests/test_workflow_ci.py
@@ -20,6 +20,8 @@ def test_mcporter_call_wrapper_fails_unknown_tools():
     text = E2E_WORKFLOW.read_text(encoding="utf-8")
 
     assert "call_tool() {" in text
+    assert "set +e" in text
+    assert "set -e" in text
     assert '"code": "ACTION_NOT_FOUND"' in text
     assert "Unknown tool" in text
 
@@ -40,3 +42,11 @@ def test_execute_python_smoke_call_avoids_shell_key_value_assignment():
     execute_python_calls = re.findall(r"call_tool execute_python \\\s*\n\s*\"code:([^\"]+)\"", text)
     assert execute_python_calls
     assert all(" = " not in code for code in execute_python_calls)
+
+
+def test_geometry_export_verification_reads_paths_from_environment():
+    text = E2E_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "export GEOM_BLEND GEOM_FBX GEOM_OBJ" in text
+    assert "path = os.environ[key]" in text
+    assert "('$GEOM_BLEND', '$GEOM_FBX', '$GEOM_OBJ')" not in text

--- a/tests/test_workflow_ci.py
+++ b/tests/test_workflow_ci.py
@@ -22,3 +22,14 @@ def test_mcporter_call_wrapper_fails_unknown_tools():
     assert "call_tool() {" in text
     assert '"code": "ACTION_NOT_FOUND"' in text
     assert "Unknown tool" in text
+
+
+def test_workflow_server_uses_blender_inprocess_dispatcher():
+    text = E2E_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "from dcc_mcp_core.host import BlockingDispatcher" in text
+    assert "from dcc_mcp_blender.host import BlenderHost" in text
+    assert "dispatcher = BlockingDispatcher()" in text
+    assert "dcc_mcp_blender.start_server(port=8765, dispatcher=dispatcher)" in text
+    assert "host.start()" in text
+    assert "host.stop()" in text

--- a/tests/test_workflow_ci.py
+++ b/tests/test_workflow_ci.py
@@ -95,3 +95,10 @@ def test_e2e_workflow_uses_checked_in_ci_scripts():
     assert ".github/scripts/start_mcp_server2.py" in text
     assert "pytest.main" in runner
     assert "os._exit(main())" in runner
+
+
+def test_windows_e2e_targets_vs2026_runner_explicitly():
+    text = E2E_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "runner: windows-2025-vs2026" in text
+    assert "runner: windows-latest" not in text

--- a/tests/test_workflow_ci.py
+++ b/tests/test_workflow_ci.py
@@ -27,9 +27,8 @@ def test_mcporter_call_wrapper_fails_unknown_tools():
 def test_workflow_server_uses_blender_inprocess_dispatcher():
     text = E2E_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "from dcc_mcp_core.host import BlockingDispatcher" in text
-    assert "from dcc_mcp_blender.host import BlenderHost" in text
-    assert "dispatcher = BlockingDispatcher()" in text
+    assert "from dcc_mcp_blender.host import BlenderCallableDispatcher, BlenderHost" in text
+    assert "dispatcher = BlenderCallableDispatcher()" in text
     assert "dcc_mcp_blender.start_server(port=8765, dispatcher=dispatcher)" in text
     assert "host.start()" in text
     assert "host.stop()" in text

--- a/tests/test_workflow_ci.py
+++ b/tests/test_workflow_ci.py
@@ -1,0 +1,24 @@
+"""Regression checks for the Blender E2E workflow."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).parent.parent
+E2E_WORKFLOW = ROOT / ".github" / "workflows" / "e2e.yml"
+
+
+def test_mcporter_calls_use_registered_tool_names():
+    text = E2E_WORKFLOW.read_text(encoding="utf-8")
+
+    stale_prefixed_calls = re.findall(r"blender-ci\.blender_[a-z_]+__[a-z_]+", text)
+    assert stale_prefixed_calls == []
+
+
+def test_mcporter_call_wrapper_fails_unknown_tools():
+    text = E2E_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "call_tool() {" in text
+    assert '"code": "ACTION_NOT_FOUND"' in text
+    assert "Unknown tool" in text

--- a/tests/test_workflow_ci.py
+++ b/tests/test_workflow_ci.py
@@ -32,3 +32,11 @@ def test_workflow_server_uses_blender_inprocess_dispatcher():
     assert "dcc_mcp_blender.start_server(port=8765, dispatcher=dispatcher)" in text
     assert "host.start()" in text
     assert "host.stop()" in text
+
+
+def test_execute_python_smoke_call_avoids_shell_key_value_assignment():
+    text = E2E_WORKFLOW.read_text(encoding="utf-8")
+
+    execute_python_calls = re.findall(r"call_tool execute_python \\\s*\n\s*\"code:([^\"]+)\"", text)
+    assert execute_python_calls
+    assert all(" = " not in code for code in execute_python_calls)

--- a/tests/test_workflow_ci.py
+++ b/tests/test_workflow_ci.py
@@ -7,6 +7,10 @@ import re
 
 ROOT = pathlib.Path(__file__).parent.parent
 E2E_WORKFLOW = ROOT / ".github" / "workflows" / "e2e.yml"
+SCRIPTS_DIR = ROOT / ".github" / "scripts"
+RUN_BLENDER_E2E = SCRIPTS_DIR / "run_blender_e2e.py"
+RUN_DOCKER_E2E = SCRIPTS_DIR / "run_docker_blender_e2e.sh"
+START_MCP_SERVER = SCRIPTS_DIR / "start_mcp_server.py"
 
 
 def test_mcporter_calls_use_registered_tool_names():
@@ -27,8 +31,10 @@ def test_mcporter_call_wrapper_fails_unknown_tools():
 
 
 def test_workflow_server_uses_blender_inprocess_dispatcher():
-    text = E2E_WORKFLOW.read_text(encoding="utf-8")
+    workflow = E2E_WORKFLOW.read_text(encoding="utf-8")
+    text = START_MCP_SERVER.read_text(encoding="utf-8")
 
+    assert ".github/scripts/start_mcp_server.py" in workflow
     assert "from dcc_mcp_blender.host import BlenderCallableDispatcher, BlenderHost" in text
     assert "dispatcher = BlenderCallableDispatcher()" in text
     assert "dcc_mcp_blender.start_server(port=8765, dispatcher=dispatcher)" in text
@@ -50,3 +56,42 @@ def test_geometry_export_verification_reads_paths_from_environment():
     assert "export GEOM_BLEND GEOM_FBX GEOM_OBJ" in text
     assert "path = os.environ[key]" in text
     assert "('$GEOM_BLEND', '$GEOM_FBX', '$GEOM_OBJ')" not in text
+
+
+def test_e2e_workflow_does_not_run_mock_unit_tests():
+    text = E2E_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Run unit tests (system Python)" not in text
+    assert 'pytest tests/ -v --tb=short -m "not e2e and not packaging"' not in text
+
+
+def test_linux_e2e_runs_in_real_blender_docker_images():
+    text = E2E_WORKFLOW.read_text(encoding="utf-8")
+    docker_script = RUN_DOCKER_E2E.read_text(encoding="utf-8")
+
+    assert "e2e-linux-docker:" in text
+    assert "Run E2E tests in Blender Docker image" in text
+    assert ".github/scripts/run_docker_blender_e2e.sh" in text
+    assert '"$BLENDER_BIN" --background --python "$workspace/.github/scripts/run_blender_e2e.py"' in docker_script
+
+    images = re.findall(r'blender-image: "(linuxserver/blender:[^"]+)"', text)
+    assert images == [
+        "linuxserver/blender:4.4.3",
+        "linuxserver/blender:4.3.2",
+        "linuxserver/blender:4.2.0",
+        "linuxserver/blender:3.6.5",
+    ]
+
+
+def test_e2e_workflow_uses_checked_in_ci_scripts():
+    text = E2E_WORKFLOW.read_text(encoding="utf-8")
+    runner = RUN_BLENDER_E2E.read_text(encoding="utf-8")
+
+    assert "Write Docker E2E runner" not in text
+    assert "cat > /tmp/run_e2e.py" not in text
+    assert "cat > /tmp/start_mcp_server.py" not in text
+    assert "cat > /tmp/start_mcp_server2.py" not in text
+    assert ".github/scripts/run_blender_e2e.py" in text
+    assert ".github/scripts/start_mcp_server2.py" in text
+    assert "pytest.main" in runner
+    assert "os._exit(main())" in runner


### PR DESCRIPTION
## Summary

- Rebase the branch onto the latest remote `main`.
- Update the `dcc-mcp-core` floor to `>=0.17.6,<1.0.0` and keep packaging metadata aligned.
- Expand Blender host/skill coverage for geometry, viewport capture, world background lighting, structured scene/object inspection, and script execution behavior.

## Validation

- `python -m pytest`

## Notes

- E2E Blender tests remain CI-oriented and were not run locally.