### PR TITLE
ci: align blender core and skill lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Install ruff
         run: pip install ruff>=0.8.0
       - name: Ruff check
-        run: ruff check src/ tests/
+        run: ruff check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py
       - name: Ruff format check
-        run: ruff format --check src/ tests/
+        run: ruff format --check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py
 
   lint-skills:
     name: Lint SKILL.md files
@@ -38,9 +38,14 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install skill validation dependencies
-        run: pip install pyyaml "dcc-mcp-core>=0.17.6,<1.0.0"
+        run: pip install pyyaml "dcc-mcp-core>=0.17.8,<1.0.0"
+      - name: Install dcc-mcp-cli
+        run: |
+          export DCC_MCP_INSTALL_DIR="$RUNNER_TEMP/dcc-mcp-bin"
+          curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | bash
+          echo "$RUNNER_TEMP/dcc-mcp-bin" >> "$GITHUB_PATH"
       - name: Validate SKILL.md front-matter
-        run: python tests/test_lint_skills.py
+        run: python tools/lint_skills.py --warnings-as-errors
 
   test:
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: googleapis/release-please-action@v5
         id: release
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/justfile
+++ b/justfile
@@ -47,23 +47,19 @@ default:
 # Run ruff check on src/ and tests/
 @lint:
     echo "🔍 Running ruff lint check..."
-    python -m ruff check src/ tests/
+    python -m ruff check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py
     echo "✅ Lint check passed"
 
 # Auto-fix ruff errors
 @lint-fix:
     echo "🔧 Auto-fixing ruff errors..."
-    python -m ruff check --fix src/ tests/
+    python -m ruff check --fix src/ tests/ tools/lint_skills.py packaging/assemble_zip.py
     echo "✅ Lint errors fixed"
 
 # Lint SKILL.md files
 @lint-skills:
     echo "🔍 Linting SKILL.md files..."
-    @if [ -f "tools/lint_skills.py" ]; then \
-        python tools/lint_skills.py --error-only; \
-    else \
-        echo "⚠️  tools/lint_skills.py not found, skipping"; \
-    fi
+    python tools/lint_skills.py --warnings-as-errors
     echo "✅ SKILL.md lint passed"
 
 # Run all lint checks
@@ -75,14 +71,12 @@ lint-all: lint lint-skills
 # Usage: vx just prek   or   just prek
 @prek:
     echo "🔧 Auto-fixing ruff errors..."
-    python -m ruff check --fix src/ tests/
+    python -m ruff check --fix src/ tests/ tools/lint_skills.py packaging/assemble_zip.py
     echo "🎨 Formatting with ruff..."
-    python -m ruff format src/ tests/
+    python -m ruff format src/ tests/ tools/lint_skills.py packaging/assemble_zip.py
     echo "🔍 Running all lint checks..."
