### PR TITLE
feat: expand blender mcp skills

### DIFF
--- a/.github/scripts/start_mcp_server.py
+++ b/.github/scripts/start_mcp_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 import time
 
 try:
@@ -20,7 +21,6 @@ def main() -> None:
     dispatcher = BlenderCallableDispatcher()
     host = BlenderHost(dispatcher)
     server = dcc_mcp_blender.start_server(port=8765, dispatcher=dispatcher)
-    host.start()
     print(f"MCP server started at {server.mcp_url}", flush=True)
 
     for skill in server.list_skills():
@@ -35,12 +35,19 @@ def main() -> None:
     print(f"All skills: {[s.get('name', '?') for s in server.list_skills()]}", flush=True)
 
     sentinel = os.path.join(os.environ.get("RUNNER_TEMP", "/tmp"), "mcp_test_done")
-    try:
+    stop_event = threading.Event()
+
+    def _watch_sentinel() -> None:
         while not os.path.exists(sentinel):
             time.sleep(1)
+        stop_event.set()
+
+    threading.Thread(target=_watch_sentinel, name="mcp-sentinel", daemon=True).start()
+    try:
+        host.run_headless(stop_event=stop_event)
     finally:
-        host.stop()
         dcc_mcp_blender.stop_server()
+        host.stop()
         print("MCP server stopped.", flush=True)
 
 

--- a/.github/scripts/start_mcp_server2.py
+++ b/.github/scripts/start_mcp_server2.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 import time
 
 try:
@@ -19,7 +20,6 @@ def main() -> None:
     dispatcher = BlenderCallableDispatcher()
     host = BlenderHost(dispatcher)
     server = dcc_mcp_blender.start_server(port=0, dispatcher=dispatcher)
-    host.start()
     print(f"Second instance MCP URL: {server.mcp_url}", flush=True)
 
     url_path = os.path.join(os.environ.get("RUNNER_TEMP", "/tmp"), "mcp_server2_url")
@@ -27,12 +27,19 @@ def main() -> None:
         handle.write(server.mcp_url)
 
     sentinel = os.path.join(os.environ.get("RUNNER_TEMP", "/tmp"), "mcp_test2_done")
-    try:
+    stop_event = threading.Event()
+
+    def _watch_sentinel() -> None:
         while not os.path.exists(sentinel):
             time.sleep(1)
+        stop_event.set()
+
+    threading.Thread(target=_watch_sentinel, name="mcp-sentinel-2", daemon=True).start()
+    try:
+        host.run_headless(stop_event=stop_event)
     finally:
-        host.stop()
         dcc_mcp_blender.stop_server()
+        host.stop()
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,13 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install skill validation dependencies
-        run: pip install pyyaml "dcc-mcp-core>=0.17.8,<1.0.0"
+        run: python -m pip install -e ".[dev]"
       - name: Install dcc-mcp-cli
         run: |
           export DCC_MCP_INSTALL_DIR="$RUNNER_TEMP/dcc-mcp-bin"
           curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | bash
           echo "$RUNNER_TEMP/dcc-mcp-bin" >> "$GITHUB_PATH"
-      - name: Validate SKILL.md front-matter
+      - name: Validate SKILL.md and tool metadata
         run: python tools/lint_skills.py --warnings-as-errors
 
   test:
@@ -140,9 +140,9 @@ jobs:
           triple = [n for n in names if "dcc_mcp_blender/dcc_mcp_blender/dcc_mcp_blender/" in n]
           assert not triple, f"unexpected triple-nested paths: {triple[:5]}"
           skill_md = [n for n in names if n.endswith("/SKILL.md") and "/skills/" in n]
-          assert len(skill_md) >= 10, f"expected >=10 SKILL.md under skills/, got {len(skill_md)}"
+          assert len(skill_md) >= 13, f"expected >=13 SKILL.md under skills/, got {len(skill_md)}"
           tools_yaml = [n for n in names if n.endswith("/tools.yaml") and "/skills/" in n]
-          assert len(tools_yaml) >= 10, f"expected >=10 tools.yaml under skills/, got {len(tools_yaml)}"
+          assert len(tools_yaml) >= 13, f"expected >=13 tools.yaml under skills/, got {len(tools_yaml)}"
           with zipfile.ZipFile(zips[-1]) as zf:
               raw = zf.read("dcc_mcp_blender/blender_manifest.toml").decode("utf-8")
           assert "wheels = [" in raw and "./wheels/" in raw, raw[:400]

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -375,6 +375,28 @@ jobs:
           call_tool create_material \
             name:mcporterMat
 