-    python -m ruff check src/ tests/
-    @if [ -f "tools/lint_skills.py" ]; then \
-        python tools/lint_skills.py --error-only; \
-    fi
+    python -m ruff check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py
+    python tools/lint_skills.py --warnings-as-errors
     echo "🧪 Running quick tests..."
     python -m pytest tests/ -x -q --ignore=tests/test_e2e_blender_standalone.py 2>/dev/null || python -m pytest tests/ -x -q
     echo "✅ prek passed — safe to commit"

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -45,7 +45,7 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.17.6"
+MIN_CORE_VERSION = "0.17.8"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ classifiers = [
 ]
 
 dependencies = [
-    # Align with dcc-mcp-core 0.17.6: DccServerOptions composition root,
+    # Align with dcc-mcp-core 0.17.8: DccServerOptions composition root,
     # HostExecutionBridge, diagnostics/resources contracts, gateway capability
     # index expectations, and current skill-management/search contracts.
-    "dcc-mcp-core>=0.17.6,<1.0.0",
+    "dcc-mcp-core>=0.17.8,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_blender/skills/blender-animation/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-animation/SKILL.md
@@ -9,7 +9,6 @@ metadata:
     version: "1.0.0"
     tags: [blender, animation, keyframes]
     search-hint: "keyframe, animation, frame range, action, timeline"
-    depends: []
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_blender/skills/blender-camera/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-camera/SKILL.md
@@ -9,7 +9,6 @@ metadata:
     version: "1.0.0"
     tags: [blender, camera, viewport]
     search-hint: "camera, lens, focal length, active camera, perspective"
-    depends: []
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_blender/skills/blender-collection/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-collection/SKILL.md
@@ -9,7 +9,6 @@ metadata:
     version: "1.0.0"
     tags: [blender, collection, hierarchy, organization]
     search-hint: "collection, group, organize, hierarchy"
-    depends: []
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_blender/skills/blender-geometry/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-geometry/SKILL.md
@@ -9,7 +9,6 @@ metadata:
     version: "1.0.0"
     tags: [blender, geometry, export, mesh]
     search-hint: "create sphere, save blend, export fbx, export obj, file exists"
-    depends: []
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_blender/skills/blender-lighting/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-lighting/SKILL.md
@@ -9,7 +9,6 @@ metadata:
     version: "1.0.0"
     tags: [blender, lighting, lights, world]
     search-hint: "create light, point, sun, area, spot, energy, color, world background, environment lighting"
-    depends: []
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_blender/skills/blender-materials/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-materials/SKILL.md
@@ -9,7 +9,6 @@ metadata:
     version: "1.0.0"
     tags: [blender, materials, shading]
     search-hint: "create material, assign, color, shader, PBR, list materials"
-    depends: []
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_blender/skills/blender-mesh/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-mesh/SKILL.md
@@ -9,7 +9,6 @@ metadata:
     version: "1.0.0"
     tags: [blender, mesh, modifier, geometry]
     search-hint: "modifier, subdivision, smooth, apply modifier, mesh edit"
-    depends: []
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_blender/skills/blender-objects/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-objects/SKILL.md
@@ -9,7 +9,6 @@ metadata:
     version: "1.0.0"
     tags: [blender, objects, transform]
     search-hint: "create object, delete, move, rotate, scale, duplicate, select"
-    depends: []
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_blender/skills/blender-render/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-render/SKILL.md
@@ -9,7 +9,6 @@ metadata:
     version: "1.0.0"
     tags: [blender, render, viewport, camera]
     search-hint: "render, viewport screenshot, output, resolution, camera, cycles, eevee"
-    depends: []
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_blender/skills/blender-scene/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-scene/SKILL.md
@@ -9,7 +9,6 @@ metadata:
     version: "1.0.0"
     tags: [blender, scene, hierarchy]
     search-hint: "new scene, open, save, list objects, hierarchy, scene info"
-    depends: []
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_blender/skills/blender-scripting/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-scripting/SKILL.md
@@ -9,7 +9,6 @@ metadata:
     version: "1.0.0"
     tags: [blender, scripting, python, automation]
     search-hint: "execute python, run script, blender python, bpy"
-    depends: []
     tools: tools.yaml
 ---
 

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -17,10 +17,10 @@ def _load_assemble_zip_module():
     return mod
 
 
-def test_core_dependency_floor_is_0176():
+def test_core_dependency_floor_is_0178():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert '"dcc-mcp-core>=0.17.6,<1.0.0"' in pyproject
+    assert '"dcc-mcp-core>=0.17.8,<1.0.0"' in pyproject
 
 
 def test_packaging_core_floor_matches_pyproject():

--- a/tests/test_lint_skills.py
+++ b/tests/test_lint_skills.py
@@ -2,98 +2,14 @@
 
 from __future__ import annotations
 
-import pathlib
 import sys
 
-import yaml
-from dcc_mcp_core import validate_skill
-
-SKILLS_DIR = pathlib.Path(__file__).parent.parent / "src" / "dcc_mcp_blender" / "skills"
-
-REQUIRED_FIELDS = {"name", "description", "metadata"}
-REQUIRED_DCC_MCP_FIELDS = {"dcc", "version", "tags", "search-hint", "tools"}
-REQUIRED_TOOL_FIELDS = {"name", "description", "source_file"}
-
-
-def _parse_front_matter(text: str) -> dict:
-    """Extract and parse YAML front-matter delimited by ``---``."""
-    lines = text.splitlines()
-    if not lines or lines[0].strip() != "---":
-        return {}
-    end = None
-    for i, line in enumerate(lines[1:], 1):
-        if line.strip() == "---":
-            end = i
-            break
-    if end is None:
-        return {}
-    return yaml.safe_load("\n".join(lines[1:end])) or {}
+from tools.lint_skills import lint_skills
 
 
 def test_all_skill_md_files():
     """Every skill directory must have a valid SKILL.md."""
-    errors = []
-
-    skill_dirs = [d for d in SKILLS_DIR.iterdir() if d.is_dir()]
-    assert skill_dirs, f"No skill directories found under {SKILLS_DIR}"
-
-    for skill_dir in sorted(skill_dirs):
-        skill_md = skill_dir / "SKILL.md"
-        if not skill_md.exists():
-            errors.append(f"{skill_dir.name}: missing SKILL.md")
-            continue
-
-        try:
-            front = _parse_front_matter(skill_md.read_text(encoding="utf-8"))
-        except yaml.YAMLError as e:
-            errors.append(f"{skill_dir.name}: YAML parse error: {e}")
-            continue
-
-        if not front:
-            errors.append(f"{skill_dir.name}: empty or missing front-matter")
-            continue
-
-        report = validate_skill(str(skill_dir))
-        if report.has_errors:
-            for issue in report.issues:
-                errors.append(f"{skill_dir.name}: {issue.category}: {issue.message}")
-
-        missing = REQUIRED_FIELDS - set(front.keys())
-        if missing:
-            errors.append(f"{skill_dir.name}: missing fields: {missing}")
-
-        dcc_mcp = front.get("metadata", {}).get("dcc-mcp", {})
-        missing_dcc_mcp = REQUIRED_DCC_MCP_FIELDS - set(dcc_mcp.keys())
-        if missing_dcc_mcp:
-            errors.append(f"{skill_dir.name}: missing metadata.dcc-mcp fields: {missing_dcc_mcp}")
-            continue
-
-        tools_file = skill_dir / str(dcc_mcp.get("tools", ""))
-        if not tools_file.exists():
-            errors.append(f"{skill_dir.name}: tools file not found: {dcc_mcp.get('tools')}")
-            continue
-
-        try:
-            tools_doc = yaml.safe_load(tools_file.read_text(encoding="utf-8")) or {}
-        except yaml.YAMLError as e:
-            errors.append(f"{skill_dir.name}: tools YAML parse error: {e}")
-            continue
-
-        tools = tools_doc.get("tools", [])
-        if not isinstance(tools, list) or not tools:
-            errors.append(f"{skill_dir.name}: tools file must contain a non-empty 'tools' list")
-            continue
-
-        for tool in tools:
-            missing_tool = REQUIRED_TOOL_FIELDS - set(tool.keys())
-            if missing_tool:
-                errors.append(f"{skill_dir.name}/{tool.get('name', '?')}: missing tool fields: {missing_tool}")
-
-            # Verify source file exists
-            source = skill_dir / tool.get("source_file", "")
-            if not source.exists():
-                errors.append(f"{skill_dir.name}: source_file not found: {tool.get('source_file')}")
-
+    errors = lint_skills()
     if errors:
         msg = "SKILL.md validation errors:\n" + "\n".join(f"  - {e}" for e in errors)
         assert False, msg

--- a/tools/lint_skills.py
+++ b/tools/lint_skills.py
@@ -1,0 +1,179 @@
+"""Validate bundled Blender skills against the current dcc-mcp-core contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+from typing import List, Optional
+
+import yaml
+from dcc_mcp_core import validate_skill
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+DEFAULT_SKILLS_DIR = ROOT / "src" / "dcc_mcp_blender" / "skills"
+
+REQUIRED_FIELDS = {"name", "description", "metadata"}
+REQUIRED_DCC_MCP_FIELDS = {"dcc", "version", "tags", "search-hint", "tools"}
+REQUIRED_TOOL_FIELDS = {"name", "description", "source_file"}
+
+
+def _find_dcc_mcp_cli() -> Optional[str]:
+    exe = shutil.which("dcc-mcp-cli")
+    if exe:
+        return exe
+    if sys.platform == "win32":
+        local_appdata = pathlib.Path.home() / "AppData" / "Local"
+        candidate = local_appdata / "dcc-mcp" / "bin" / "dcc-mcp-cli.exe"
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+def lint_skills_with_cli(skills_dir: pathlib.Path, warnings_as_errors: bool = False) -> Optional[List[str]]:
+    """Run the standalone dcc-mcp-cli skill linter when it is installed."""
+    cli = _find_dcc_mcp_cli()
+    if cli is None:
+        return None
+
+    cmd = [cli, "lint"]
+    if warnings_as_errors:
+        cmd.append("--warnings-as-errors")
+    cmd.append(str(skills_dir))
+    proc = subprocess.run(cmd, cwd=str(ROOT), check=False, capture_output=True, text=True)
+    output = (proc.stdout or proc.stderr).strip()
+    try:
+        payload = json.loads(output) if output else {}
+    except json.JSONDecodeError:
+        return [output or f"dcc-mcp-cli lint failed with exit code {proc.returncode}"] if proc.returncode else []
+
+    errors: List[str] = []
+    for report in payload.get("reports", []):
+        for issue in report.get("issues", []):
+            severity = issue.get("severity", "unknown")
+            if severity == "error" or warnings_as_errors:
+                errors.append(f"{report.get('skill_dir')}: {issue.get('category')}: {issue.get('message')}")
+
+    if proc.returncode != 0 and not errors:
+        errors.append(output or f"dcc-mcp-cli lint failed with exit code {proc.returncode}")
+    return errors
+
+
+def _parse_front_matter(text: str) -> dict:
+    """Extract and parse YAML front matter delimited by ``---``."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    end = None
+    for i, line in enumerate(lines[1:], 1):
+        if line.strip() == "---":
+            end = i
+            break
+    if end is None:
+        return {}
+    return yaml.safe_load("\n".join(lines[1:end])) or {}
+
+
+def lint_skills(
+    skills_dir: pathlib.Path = DEFAULT_SKILLS_DIR,
+    *,
+    use_cli: bool = True,
+    warnings_as_errors: bool = False,
+) -> List[str]:
+    """Return validation errors for all skill directories under *skills_dir*."""
+    if use_cli:
+        cli_errors = lint_skills_with_cli(skills_dir, warnings_as_errors=warnings_as_errors)
+        if cli_errors is not None:
+            return cli_errors
+
+    errors: List[str] = []
+    skill_dirs = [d for d in skills_dir.iterdir() if d.is_dir()]
+    if not skill_dirs:
+        return [f"No skill directories found under {skills_dir}"]
+
+    for skill_dir in sorted(skill_dirs):
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.exists():
+            errors.append(f"{skill_dir.name}: missing SKILL.md")
+            continue
+
+        try:
+            front = _parse_front_matter(skill_md.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            errors.append(f"{skill_dir.name}: YAML parse error: {exc}")
+            continue
+
+        if not front:
+            errors.append(f"{skill_dir.name}: empty or missing front matter")
+            continue
+
+        report = validate_skill(str(skill_dir))
+        if report.has_errors:
+            for issue in report.issues:
+                errors.append(f"{skill_dir.name}: {issue.category}: {issue.message}")
+
+        missing = REQUIRED_FIELDS - set(front.keys())
+        if missing:
+            errors.append(f"{skill_dir.name}: missing fields: {missing}")
+
+        dcc_mcp = front.get("metadata", {}).get("dcc-mcp", {})
+        missing_dcc_mcp = REQUIRED_DCC_MCP_FIELDS - set(dcc_mcp.keys())
+        if missing_dcc_mcp:
+            errors.append(f"{skill_dir.name}: missing metadata.dcc-mcp fields: {missing_dcc_mcp}")
+            continue
+
+        tools_file = skill_dir / str(dcc_mcp.get("tools", ""))
+        if not tools_file.exists():
+            errors.append(f"{skill_dir.name}: tools file not found: {dcc_mcp.get('tools')}")
+            continue
+
+        try:
+            tools_doc = yaml.safe_load(tools_file.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError as exc:
+            errors.append(f"{skill_dir.name}: tools YAML parse error: {exc}")
+            continue
+
+        tools = tools_doc.get("tools", [])
+        if not isinstance(tools, list) or not tools:
+            errors.append(f"{skill_dir.name}: tools file must contain a non-empty 'tools' list")
+            continue
+
+        for tool in tools:
+            missing_tool = REQUIRED_TOOL_FIELDS - set(tool.keys())
+            if missing_tool:
+                errors.append(f"{skill_dir.name}/{tool.get('name', '?')}: missing tool fields: {missing_tool}")
+
+            source = skill_dir / tool.get("source_file", "")
+            if not source.exists():
+                errors.append(f"{skill_dir.name}: source_file not found: {tool.get('source_file')}")
+
+    return errors
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skills-dir", type=pathlib.Path, default=DEFAULT_SKILLS_DIR)
+    parser.add_argument("--no-cli", action="store_true", help="Use the Python validator even when dcc-mcp-cli exists.")
+    parser.add_argument("--warnings-as-errors", action="store_true")
+    args = parser.parse_args(argv)
+
+    errors = lint_skills(
+        args.skills_dir,
+        use_cli=not args.no_cli,
+        warnings_as_errors=args.warnings_as_errors,
+    )
+    if errors:
+        print("SKILL.md validation errors:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print("All SKILL.md files are valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Align dcc-mcp-blender with dcc-mcp-core 0.17.8 across runtime dependency, packaging, and CI checks.
- Add a reusable skill lint wrapper that prefers the standalone dcc-mcp-cli and falls back to the core Python validator.
- Install dcc-mcp-cli in CI and run skill lint with warnings treated as errors.
- Remove empty depends declarations from bundled Blender skills so CLI lint is clean.
- Add a release-please token fallback to keep release automation working without a PAT secret.

## Validation
- dcc-mcp-cli --output pretty lint --warnings-as-errors src\dcc_mcp_blender\skills
- python tools\lint_skills.py --warnings-as-errors
- python tools\lint_skills.py --no-cli --warnings-as-errors
- ruff check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py
- ruff format --check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py
- pytest tests/ -v --tb=short -m "not e2e and not packaging"
- python packaging\assemble_zip.py --platform linux --output-dir dist_addon_test