+          # ── 7b. Shader nodes, geometry nodes, and physics ───────────────────
+          call_tool list_material_nodes \
+            material_name:mcporterMat
+
+          call_tool set_principled_input \
+            material_name:mcporterMat input_name:Metallic value:0.35
+
+          call_tool add_geometry_nodes_modifier \
+            object_name:mcporterCube name:mcporterGeoNodes group_name:mcporterGeoGroup
+
+          call_tool list_geometry_nodes_modifiers \
+            object_name:mcporterCube
+
+          call_tool add_rigid_body \
+            object_name:mcporterCube mass:2.0 collision_shape:BOX
+
+          call_tool set_rigid_body_properties \
+            object_name:mcporterCube mass:3.0 friction:0.2
+
+          call_tool remove_rigid_body \
+            object_name:mcporterCube
+
           # ── 8. Python scripting (execute arbitrary Blender Python) ──────────
           call_tool execute_python \
             "code:import bpy; bpy.ops.mesh.primitive_cone_add()"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![GitHub release downloads](https://img.shields.io/github/downloads/loonghao/dcc-mcp-blender/total.svg?label=release%20downloads)](https://github.com/loonghao/dcc-mcp-blender/releases)
 [![GitHub Release](https://img.shields.io/github/v/release/loonghao/dcc-mcp-blender.svg)](https://github.com/loonghao/dcc-mcp-blender/releases)
 [![Coverage](https://img.shields.io/badge/coverage-pytest--cov-blue.svg)](https://github.com/loonghao/dcc-mcp-blender/blob/main/pyproject.toml)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.6-blue.svg)](https://github.com/loonghao/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.25-blue.svg)](https://github.com/loonghao/dcc-mcp-core)
 [![Blender](https://img.shields.io/badge/Blender-3.6%20LTS%20%7C%204.2%20LTS%20%7C%204.3%20%7C%204.4-orange.svg)](https://www.blender.org/download/releases/)
 [![MCP](https://img.shields.io/badge/MCP-2025--03--26-purple.svg)](https://modelcontextprotocol.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -29,7 +29,7 @@
 ├─────────────────────────────────┤
 │  dcc_mcp_blender                │
 │  ├─ BlenderMcpServer            │
-│  ├─ SkillCatalog (50+ skills)   │
+│  ├─ SkillCatalog (55+ tools)    │
 │  ├─ ActionRegistry              │
 │  └─ HTTP Handlers               │
 ├─────────────────────────────────┤
@@ -49,7 +49,7 @@
 ## Features
 
 - **Embedded MCP server** — no external gateway needed; the server runs inside Blender's Python interpreter
-- **50+ pre-built skills** — scene management, object manipulation, materials, rendering, scripting and more
+- **55+ pre-built tools** — scene management, object manipulation, materials, rendering, nodes, physics, scripting and more
 - **Extensible skill system** — drop new skill folders alongside built-ins or point to them via env vars
 - **Main-thread host adapter** — `BlenderHost` drives dispatcher ticks through `bpy.app.timers` or a background loop
 - **Streamable HTTP transport** — compatible with any MCP 2025-03-26 client
@@ -62,16 +62,19 @@
 | Category | Tools |
 |---|---|
 | **blender-scene** | `new_scene`, `open_scene`, `save_scene`, `list_objects`, `get_scene_info`, `get_session_info` |
-| **blender-objects** | `create_object`, `delete_object`, `duplicate_object`, `move_object`, `rotate_object`, `scale_object`, `list_objects` |
-| **blender-mesh** | `create_mesh`, `apply_modifier`, `subdivide_mesh`, `extrude_faces`, `merge_vertices` |
+| **blender-objects** | `create_object`, `delete_object`, `duplicate_object`, `move_object`, `rotate_object`, `scale_object`, `get_object_info` |
+| **blender-mesh** | `add_modifier`, `apply_modifier`, `list_modifiers`, `get_mesh_info` |
 | **blender-materials** | `create_material`, `assign_material`, `set_material_color`, `list_materials`, `delete_material` |
-| **blender-render** | `render_scene`, `set_render_settings`, `set_camera`, `get_render_info` |
+| **blender-shader-nodes** | `list_material_nodes`, `set_principled_input` |
+| **blender-render** | `render_scene`, `set_render_settings`, `get_render_info`, `capture_viewport` |
 | **blender-scripting** | `execute_python`, `execute_script_file`, `get_blender_info` |
-| **blender-animation** | `set_keyframe`, `delete_keyframe`, `set_frame_range`, `get_frame_range`, `bake_action` |
-| **blender-lighting** | `create_light`, `delete_light`, `set_light_properties`, `list_lights` |
+| **blender-animation** | `set_keyframe`, `set_frame_range`, `get_frame_range`, `set_current_frame` |
+| **blender-lighting** | `create_light`, `set_light_properties`, `list_lights`, `set_world_background` |
 | **blender-camera** | `create_camera`, `set_active_camera`, `set_camera_properties`, `list_cameras` |
-| **blender-collection** | `create_collection`, `link_to_collection`, `unlink_from_collection`, `list_collections` |
+| **blender-collection** | `create_collection`, `link_to_collection`, `list_collections` |
 | **blender-geometry** | `create_sphere`, `save_blend`, `file_exists`, `export_fbx`, `export_obj` |
+| **blender-geometry-nodes** | `add_geometry_nodes_modifier`, `list_geometry_nodes_modifiers` |
+| **blender-physics** | `add_rigid_body`, `set_rigid_body_properties`, `remove_rigid_body` |
 
 ---
 

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -45,7 +45,7 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.17.8"
+MIN_CORE_VERSION = "0.17.25"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ classifiers = [
 ]
 
 dependencies = [
-    # Align with dcc-mcp-core 0.17.8: DccServerOptions composition root,
+    # Align with dcc-mcp-core 0.17.25: DccServerOptions composition root,
     # HostExecutionBridge, diagnostics/resources contracts, gateway capability
-    # index expectations, and current skill-management/search contracts.
-    "dcc-mcp-core>=0.17.8,<1.0.0",
+    # index expectations, and current skill-management/search/lint contracts.
+    "dcc-mcp-core>=0.17.25,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_blender/host.py
+++ b/src/dcc_mcp_blender/host.py
@@ -16,6 +16,11 @@ class BlenderCallableDispatcher:
     def __init__(self, dispatcher: Optional[BlockingDispatcher] = None) -> None:
         self._dispatcher = dispatcher or BlockingDispatcher()
 
+    @property
+    def host_dispatcher(self) -> BlockingDispatcher:
+        """Return the core dispatcher that backs HTTP main-thread routing."""
+        return self._dispatcher
+
     def dispatch_callable(
         self,
         func: Callable[..., Any],
@@ -52,6 +57,27 @@ class BlenderCallableDispatcher:
     def is_shutdown(self) -> bool:
         """Return whether the underlying dispatcher is shut down."""
         return bool(self._dispatcher.is_shutdown())
+
+
+class BlenderInlineCallableDispatcher:
+    """Callable bridge used after the core dispatcher owns the main-thread hop."""
+
+    def __init__(self, host_dispatcher: Any) -> None:
+        self._host_dispatcher = host_dispatcher
+
+    def dispatch_callable(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Execute ``func`` inline once HTTP has dispatched onto Blender's thread."""
+        return func(*args, **kwargs)
+
+    def shutdown(self, reason: str = "Interrupted") -> Any:
+        """Forward shutdown to the underlying host dispatcher when supported."""
+        shutdown = getattr(self._host_dispatcher, "shutdown", None)
+        if not callable(shutdown):
+            return None
+        try:
+            return shutdown(reason)
+        except TypeError:
+            return shutdown()
 
 
 class BlenderHost(HostAdapter):

--- a/src/dcc_mcp_blender/server.py
+++ b/src/dcc_mcp_blender/server.py
@@ -27,11 +27,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from dcc_mcp_core import DccServerOptions
+from dcc_mcp_core import DccServerOptions, HostExecutionBridge
 from dcc_mcp_core.server_base import DccServerBase
 
 from dcc_mcp_blender import _env
 from dcc_mcp_blender.__version__ import __version__
+from dcc_mcp_blender.host import BlenderInlineCallableDispatcher
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,21 @@ _ENV_EXTRA_SKILL_PATHS = "DCC_MCP_BLENDER_SKILL_PATHS"
 _ENV_GENERIC_SKILL_PATHS = "DCC_MCP_SKILL_PATHS"
 
 _DCC_NAME = "blender"
+
+
+def _is_host_queue_dispatcher(dispatcher: Any) -> bool:
+    """Return True for core QueueDispatcher / BlockingDispatcher-like objects."""
+    return callable(getattr(dispatcher, "post", None)) and callable(getattr(dispatcher, "tick", None))
+
+
+def _host_dispatcher_from(dispatcher: Any) -> Any | None:
+    """Resolve the core host dispatcher hidden behind adapter wrappers."""
+    if _is_host_queue_dispatcher(dispatcher):
+        return dispatcher
+    host_dispatcher = getattr(dispatcher, "host_dispatcher", None)
+    if host_dispatcher is not None and _is_host_queue_dispatcher(host_dispatcher):
+        return host_dispatcher
+    return None
 
 
 # ── options ─────────────────────────────────────────────────────────────────
@@ -83,6 +99,22 @@ class BlenderServerOptions:
 
     def to_core_options(self) -> DccServerOptions:
         """Convert to core DccServerOptions using from_env()."""
+        dispatcher = self.dispatcher
+        execution_bridge = self.execution_bridge
+        if execution_bridge is None and dispatcher is not None:
+            host_dispatcher = _host_dispatcher_from(dispatcher)
+            bridge_dispatcher = (
+                BlenderInlineCallableDispatcher(host_dispatcher) if host_dispatcher is not None else dispatcher
+            )
+            execution_bridge = HostExecutionBridge(
+                dispatcher=bridge_dispatcher,
+                host_dispatcher=host_dispatcher,
+                default_thread_affinity="main",
+            )
+            dispatcher = None
+        elif execution_bridge is not None:
+            dispatcher = None
+
         return DccServerOptions.from_env(
             dcc_name=_DCC_NAME,
             builtin_skills_dir=_BUILTIN_SKILLS_DIR,
@@ -105,8 +137,8 @@ class BlenderServerOptions:
             dcc_window_handle=self.dcc_window_handle,
             snapshot_provider=self.snapshot_provider,
             # Execution kwargs (new in 0.17+)
-            dispatcher=self.dispatcher,
-            execution_bridge=self.execution_bridge,
+            dispatcher=dispatcher,
+            execution_bridge=execution_bridge,
         )
 
 

--- a/src/dcc_mcp_blender/skills/blender-animation/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-animation/tools.yaml
@@ -2,24 +2,32 @@ tools:
   - name: set_keyframe
     description: "Insert a keyframe on an object at the current or specified frame"
     source_file: scripts/set_keyframe.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false
   - name: set_frame_range
     description: "Set the animation frame range (start and end frames)"
     source_file: scripts/set_frame_range.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: true
   - name: get_frame_range
     description: "Get the current animation frame range"
     source_file: scripts/get_frame_range.py
+    execution: sync
+    affinity: main
     read_only: true
     destructive: false
     idempotent: true
   - name: set_current_frame
     description: "Set the current animation frame"
     source_file: scripts/set_current_frame.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-camera/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-camera/tools.yaml
@@ -2,24 +2,32 @@ tools:
   - name: create_camera
     description: "Create a new camera object"
     source_file: scripts/create_camera.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false
   - name: set_active_camera
     description: "Set the active render camera for the scene"
     source_file: scripts/set_active_camera.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: true
   - name: set_camera_properties
     description: "Configure camera properties (focal length, type, etc.)"
     source_file: scripts/set_camera_properties.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: true
   - name: list_cameras
     description: "List all cameras in the scene"
     source_file: scripts/list_cameras.py
+    execution: sync
+    affinity: main
     read_only: true
     destructive: false
     idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-collection/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-collection/tools.yaml
@@ -2,18 +2,24 @@ tools:
   - name: create_collection
     description: "Create a new collection in the scene"
     source_file: scripts/create_collection.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false
   - name: link_to_collection
     description: "Link an object to a collection"
     source_file: scripts/link_to_collection.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: true
   - name: list_collections
     description: "List all collections in the scene"
     source_file: scripts/list_collections.py
+    execution: sync
+    affinity: main
     read_only: true
     destructive: false
     idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-geometry-nodes/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-geometry-nodes/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: blender-geometry-nodes
+description: "Blender geometry nodes modifier tools for procedural object workflows"
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, geometry-nodes, procedural, modifiers]
+    search-hint: "geometry nodes modifier, procedural nodes, node group, list geometry nodes"
+    tools: tools.yaml
+---
+
+# blender-geometry-nodes
+
+Tools for adding and inspecting Geometry Nodes modifiers on scene objects.

--- a/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/add_geometry_nodes_modifier.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/add_geometry_nodes_modifier.py
@@ -1,0 +1,62 @@
+"""Add a Geometry Nodes modifier to a Blender mesh object."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def add_geometry_nodes_modifier(
+    object_name: str,
+    name: str = "Geometry Nodes",
+    group_name: Optional[str] = None,
+    create_node_group: bool = True,
+) -> dict:
+    """Add a Geometry Nodes modifier and optionally attach a node group."""
+    try:
+        import bpy
+
+        obj = bpy.data.objects.get(object_name)
+        if obj is None:
+            return skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+        if obj.type != "MESH":
+            return skill_error(
+                f"{object_name} is not a mesh",
+                f"Geometry Nodes modifiers are currently supported for MESH objects, got {obj.type}.",
+            )
+
+        bpy.context.view_layer.objects.active = obj
+        modifier = obj.modifiers.new(name=name, type="NODES")
+
+        node_group = None
+        if create_node_group or group_name:
+            wanted_group_name = group_name or f"{object_name} Geometry Nodes"
+            node_group = bpy.data.node_groups.get(wanted_group_name)
+            if node_group is None:
+                node_group = bpy.data.node_groups.new(wanted_group_name, "GeometryNodeTree")
+            modifier.node_group = node_group
+
+        return skill_success(
+            f"Added Geometry Nodes modifier to {object_name}",
+            object_name=object_name,
+            modifier_name=modifier.name,
+            node_group=getattr(node_group, "name", None),
+            prompt="Use list_geometry_nodes_modifiers to inspect procedural modifiers on this object.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to add Geometry Nodes modifier to {object_name}")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`add_geometry_nodes_modifier`."""
+    return add_geometry_nodes_modifier(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/list_geometry_nodes_modifiers.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/list_geometry_nodes_modifiers.py
@@ -1,0 +1,54 @@
+"""List Geometry Nodes modifiers on a Blender object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def list_geometry_nodes_modifiers(object_name: str) -> dict:
+    """Return Geometry Nodes modifiers attached to an object."""
+    try:
+        import bpy
+
+        obj = bpy.data.objects.get(object_name)
+        if obj is None:
+            return skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+
+        modifiers = []
+        for modifier in obj.modifiers:
+            if modifier.type != "NODES":
+                continue
+            node_group = getattr(modifier, "node_group", None)
+            modifiers.append(
+                {
+                    "name": modifier.name,
+                    "type": modifier.type,
+                    "node_group": getattr(node_group, "name", None),
+                    "show_viewport": modifier.show_viewport,
+                    "show_render": modifier.show_render,
+                }
+            )
+
+        return skill_success(
+            f"Found {len(modifiers)} Geometry Nodes modifiers on {object_name}",
+            object_name=object_name,
+            modifiers=modifiers,
+            count=len(modifiers),
+            prompt="Use blender-shader-nodes or blender-mesh tools to continue procedural scene work.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to list Geometry Nodes modifiers on {object_name}")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_geometry_nodes_modifiers`."""
+    return list_geometry_nodes_modifiers(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-geometry-nodes/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-geometry-nodes/tools.yaml
@@ -1,0 +1,17 @@
+tools:
+  - name: add_geometry_nodes_modifier
+    description: "Add a Geometry Nodes modifier to a mesh object"
+    source_file: scripts/add_geometry_nodes_modifier.py
+    execution: sync
+    affinity: main
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: list_geometry_nodes_modifiers
+    description: "List Geometry Nodes modifiers on an object"
+    source_file: scripts/list_geometry_nodes_modifiers.py
+    execution: sync
+    affinity: main
+    read_only: true
+    destructive: false
+    idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-geometry/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-geometry/tools.yaml
@@ -3,6 +3,7 @@ tools:
     description: "Create a UV sphere in the Blender scene"
     source_file: scripts/create_sphere.py
     execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false
@@ -10,6 +11,7 @@ tools:
     description: "Save the current Blender file"
     source_file: scripts/save_blend.py
     execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false
@@ -17,6 +19,7 @@ tools:
     description: "Check whether a file exists and report its size"
     source_file: scripts/file_exists.py
     execution: sync
+    affinity: any
     read_only: true
     destructive: false
     idempotent: true
@@ -24,6 +27,7 @@ tools:
     description: "Export the current scene to FBX"
     source_file: scripts/export_fbx.py
     execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false
@@ -31,6 +35,7 @@ tools:
     description: "Export the current scene to OBJ"
     source_file: scripts/export_obj.py
     execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false

--- a/src/dcc_mcp_blender/skills/blender-lighting/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-lighting/tools.yaml
@@ -2,24 +2,32 @@ tools:
   - name: create_light
     description: "Create a new light object (POINT, SUN, AREA, SPOT)"
     source_file: scripts/create_light.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false
   - name: set_light_properties
     description: "Set energy, color, and other light properties"
     source_file: scripts/set_light_properties.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: true
   - name: list_lights
     description: "List all lights in the current scene"
     source_file: scripts/list_lights.py
+    execution: sync
+    affinity: main
     read_only: true
     destructive: false
     idempotent: true
   - name: set_world_background
     description: "Set the scene world background color and optional strength"
     source_file: scripts/set_world_background.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-materials/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-materials/tools.yaml
@@ -2,30 +2,40 @@ tools:
   - name: create_material
     description: "Create a new Principled BSDF material"
     source_file: scripts/create_material.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false
   - name: assign_material
     description: "Assign a material to an object"
     source_file: scripts/assign_material.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: true
   - name: set_material_color
     description: "Set the base color of a material"
     source_file: scripts/set_material_color.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: true
   - name: list_materials
     description: "List all materials in the current scene"
     source_file: scripts/list_materials.py
+    execution: sync
+    affinity: main
     read_only: true
     destructive: false
     idempotent: true
   - name: delete_material
     description: "Delete a material"
     source_file: scripts/delete_material.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: true
     idempotent: false

--- a/src/dcc_mcp_blender/skills/blender-mesh/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-mesh/tools.yaml
@@ -2,24 +2,32 @@ tools:
   - name: add_modifier
     description: "Add a modifier to a mesh object (Subdivision, Mirror, Array, etc.)"
     source_file: scripts/add_modifier.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false
   - name: apply_modifier
     description: "Apply (bake) a modifier permanently to the mesh"
     source_file: scripts/apply_modifier.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: true
     idempotent: false
   - name: list_modifiers
     description: "List all modifiers on an object"
     source_file: scripts/list_modifiers.py
+    execution: sync
+    affinity: main
     read_only: true
     destructive: false
     idempotent: true
   - name: get_mesh_info
     description: "Get vertex, edge, and face count of a mesh"
     source_file: scripts/get_mesh_info.py
+    execution: sync
+    affinity: main
     read_only: true
     destructive: false
     idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-objects/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-objects/tools.yaml
@@ -2,42 +2,56 @@ tools:
   - name: create_object
     description: "Create a new Blender object (mesh primitive, empty, etc.)"
     source_file: scripts/create_object.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false
   - name: delete_object
     description: "Delete an object from the scene"
     source_file: scripts/delete_object.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: true
     idempotent: false
   - name: duplicate_object
     description: "Duplicate an existing object"
     source_file: scripts/duplicate_object.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false
   - name: move_object
     description: "Move an object to a specified location"
     source_file: scripts/move_object.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: true
   - name: rotate_object
     description: "Rotate an object by Euler angles (degrees)"
     source_file: scripts/rotate_object.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: true
   - name: scale_object
     description: "Scale an object"
     source_file: scripts/scale_object.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: true
   - name: get_object_info
     description: "Get detailed information about an object"
     source_file: scripts/get_object_info.py
+    execution: sync
+    affinity: main
     read_only: true
     destructive: false
     idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-physics/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-physics/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: blender-physics
+description: "Blender rigid body physics tools for scene simulation setup"
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, physics, rigid-body, simulation]
+    search-hint: "rigid body, physics, collision shape, mass, friction, restitution"
+    tools: tools.yaml
+---
+
+# blender-physics
+
+Rigid body setup tools for AI-assisted simulation-ready scene assembly.

--- a/src/dcc_mcp_blender/skills/blender-physics/scripts/add_rigid_body.py
+++ b/src/dcc_mcp_blender/skills/blender-physics/scripts/add_rigid_body.py
@@ -1,0 +1,99 @@
+"""Add rigid body physics to a Blender object."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+SUPPORTED_BODY_TYPES = {"ACTIVE", "PASSIVE"}
+NUMERIC_PROPERTIES = {"mass", "friction", "restitution"}
+
+
+def _activate_object(bpy, obj) -> None:
+    try:
+        bpy.ops.object.select_all(action="DESELECT")
+    except Exception:
+        pass
+    try:
+        obj.select_set(True)
+    except Exception:
+        pass
+    bpy.context.view_layer.objects.active = obj
+
+
+def _apply_properties(rigid_body, properties: Dict[str, Any]) -> None:
+    for key, value in properties.items():
+        if value is not None and hasattr(rigid_body, key):
+            if key in NUMERIC_PROPERTIES:
+                value = float(value)
+            setattr(rigid_body, key, value)
+
+
+def add_rigid_body(
+    object_name: str,
+    body_type: str = "ACTIVE",
+    mass: float = 1.0,
+    friction: float = 0.5,
+    restitution: float = 0.0,
+    collision_shape: str = "CONVEX_HULL",
+    properties: Optional[Dict[str, Any]] = None,
+) -> dict:
+    """Add rigid body physics to an object."""
+    try:
+        import bpy
+
+        obj = bpy.data.objects.get(object_name)
+        if obj is None:
+            return skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+
+        normalized_type = body_type.upper()
+        if normalized_type not in SUPPORTED_BODY_TYPES:
+            return skill_error(
+                f"Unsupported rigid body type: {body_type}",
+                f"Expected one of {sorted(SUPPORTED_BODY_TYPES)}.",
+            )
+
+        _activate_object(bpy, obj)
+        if getattr(obj, "rigid_body", None) is None:
+            bpy.ops.rigidbody.object_add(type=normalized_type)
+
+        rigid_body = getattr(obj, "rigid_body", None)
+        if rigid_body is None:
+            return skill_error(f"Rigid body was not created for {object_name}", "Blender did not attach a rigid body.")
+
+        updates = {
+            "type": normalized_type,
+            "mass": mass,
+            "friction": friction,
+            "restitution": restitution,
+            "collision_shape": collision_shape,
+        }
+        if properties:
+            updates.update(properties)
+        _apply_properties(rigid_body, updates)
+
+        return skill_success(
+            f"Added {normalized_type} rigid body to {object_name}",
+            object_name=object_name,
+            body_type=getattr(rigid_body, "type", normalized_type),
+            mass=getattr(rigid_body, "mass", mass),
+            collision_shape=getattr(rigid_body, "collision_shape", collision_shape),
+            prompt="Use set_rigid_body_properties to tune simulation behavior.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to add rigid body to {object_name}")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`add_rigid_body`."""
+    return add_rigid_body(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-physics/scripts/remove_rigid_body.py
+++ b/src/dcc_mcp_blender/skills/blender-physics/scripts/remove_rigid_body.py
@@ -1,0 +1,54 @@
+"""Remove rigid body physics from a Blender object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def _activate_object(bpy, obj) -> None:
+    try:
+        bpy.ops.object.select_all(action="DESELECT")
+    except Exception:
+        pass
+    try:
+        obj.select_set(True)
+    except Exception:
+        pass
+    bpy.context.view_layer.objects.active = obj
+
+
+def remove_rigid_body(object_name: str) -> dict:
+    """Remove rigid body physics from an object."""
+    try:
+        import bpy
+
+        obj = bpy.data.objects.get(object_name)
+        if obj is None:
+            return skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+        if getattr(obj, "rigid_body", None) is None:
+            return skill_error(f"{object_name} has no rigid body", "Nothing to remove.")
+
+        _activate_object(bpy, obj)
+        bpy.ops.rigidbody.object_remove()
+
+        return skill_success(
+            f"Removed rigid body from {object_name}",
+            object_name=object_name,
+            prompt="Use add_rigid_body to set up a new simulation body.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to remove rigid body from {object_name}")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`remove_rigid_body`."""
+    return remove_rigid_body(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-physics/scripts/set_rigid_body_properties.py
+++ b/src/dcc_mcp_blender/skills/blender-physics/scripts/set_rigid_body_properties.py
@@ -1,0 +1,79 @@
+"""Update rigid body physics properties on a Blender object."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+NUMERIC_PROPERTIES = {"mass", "friction", "restitution", "linear_damping", "angular_damping"}
+
+
+def set_rigid_body_properties(
+    object_name: str,
+    body_type: Optional[str] = None,
+    mass: Optional[float] = None,
+    friction: Optional[float] = None,
+    restitution: Optional[float] = None,
+    linear_damping: Optional[float] = None,
+    angular_damping: Optional[float] = None,
+    collision_shape: Optional[str] = None,
+    properties: Optional[Dict[str, Any]] = None,
+) -> dict:
+    """Update rigid body settings on an object."""
+    try:
+        import bpy
+
+        obj = bpy.data.objects.get(object_name)
+        if obj is None:
+            return skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+
+        rigid_body = getattr(obj, "rigid_body", None)
+        if rigid_body is None:
+            return skill_error(f"{object_name} has no rigid body", "Call add_rigid_body first.")
+
+        updates = {
+            "type": body_type.upper() if isinstance(body_type, str) else body_type,
+            "mass": mass,
+            "friction": friction,
+            "restitution": restitution,
+            "linear_damping": linear_damping,
+            "angular_damping": angular_damping,
+            "collision_shape": collision_shape,
+        }
+        if properties:
+            updates.update(properties)
+
+        applied = {}
+        for key, value in updates.items():
+            if value is None:
+                continue
+            if not hasattr(rigid_body, key):
+                continue
+            if key in NUMERIC_PROPERTIES:
+                value = float(value)
+            setattr(rigid_body, key, value)
+            applied[key] = value
+
+        return skill_success(
+            f"Updated rigid body on {object_name}",
+            object_name=object_name,
+            applied=applied,
+            prompt="Use Blender playback or render tools to inspect the simulation setup.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to update rigid body on {object_name}")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_rigid_body_properties`."""
+    return set_rigid_body_properties(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-physics/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-physics/tools.yaml
@@ -1,0 +1,25 @@
+tools:
+  - name: add_rigid_body
+    description: "Add a rigid body physics component to an object"
+    source_file: scripts/add_rigid_body.py
+    execution: sync
+    affinity: main
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: set_rigid_body_properties
+    description: "Update rigid body physics properties on an object"
+    source_file: scripts/set_rigid_body_properties.py
+    execution: sync
+    affinity: main
+    read_only: false
+    destructive: false
+    idempotent: true
+  - name: remove_rigid_body
+    description: "Remove rigid body physics from an object"
+    source_file: scripts/remove_rigid_body.py
+    execution: sync
+    affinity: main
+    read_only: false
+    destructive: true
+    idempotent: false

--- a/src/dcc_mcp_blender/skills/blender-render/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-render/tools.yaml
@@ -2,24 +2,32 @@ tools:
   - name: render_scene
     description: "Render the current scene and save to a file"
     source_file: scripts/render_scene.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false
   - name: set_render_settings
     description: "Configure render settings (engine, resolution, samples, output path)"
     source_file: scripts/set_render_settings.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: true
   - name: get_render_info
     description: "Return current render settings"
     source_file: scripts/get_render_info.py
+    execution: sync
+    affinity: main
     read_only: true
     destructive: false
     idempotent: true
   - name: capture_viewport
     description: "Capture the active viewport to an image file"
     source_file: scripts/capture_viewport.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false

--- a/src/dcc_mcp_blender/skills/blender-scene/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-scene/tools.yaml
@@ -2,36 +2,48 @@ tools:
   - name: new_scene
     description: "Create a new empty Blender scene"
     source_file: scripts/new_scene.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: true
     idempotent: false
   - name: save_scene
     description: "Save the current Blender scene"
     source_file: scripts/save_scene.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: true
   - name: open_scene
     description: "Open a Blender scene file (.blend) from disk"
     source_file: scripts/open_scene.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: true
     idempotent: false
   - name: list_objects
     description: "List all objects in the current Blender scene"
     source_file: scripts/list_objects.py
+    execution: sync
+    affinity: main
     read_only: true
     destructive: false
     idempotent: true
   - name: get_scene_info
     description: "Return a hierarchical description of the current scene"
     source_file: scripts/get_scene_info.py
+    execution: sync
+    affinity: main
     read_only: true
     destructive: false
     idempotent: true
   - name: get_session_info
     description: "Return Blender version, scene path, and basic session statistics"
     source_file: scripts/get_session_info.py
+    execution: sync
+    affinity: main
     read_only: true
     destructive: false
     idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-scripting/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-scripting/tools.yaml
@@ -2,18 +2,24 @@ tools:
   - name: execute_python
     description: "Execute a Python code snippet inside Blender"
     source_file: scripts/execute_python.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false
   - name: execute_script_file
     description: "Execute a Python script file inside Blender"
     source_file: scripts/execute_script_file.py
+    execution: sync
+    affinity: main
     read_only: false
     destructive: false
     idempotent: false
   - name: get_blender_info
     description: "Get Blender version and Python environment information"
     source_file: scripts/get_blender_info.py
+    execution: sync
+    affinity: main
     read_only: true
     destructive: false
     idempotent: true

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: blender-shader-nodes
+description: "Blender shader node inspection and Principled BSDF editing tools"
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, shader, nodes, materials]
+    search-hint: "shader nodes, material nodes, principled bsdf, metallic roughness base color"
+    tools: tools.yaml
+---
+
+# blender-shader-nodes
+
+Focused tools for inspecting material node graphs and editing common Principled BSDF inputs.

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/list_material_nodes.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/list_material_nodes.py
@@ -1,0 +1,69 @@
+"""List shader nodes on a Blender material."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, List
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def _socket_names(sockets: Any) -> List[str]:
+    if hasattr(sockets, "keys"):
+        try:
+            return [str(name) for name in sockets.keys()]
+        except Exception:
+            pass
+
+    try:
+        items: Iterable[Any] = sockets
+    except TypeError:
+        return []
+    return [str(getattr(socket, "name", socket)) for socket in items]
+
+
+def list_material_nodes(material_name: str, include_sockets: bool = True) -> dict:
+    """List nodes in a material's shader graph."""
+    try:
+        import bpy
+
+        mat = bpy.data.materials.get(material_name)
+        if mat is None:
+            return skill_error(f"Material not found: {material_name}", f"No material named '{material_name}'.")
+        if not mat.use_nodes or mat.node_tree is None:
+            return skill_error(f"Material {material_name} does not use nodes", "Enable material nodes first.")
+
+        nodes = []
+        for node in mat.node_tree.nodes:
+            info = {
+                "name": node.name,
+                "type": node.type,
+                "label": getattr(node, "label", ""),
+            }
+            if include_sockets:
+                info["inputs"] = _socket_names(node.inputs)
+                info["outputs"] = _socket_names(node.outputs)
+            nodes.append(info)
+
+        return skill_success(
+            f"Found {len(nodes)} shader nodes on {material_name}",
+            material_name=material_name,
+            nodes=nodes,
+            count=len(nodes),
+            prompt="Use set_principled_input to tune common Principled BSDF inputs.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to list shader nodes for {material_name}")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_material_nodes`."""
+    return list_material_nodes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/set_principled_input.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/set_principled_input.py
@@ -1,0 +1,91 @@
+"""Set common Principled BSDF input values on a Blender material."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def _find_principled_node(nodes: Any, node_name: str):
+    node = nodes.get(node_name) if hasattr(nodes, "get") else None
+    if node is not None:
+        return node
+
+    for candidate in nodes:
+        if getattr(candidate, "type", "") == "BSDF_PRINCIPLED":
+            return candidate
+    return None
+
+
+def _normalise_value(default_value: Any, value: Any) -> Any:
+    if isinstance(value, tuple):
+        value = list(value)
+    if not isinstance(value, list):
+        return value
+
+    try:
+        target_len = len(default_value)
+    except TypeError:
+        return value
+
+    if target_len == 4 and len(value) == 3:
+        return value + [1.0]
+    return value
+
+
+def set_principled_input(
+    material_name: str,
+    input_name: str,
+    value: Any,
+    node_name: str = "Principled BSDF",
+) -> dict:
+    """Set a Principled BSDF input value."""
+    try:
+        import bpy
+
+        mat = bpy.data.materials.get(material_name)
+        if mat is None:
+            return skill_error(f"Material not found: {material_name}", f"No material named '{material_name}'.")
+        if not mat.use_nodes or mat.node_tree is None:
+            return skill_error(f"Material {material_name} does not use nodes", "Enable material nodes first.")
+
+        node = _find_principled_node(mat.node_tree.nodes, node_name)
+        if node is None:
+            return skill_error(
+                f"No Principled BSDF node in {material_name}",
+                "This tool edits the material's Principled BSDF shader.",
+            )
+
+        socket: Optional[Any] = node.inputs.get(input_name) if hasattr(node.inputs, "get") else None
+        if socket is None:
+            return skill_error(
+                f"Input not found on Principled BSDF: {input_name}",
+                f"Available inputs: {', '.join(str(name) for name in node.inputs.keys())}",
+            )
+
+        socket.default_value = _normalise_value(socket.default_value, value)
+        return skill_success(
+            f"Set {input_name} on {material_name}",
+            material_name=material_name,
+            node_name=getattr(node, "name", node_name),
+            input_name=input_name,
+            value=socket.default_value,
+            prompt="Use render_scene or capture_viewport to inspect the material result.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to set {input_name} on {material_name}")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_principled_input`."""
+    return set_principled_input(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/tools.yaml
@@ -1,0 +1,17 @@
+tools:
+  - name: list_material_nodes
+    description: "List shader nodes and sockets for a material"
+    source_file: scripts/list_material_nodes.py
+    execution: sync
+    affinity: main
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: set_principled_input
+    description: "Set a value on a material's Principled BSDF shader"
+    source_file: scripts/set_principled_input.py
+    execution: sync
+    affinity: main
+    read_only: false
+    destructive: false
+    idempotent: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,7 @@ def make_mock_bpy(
     mock_bpy.data.lights = MagicMock()
     mock_bpy.data.cameras = MagicMock()
     mock_bpy.data.worlds = MagicMock()
+    mock_bpy.data.node_groups = MagicMock()
     if data_attrs:
         for k, v in data_attrs.items():
             getattr(mock_bpy.data, k)
@@ -131,6 +132,7 @@ def make_mock_bpy(
     mock_bpy.ops.wm = MagicMock()
     mock_bpy.ops.render = MagicMock()
     mock_bpy.ops.screen = MagicMock()
+    mock_bpy.ops.rigidbody = MagicMock()
     if ops_attrs:
         for k, v in ops_attrs.items():
             setattr(mock_bpy.ops, k, v)

--- a/tests/e2e/test_nodes_physics_e2e.py
+++ b/tests/e2e/test_nodes_physics_e2e.py
@@ -1,0 +1,85 @@
+"""E2E tests for shader nodes, geometry nodes, and physics skills."""
+
+from __future__ import annotations
+
+import pytest
+
+bpy = pytest.importorskip("bpy", reason="bpy not available - run inside Blender Python interpreter")
+
+pytestmark = pytest.mark.e2e
+
+from tests.e2e.conftest import load_skill  # noqa: E402
+
+
+def _new_scene():
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+
+
+class TestShaderNodesE2E:
+    def setup_method(self):
+        _new_scene()
+
+    def test_list_and_update_principled_inputs(self):
+        mat = bpy.data.materials.new("E2EShader")
+        mat.use_nodes = True
+
+        list_mod = load_skill("blender-shader-nodes", "list_material_nodes")
+        list_result = list_mod.list_material_nodes(material_name="E2EShader")
+        assert list_result["success"] is True
+        assert list_result["context"]["count"] >= 1
+
+        set_mod = load_skill("blender-shader-nodes", "set_principled_input")
+        result = set_mod.set_principled_input(
+            material_name="E2EShader",
+            input_name="Metallic",
+            value=0.75,
+        )
+        assert result["success"] is True
+        bsdf = mat.node_tree.nodes.get("Principled BSDF")
+        assert bsdf.inputs["Metallic"].default_value == pytest.approx(0.75)
+
+
+class TestGeometryNodesE2E:
+    def setup_method(self):
+        _new_scene()
+
+    def test_add_and_list_geometry_nodes_modifier(self):
+        bpy.ops.mesh.primitive_cube_add()
+        cube_name = bpy.context.active_object.name
+
+        add_mod = load_skill("blender-geometry-nodes", "add_geometry_nodes_modifier")
+        result = add_mod.add_geometry_nodes_modifier(
+            object_name=cube_name,
+            name="E2E Geometry Nodes",
+            group_name="E2E Geometry Group",
+        )
+        assert result["success"] is True
+
+        list_mod = load_skill("blender-geometry-nodes", "list_geometry_nodes_modifiers")
+        list_result = list_mod.list_geometry_nodes_modifiers(object_name=cube_name)
+        assert list_result["success"] is True
+        assert list_result["context"]["count"] == 1
+
+
+class TestPhysicsE2E:
+    def setup_method(self):
+        _new_scene()
+
+    def test_add_update_and_remove_rigid_body(self):
+        bpy.ops.mesh.primitive_cube_add()
+        cube_name = bpy.context.active_object.name
+        cube = bpy.data.objects[cube_name]
+
+        add_mod = load_skill("blender-physics", "add_rigid_body")
+        add_result = add_mod.add_rigid_body(object_name=cube_name, mass=2.0, collision_shape="BOX")
+        assert add_result["success"] is True
+        assert cube.rigid_body is not None
+
+        set_mod = load_skill("blender-physics", "set_rigid_body_properties")
+        set_result = set_mod.set_rigid_body_properties(object_name=cube_name, mass=3.0, friction=0.1)
+        assert set_result["success"] is True
+        assert cube.rigid_body.mass == pytest.approx(3.0)
+
+        remove_mod = load_skill("blender-physics", "remove_rigid_body")
+        remove_result = remove_mod.remove_rigid_body(object_name=cube_name)
+        assert remove_result["success"] is True

--- a/tests/e2e/test_server_e2e.py
+++ b/tests/e2e/test_server_e2e.py
@@ -16,9 +16,14 @@ Run::
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 bpy = pytest.importorskip("bpy", reason="bpy not available — run inside Blender Python interpreter")
+
+if sys.platform == "win32":
+    pytest.skip("server lifecycle is covered by separate-process workflow smoke on Windows", allow_module_level=True)
 
 pytestmark = pytest.mark.e2e
 
@@ -147,38 +152,28 @@ class TestProgressiveLoadingE2E:
     def test_unload_and_reload_skill(self):
         """Unload a skill then reload it — verifies round-trip."""
         import dcc_mcp_blender
+        from dcc_mcp_blender.host import BlenderCallableDispatcher, BlenderHost
 
-        server = dcc_mcp_blender.start_server(port=0)
+        dispatcher = BlenderCallableDispatcher()
+        host = BlenderHost(dispatcher)
+        server = dcc_mcp_blender.start_server(port=0, dispatcher=dispatcher)
+        host.start()
+        try:
+            skill_name = "blender-scene"
 
-        # Pick the first skill that is currently loaded (eager or lazy)
-        loaded = [
-            s
-            for s in server.list_skills()
-            if _skill_get(s, "loaded") or server.is_skill_loaded(_skill_get(s, "name", ""))
-        ]
-        if not loaded:
-            # create_skill_manager only discovered but did not load — load one now
-            discovered = server.list_skills()
-            if not discovered:
-                return  # no skills at all; nothing to test
-            skill_name = _skill_get(discovered[0], "name", "blender-scene")
-            server.load_skill(skill_name)
-            loaded = [{"name": skill_name}]
+            if not server.is_skill_loaded(skill_name):
+                assert server.load_skill(skill_name) is True
+            assert server.is_skill_loaded(skill_name)
 
-        skill_name = _skill_get(loaded[0], "name", "blender-scene")
+            removed = server.unload_skill(skill_name)
+            assert removed is True
+            assert not server.is_skill_loaded(skill_name)
 
-        # Ensure it is loaded before unloading
-        if not server.is_skill_loaded(skill_name):
-            server.load_skill(skill_name)
-
-        removed = server.unload_skill(skill_name)
-        assert removed is True
-        assert not server.is_skill_loaded(skill_name)
-
-        # Reload
-        loaded_again = server.load_skill(skill_name)
-        assert loaded_again is True
-        assert server.is_skill_loaded(skill_name)
+            loaded_again = server.load_skill(skill_name)
+            assert loaded_again is True
+            assert server.is_skill_loaded(skill_name)
+        finally:
+            host.stop()
 
     def test_discover_extra_paths_no_crash(self):
         """Calling discover_skills() with no extra paths must not raise."""
@@ -204,8 +199,12 @@ class TestMultiInstanceGatewayE2E:
 
         from dcc_mcp_blender.server import BlenderMcpServer
 
-        s1 = BlenderMcpServer(port=0)
-        s2 = BlenderMcpServer(port=0)
+        # This is an in-process HTTP isolation check. Gateway election is covered
+        # by separate-process workflow smoke tests and can leave native threads
+        # racing Blender teardown on Windows when two elected gateways run inside
+        # one interpreter.
+        s1 = BlenderMcpServer(port=0, gateway_port=0, enable_gateway_failover=False)
+        s2 = BlenderMcpServer(port=0, gateway_port=0, enable_gateway_failover=False)
         s1.start()
         s2.start()
         try:

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -17,10 +17,10 @@ def _load_assemble_zip_module():
     return mod
 
 
-def test_core_dependency_floor_is_0178():
+def test_core_dependency_floor_is_01725():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert '"dcc-mcp-core>=0.17.8,<1.0.0"' in pyproject
+    assert '"dcc-mcp-core>=0.17.25,<1.0.0"' in pyproject
 
 
 def test_packaging_core_floor_matches_pyproject():

--- a/tests/test_lint_skills.py
+++ b/tests/test_lint_skills.py
@@ -3,16 +3,120 @@
 from __future__ import annotations
 
 import sys
+from types import SimpleNamespace
 
-from tools.lint_skills import lint_skills
+import tools.lint_skills as skill_lint
 
 
 def test_all_skill_md_files():
     """Every skill directory must have a valid SKILL.md."""
-    errors = lint_skills()
+    errors = skill_lint.lint_skills()
     if errors:
         msg = "SKILL.md validation errors:\n" + "\n".join(f"  - {e}" for e in errors)
         assert False, msg
+
+
+def test_tool_metadata_requires_execution_affinity_and_safety_flags(tmp_path, monkeypatch):
+    """Local lint must catch fields that the optional external CLI may not enforce yet."""
+    skill_dir = tmp_path / "blender-example"
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: blender-example
+description: "Example Blender skill"
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender]
+    search-hint: "example"
+    tools: tools.yaml
+---
+
+# blender-example
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "tools.yaml").write_text(
+        """tools:
+  - name: example_tool
+    description: "Example"
+    source_file: scripts/example_tool.py
+""",
+        encoding="utf-8",
+    )
+    (scripts_dir / "example_tool.py").write_text(
+        """from dcc_mcp_core.skill import skill_entry
+
+
+@skill_entry
+def main(**kwargs):
+    return {"success": True}
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(skill_lint, "validate_skill", lambda _path: SimpleNamespace(has_errors=False, issues=[]))
+
+    errors = skill_lint.lint_skills(tmp_path, use_cli=False)
+
+    assert any("missing tool fields" in error and "affinity" in error for error in errors)
+    assert any("missing tool fields" in error and "execution" in error for error in errors)
+    assert any("missing tool fields" in error and "read_only" in error for error in errors)
+
+
+def test_tool_metadata_rejects_top_level_bpy_import(tmp_path, monkeypatch):
+    """Skill scripts must remain importable without Blender installed."""
+    skill_dir = tmp_path / "blender-example"
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: blender-example
+description: "Example Blender skill"
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender]
+    search-hint: "example"
+    tools: tools.yaml
+---
+
+# blender-example
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "tools.yaml").write_text(
+        """tools:
+  - name: example_tool
+    description: "Example"
+    source_file: scripts/example_tool.py
+    execution: sync
+    affinity: main
+    read_only: true
+    destructive: false
+    idempotent: true
+""",
+        encoding="utf-8",
+    )
+    (scripts_dir / "example_tool.py").write_text(
+        """import bpy
+
+from dcc_mcp_core.skill import skill_entry
+
+
+@skill_entry
+def main(**kwargs):
+    return {"success": True}
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(skill_lint, "validate_skill", lambda _path: SimpleNamespace(has_errors=False, issues=[]))
+
+    errors = skill_lint.lint_skills(tmp_path, use_cli=False)
+
+    assert any("host API import must be lazy" in error for error in errors)
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -54,6 +54,37 @@ class TestBlenderMcpServerBasic:
         server = BlenderMcpServer()
         assert server.mcp_url is None
 
+    def test_dispatcher_is_wrapped_as_execution_bridge(self):
+        from dcc_mcp_blender.host import BlenderCallableDispatcher, BlenderInlineCallableDispatcher
+        from dcc_mcp_blender.server import BlenderMcpServer
+
+        dispatcher = BlenderCallableDispatcher()
+        server = BlenderMcpServer(port=0, dispatcher=dispatcher)
+
+        mode = server._options.execution.mode
+        assert getattr(mode, "kind", None) == "bridge"
+        assert isinstance(mode.bridge.dispatcher, BlenderInlineCallableDispatcher)
+        assert mode.bridge.host_dispatcher is dispatcher.host_dispatcher
+        assert mode.bridge.dispatch_callable(lambda: "ok") == "ok"
+
+    def test_explicit_execution_bridge_takes_precedence(self):
+        from dcc_mcp_core import HostExecutionBridge
+
+        from dcc_mcp_blender.host import BlenderCallableDispatcher
+        from dcc_mcp_blender.server import BlenderMcpServer
+
+        dispatcher = BlenderCallableDispatcher()
+        bridge = HostExecutionBridge(dispatcher=dispatcher)
+        server = BlenderMcpServer(
+            port=0,
+            dispatcher=BlenderCallableDispatcher(),
+            execution_bridge=bridge,
+        )
+
+        mode = server._options.execution.mode
+        assert getattr(mode, "kind", None) == "bridge"
+        assert mode.bridge is bridge
+
 
 class TestSkillPathCollection:
     """_collect_skill_paths respects all path sources."""

--- a/tests/test_skills_geometry_nodes.py
+++ b/tests/test_skills_geometry_nodes.py
@@ -1,0 +1,103 @@
+"""Unit tests for blender-geometry-nodes skill scripts (bpy mocked)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tests.conftest import load_and_call, make_mock_bpy
+
+
+def _make_mesh_obj(name="Cube"):
+    obj = MagicMock()
+    obj.name = name
+    obj.type = "MESH"
+    obj.modifiers = MagicMock()
+    obj.modifiers.__iter__ = MagicMock(return_value=iter([]))
+    return obj
+
+
+class TestAddGeometryNodesModifier:
+    def test_adds_modifier_and_node_group(self):
+        bpy = make_mock_bpy()
+        obj = _make_mesh_obj()
+        bpy.data.objects.get.return_value = obj
+
+        modifier = MagicMock()
+        modifier.name = "Geometry Nodes"
+        modifier.type = "NODES"
+        obj.modifiers.new.return_value = modifier
+
+        group = MagicMock()
+        group.name = "Procedural Group"
+        bpy.data.node_groups.get.return_value = None
+        bpy.data.node_groups.new.return_value = group
+
+        result = load_and_call(
+            "blender-geometry-nodes/scripts/add_geometry_nodes_modifier.py",
+            bpy,
+            object_name="Cube",
+            group_name="Procedural Group",
+        )
+
+        assert result["success"] is True
+        obj.modifiers.new.assert_called_once_with(name="Geometry Nodes", type="NODES")
+        bpy.data.node_groups.new.assert_called_once_with("Procedural Group", "GeometryNodeTree")
+        assert modifier.node_group is group
+
+    def test_non_mesh_returns_error(self):
+        bpy = make_mock_bpy()
+        obj = _make_mesh_obj("Light")
+        obj.type = "LIGHT"
+        bpy.data.objects.get.return_value = obj
+
+        result = load_and_call(
+            "blender-geometry-nodes/scripts/add_geometry_nodes_modifier.py",
+            bpy,
+            object_name="Light",
+        )
+
+        assert result["success"] is False
+
+
+class TestListGeometryNodesModifiers:
+    def test_lists_only_geometry_nodes_modifiers(self):
+        bpy = make_mock_bpy()
+        obj = _make_mesh_obj()
+        group = MagicMock()
+        group.name = "GeoGroup"
+
+        geo = MagicMock()
+        geo.name = "Geometry Nodes"
+        geo.type = "NODES"
+        geo.node_group = group
+        geo.show_viewport = True
+        geo.show_render = True
+
+        bevel = MagicMock()
+        bevel.name = "Bevel"
+        bevel.type = "BEVEL"
+
+        obj.modifiers.__iter__ = MagicMock(return_value=iter([geo, bevel]))
+        bpy.data.objects.get.return_value = obj
+
+        result = load_and_call(
+            "blender-geometry-nodes/scripts/list_geometry_nodes_modifiers.py",
+            bpy,
+            object_name="Cube",
+        )
+
+        assert result["success"] is True
+        assert result["context"]["count"] == 1
+        assert result["context"]["modifiers"][0]["node_group"] == "GeoGroup"
+
+    def test_missing_object_returns_error(self):
+        bpy = make_mock_bpy()
+        bpy.data.objects.get.return_value = None
+
+        result = load_and_call(
+            "blender-geometry-nodes/scripts/list_geometry_nodes_modifiers.py",
+            bpy,
+            object_name="Ghost",
+        )
+
+        assert result["success"] is False

--- a/tests/test_skills_physics.py
+++ b/tests/test_skills_physics.py
@@ -1,0 +1,124 @@
+"""Unit tests for blender-physics skill scripts (bpy mocked)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tests.conftest import load_and_call, make_mock_bpy
+
+
+def _make_obj(name="Cube"):
+    obj = MagicMock()
+    obj.name = name
+    obj.type = "MESH"
+    obj.rigid_body = None
+    return obj
+
+
+class TestAddRigidBody:
+    def test_adds_rigid_body_and_applies_properties(self):
+        bpy = make_mock_bpy()
+        obj = _make_obj()
+        rigid_body = MagicMock()
+        rigid_body.type = "ACTIVE"
+        rigid_body.mass = 1.0
+        rigid_body.collision_shape = "CONVEX_HULL"
+        bpy.data.objects.get.return_value = obj
+
+        def _add_body(type="ACTIVE"):
+            obj.rigid_body = rigid_body
+            rigid_body.type = type
+
+        bpy.ops.rigidbody.object_add.side_effect = _add_body
+
+        result = load_and_call(
+            "blender-physics/scripts/add_rigid_body.py",
+            bpy,
+            object_name="Cube",
+            body_type="PASSIVE",
+            mass="2.5",
+            collision_shape="BOX",
+        )
+
+        assert result["success"] is True
+        bpy.ops.rigidbody.object_add.assert_called_once_with(type="PASSIVE")
+        assert rigid_body.mass == 2.5
+        assert rigid_body.collision_shape == "BOX"
+
+    def test_invalid_body_type_returns_error(self):
+        bpy = make_mock_bpy()
+        bpy.data.objects.get.return_value = _make_obj()
+
+        result = load_and_call(
+            "blender-physics/scripts/add_rigid_body.py",
+            bpy,
+            object_name="Cube",
+            body_type="FLYING",
+        )
+
+        assert result["success"] is False
+
+
+class TestSetRigidBodyProperties:
+    def test_updates_existing_rigid_body(self):
+        bpy = make_mock_bpy()
+        obj = _make_obj()
+        obj.rigid_body = MagicMock()
+        obj.rigid_body.mass = 1.0
+        obj.rigid_body.friction = 0.5
+        bpy.data.objects.get.return_value = obj
+
+        result = load_and_call(
+            "blender-physics/scripts/set_rigid_body_properties.py",
+            bpy,
+            object_name="Cube",
+            mass="3.0",
+            friction="0.2",
+        )
+
+        assert result["success"] is True
+        assert obj.rigid_body.mass == 3.0
+        assert obj.rigid_body.friction == 0.2
+        assert result["context"]["applied"]["mass"] == 3.0
+
+    def test_missing_rigid_body_returns_error(self):
+        bpy = make_mock_bpy()
+        bpy.data.objects.get.return_value = _make_obj()
+
+        result = load_and_call(
+            "blender-physics/scripts/set_rigid_body_properties.py",
+            bpy,
+            object_name="Cube",
+            mass=3.0,
+        )
+
+        assert result["success"] is False
+
+
+class TestRemoveRigidBody:
+    def test_removes_existing_rigid_body(self):
+        bpy = make_mock_bpy()
+        obj = _make_obj()
+        obj.rigid_body = MagicMock()
+        bpy.data.objects.get.return_value = obj
+
+        result = load_and_call(
+            "blender-physics/scripts/remove_rigid_body.py",
+            bpy,
+            object_name="Cube",
+        )
+
+        assert result["success"] is True
+        bpy.ops.rigidbody.object_remove.assert_called_once_with()
+
+    def test_missing_rigid_body_returns_error(self):
+        bpy = make_mock_bpy()
+        bpy.data.objects.get.return_value = _make_obj()
+
+        result = load_and_call(
+            "blender-physics/scripts/remove_rigid_body.py",
+            bpy,
+            object_name="Cube",
+        )
+
+        assert result["success"] is False

--- a/tests/test_skills_shader_nodes.py
+++ b/tests/test_skills_shader_nodes.py
@@ -1,0 +1,121 @@
+"""Unit tests for blender-shader-nodes skill scripts (bpy mocked)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tests.conftest import load_and_call, make_mock_bpy
+
+
+def _nodes_collection(nodes):
+    collection = MagicMock()
+    collection.__iter__ = MagicMock(return_value=iter(nodes))
+    by_name = {node.name: node for node in nodes}
+    collection.get = MagicMock(side_effect=lambda name: by_name.get(name))
+    return collection
+
+
+def _make_material(name="ShaderMat", use_nodes=True):
+    mat = MagicMock()
+    mat.name = name
+    mat.use_nodes = use_nodes
+
+    bsdf = MagicMock()
+    bsdf.name = "Principled BSDF"
+    bsdf.type = "BSDF_PRINCIPLED"
+    bsdf.label = ""
+    bsdf.inputs = {
+        "Base Color": MagicMock(default_value=[1.0, 1.0, 1.0, 1.0]),
+        "Metallic": MagicMock(default_value=0.0),
+        "Roughness": MagicMock(default_value=0.5),
+    }
+    bsdf.outputs = {"BSDF": MagicMock(name="BSDF")}
+
+    output = MagicMock()
+    output.name = "Material Output"
+    output.type = "OUTPUT_MATERIAL"
+    output.label = ""
+    output.inputs = {"Surface": MagicMock(name="Surface")}
+    output.outputs = {}
+
+    mat.node_tree.nodes = _nodes_collection([bsdf, output])
+    return mat, bsdf
+
+
+class TestListMaterialNodes:
+    def test_lists_nodes_and_sockets(self):
+        bpy = make_mock_bpy()
+        mat, _bsdf = _make_material("ShaderMat")
+        bpy.data.materials.get.return_value = mat
+
+        result = load_and_call(
+            "blender-shader-nodes/scripts/list_material_nodes.py",
+            bpy,
+            material_name="ShaderMat",
+        )
+
+        assert result["success"] is True
+        assert result["context"]["count"] == 2
+        assert result["context"]["nodes"][0]["name"] == "Principled BSDF"
+        assert "Base Color" in result["context"]["nodes"][0]["inputs"]
+
+    def test_material_not_found(self):
+        bpy = make_mock_bpy()
+        bpy.data.materials.get.return_value = None
+
+        result = load_and_call(
+            "blender-shader-nodes/scripts/list_material_nodes.py",
+            bpy,
+            material_name="Ghost",
+        )
+
+        assert result["success"] is False
+
+
+class TestSetPrincipledInput:
+    def test_sets_scalar_input(self):
+        bpy = make_mock_bpy()
+        mat, bsdf = _make_material("ShaderMat")
+        bpy.data.materials.get.return_value = mat
+
+        result = load_and_call(
+            "blender-shader-nodes/scripts/set_principled_input.py",
+            bpy,
+            material_name="ShaderMat",
+            input_name="Metallic",
+            value=0.8,
+        )
+
+        assert result["success"] is True
+        assert bsdf.inputs["Metallic"].default_value == 0.8
+
+    def test_expands_rgb_color_to_rgba(self):
+        bpy = make_mock_bpy()
+        mat, bsdf = _make_material("ShaderMat")
+        bpy.data.materials.get.return_value = mat
+
+        result = load_and_call(
+            "blender-shader-nodes/scripts/set_principled_input.py",
+            bpy,
+            material_name="ShaderMat",
+            input_name="Base Color",
+            value=[0.1, 0.2, 0.3],
+        )
+
+        assert result["success"] is True
+        assert bsdf.inputs["Base Color"].default_value == [0.1, 0.2, 0.3, 1.0]
+
+    def test_missing_input_returns_error(self):
+        bpy = make_mock_bpy()
+        mat, _bsdf = _make_material("ShaderMat")
+        bpy.data.materials.get.return_value = mat
+
+        result = load_and_call(
+            "blender-shader-nodes/scripts/set_principled_input.py",
+            bpy,
+            material_name="ShaderMat",
+            input_name="Not Real",
+            value=1.0,
+        )
+
+        assert result["success"] is False

--- a/tests/test_skills_structure.py
+++ b/tests/test_skills_structure.py
@@ -18,6 +18,9 @@ EXPECTED_SKILLS = [
     "blender-camera",
     "blender-collection",
     "blender-geometry",
+    "blender-shader-nodes",
+    "blender-geometry-nodes",
+    "blender-physics",
 ]
 
 

--- a/tests/test_workflow_ci.py
+++ b/tests/test_workflow_ci.py
@@ -38,7 +38,7 @@ def test_workflow_server_uses_blender_inprocess_dispatcher():
     assert "from dcc_mcp_blender.host import BlenderCallableDispatcher, BlenderHost" in text
     assert "dispatcher = BlenderCallableDispatcher()" in text
     assert "dcc_mcp_blender.start_server(port=8765, dispatcher=dispatcher)" in text
-    assert "host.start()" in text
+    assert "host.run_headless(stop_event=stop_event)" in text
     assert "host.stop()" in text
 
 
@@ -56,6 +56,21 @@ def test_geometry_export_verification_reads_paths_from_environment():
     assert "export GEOM_BLEND GEOM_FBX GEOM_OBJ" in text
     assert "path = os.environ[key]" in text
     assert "('$GEOM_BLEND', '$GEOM_FBX', '$GEOM_OBJ')" not in text
+
+
+def test_e2e_workflow_smokes_nodes_and_physics_tools():
+    text = E2E_WORKFLOW.read_text(encoding="utf-8")
+
+    for tool_name in (
+        "list_material_nodes",
+        "set_principled_input",
+        "add_geometry_nodes_modifier",
+        "list_geometry_nodes_modifiers",
+        "add_rigid_body",
+        "set_rigid_body_properties",
+        "remove_rigid_body",
+    ):
+        assert f"call_tool {tool_name}" in text
 
 
 def test_e2e_workflow_does_not_run_mock_unit_tests():

--- a/tools/lint_skills.py
+++ b/tools/lint_skills.py
@@ -18,7 +18,19 @@ DEFAULT_SKILLS_DIR = ROOT / "src" / "dcc_mcp_blender" / "skills"
 
 REQUIRED_FIELDS = {"name", "description", "metadata"}
 REQUIRED_DCC_MCP_FIELDS = {"dcc", "version", "tags", "search-hint", "tools"}
-REQUIRED_TOOL_FIELDS = {"name", "description", "source_file"}
+REQUIRED_TOOL_FIELDS = {
+    "name",
+    "description",
+    "source_file",
+    "execution",
+    "affinity",
+    "read_only",
+    "destructive",
+    "idempotent",
+}
+VALID_EXECUTION = {"sync", "async"}
+VALID_AFFINITY = {"main", "any"}
+SAFETY_FIELDS = {"read_only", "destructive", "idempotent"}
 
 
 def _find_dcc_mcp_cli() -> Optional[str]:
@@ -84,12 +96,12 @@ def lint_skills(
     warnings_as_errors: bool = False,
 ) -> List[str]:
     """Return validation errors for all skill directories under *skills_dir*."""
+    errors: List[str] = []
     if use_cli:
         cli_errors = lint_skills_with_cli(skills_dir, warnings_as_errors=warnings_as_errors)
         if cli_errors is not None:
-            return cli_errors
+            errors.extend(cli_errors)
 
-    errors: List[str] = []
     skill_dirs = [d for d in skills_dir.iterdir() if d.is_dir()]
     if not skill_dirs:
         return [f"No skill directories found under {skills_dir}"]
@@ -142,13 +154,52 @@ def lint_skills(
             continue
 
         for tool in tools:
+            tool_name = tool.get("name", "?")
             missing_tool = REQUIRED_TOOL_FIELDS - set(tool.keys())
             if missing_tool:
-                errors.append(f"{skill_dir.name}/{tool.get('name', '?')}: missing tool fields: {missing_tool}")
+                errors.append(f"{skill_dir.name}/{tool_name}: missing tool fields: {missing_tool}")
 
-            source = skill_dir / tool.get("source_file", "")
+            execution = tool.get("execution")
+            if execution is not None and execution not in VALID_EXECUTION:
+                errors.append(
+                    f"{skill_dir.name}/{tool_name}: invalid execution {execution!r}; "
+                    f"expected one of {sorted(VALID_EXECUTION)}"
+                )
+
+            affinity = tool.get("affinity")
+            if affinity is not None and affinity not in VALID_AFFINITY:
+                errors.append(
+                    f"{skill_dir.name}/{tool_name}: invalid affinity {affinity!r}; "
+                    f"expected one of {sorted(VALID_AFFINITY)}"
+                )
+
+            for field in SAFETY_FIELDS:
+                if field in tool and not isinstance(tool[field], bool):
+                    errors.append(f"{skill_dir.name}/{tool_name}: {field} must be a boolean")
+
+            if execution == "async" and "timeout_hint_secs" not in tool:
+                errors.append(f"{skill_dir.name}/{tool_name}: async tools must declare timeout_hint_secs")
+
+            source_file = tool.get("source_file", "")
+            if source_file and pathlib.PurePosixPath(source_file).parts[:1] != ("scripts",):
+                errors.append(f"{skill_dir.name}/{tool_name}: source_file must be under scripts/: {source_file}")
+
+            source = skill_dir / source_file
             if not source.exists():
-                errors.append(f"{skill_dir.name}: source_file not found: {tool.get('source_file')}")
+                errors.append(f"{skill_dir.name}: source_file not found: {source_file}")
+                continue
+
+            try:
+                script_text = source.read_text(encoding="utf-8")
+            except UnicodeDecodeError as exc:
+                errors.append(f"{skill_dir.name}/{tool_name}: could not read source file as UTF-8: {exc}")
+                continue
+
+            for forbidden in ("import bpy", "from bpy"):
+                if any(line.startswith(forbidden) for line in script_text.splitlines()):
+                    errors.append(
+                        f"{skill_dir.name}/{tool_name}: host API import must be lazy inside the tool function"
+                    )
 
     return errors
 


### PR DESCRIPTION
## Summary
- bump dcc-mcp-core floor to 0.17.25 and align packaging/CI validation
- add shader node, geometry node, and rigid-body physics Blender MCP skills
- wire Blender main-thread execution through HostExecutionBridge and strengthen real MCP smoke coverage

## Validation
- python -m ruff format --check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py .github/scripts/start_mcp_server.py .github/scripts/start_mcp_server2.py
- python -m ruff check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py .github/scripts/start_mcp_server.py .github/scripts/start_mcp_server2.py
- python tools/lint_skills.py --warnings-as-errors
- python -m pytest tests/ -q
- Blender 4.4.3 E2E: 98 passed, 1 skipped
- Live HTTP mcporter/gateway smoke covered session info, object/material creation, shader nodes, geometry nodes, and rigid-body physics