### PR TITLE
fix: repair blender addon startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Install ruff
         run: pip install ruff>=0.8.0
       - name: Ruff check
-        run: ruff check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py
+        run: ruff check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py packaging/addon_entry/__init__.py
       - name: Ruff format check
-        run: ruff format --check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py
+        run: ruff format --check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py packaging/addon_entry/__init__.py
 
   lint-skills:
     name: Lint SKILL.md files
@@ -130,20 +130,23 @@ jobs:
           assert zips, f"expected dist_addon/dcc_mcp_blender_addon_{platform}_v*.zip"
           with zipfile.ZipFile(zips[-1]) as zf:
               names = zf.namelist()
-          wheels = [n for n in names if "/wheels/" in n and n.endswith(".whl")]
+          wheels = [n for n in names if n.startswith("wheels/") and n.endswith(".whl")]
           assert wheels, f"expected bundled .whl under wheels/, sample: {names[:30]}"
           assert not any(
-              n.startswith("dcc_mcp_blender/dcc_mcp_core/") for n in names
+              n.startswith("dcc_mcp_core/") for n in names
           ), "unexpected extracted dcc_mcp_core tree — use manifest wheels instead"
-          assert any(n.endswith("dcc_mcp_blender/__init__.py") for n in names), names[:25]
-          assert any(n.endswith("dcc_mcp_blender/blender_manifest.toml") for n in names), names[:25]
-          triple = [n for n in names if "dcc_mcp_blender/dcc_mcp_blender/dcc_mcp_blender/" in n]
-          assert not triple, f"unexpected triple-nested paths: {triple[:5]}"
-          skill_md = [n for n in names if n.endswith("/SKILL.md") and "/skills/" in n]
+          assert "__init__.py" in names, names[:25]
+          assert "server.py" in names, names[:25]
+          assert "host.py" in names, names[:25]
+          assert "blender_manifest.toml" in names, names[:25]
+          nested = [n for n in names if n.startswith("dcc_mcp_blender/")]
+          assert not nested, f"unexpected nested adapter package paths: {nested[:5]}"
+          skill_md = [n for n in names if n.startswith("skills/") and n.endswith("/SKILL.md")]
           assert len(skill_md) >= 13, f"expected >=13 SKILL.md under skills/, got {len(skill_md)}"
-          tools_yaml = [n for n in names if n.endswith("/tools.yaml") and "/skills/" in n]
+          tools_yaml = [n for n in names if n.startswith("skills/") and n.endswith("/tools.yaml")]
           assert len(tools_yaml) >= 13, f"expected >=13 tools.yaml under skills/, got {len(tools_yaml)}"
           with zipfile.ZipFile(zips[-1]) as zf:
-              raw = zf.read("dcc_mcp_blender/blender_manifest.toml").decode("utf-8")
+              raw = zf.read("blender_manifest.toml").decode("utf-8")
           assert "wheels = [" in raw and "./wheels/" in raw, raw[:400]
+          assert raw.index("wheels = [") < raw.index("[permissions]"), raw
           PY

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![GitHub release downloads](https://img.shields.io/github/downloads/loonghao/dcc-mcp-blender/total.svg?label=release%20downloads)](https://github.com/loonghao/dcc-mcp-blender/releases)
 [![GitHub Release](https://img.shields.io/github/v/release/loonghao/dcc-mcp-blender.svg)](https://github.com/loonghao/dcc-mcp-blender/releases)
 [![Coverage](https://img.shields.io/badge/coverage-pytest--cov-blue.svg)](https://github.com/loonghao/dcc-mcp-blender/blob/main/pyproject.toml)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.25-blue.svg)](https://github.com/loonghao/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.34-blue.svg)](https://github.com/loonghao/dcc-mcp-core)
 [![Blender](https://img.shields.io/badge/Blender-3.6%20LTS%20%7C%204.2%20LTS%20%7C%204.3%20%7C%204.4-orange.svg)](https://www.blender.org/download/releases/)
 [![MCP](https://img.shields.io/badge/MCP-2025--03--26-purple.svg)](https://modelcontextprotocol.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/packaging/addon_entry/__init__.py
+++ b/packaging/addon_entry/__init__.py
@@ -9,34 +9,25 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 import webbrowser
-from typing import List, Tuple
+from contextlib import suppress
+from typing import Any, List, Tuple
 
 import bpy
 
 # Do not mutate sys.path — Blender extensions forbid injecting the add-on root into
 # sys.path (policy violation). Dependencies are loaded via blender_manifest.toml wheels.
+_self_module = sys.modules.get(__name__)
+if __name__ != "dcc_mcp_blender" and globals().get("__path__") is not None and _self_module is not None:
+    sys.modules.setdefault("dcc_mcp_blender", _self_module)
 
 logger = logging.getLogger(__name__)
-
-try:
-    from dcc_mcp_blender.__version__ import __version__ as _PKG_VERSION  # noqa: E402
-except Exception:  # noqa: BLE001
-    _PKG_VERSION = "0.1.0"
-
-
-def _version_tuple() -> Tuple[int, int, int]:
-    parts = (_PKG_VERSION.split(".") + ["0", "0", "0"])[:3]
-    try:
-        return int(parts[0]), int(parts[1]), int(parts[2])
-    except ValueError:
-        return 0, 1, 0
-
 
 bl_info = {
     "name": "DCC MCP Blender",
     "author": "Long Hao",
-    "version": _version_tuple(),
+    "version": (0, 1, 4),
     "blender": (4, 2, 0),
     "location": "Top Bar > DCC MCP",
     "description": "Embeds an MCP HTTP server inside Blender for AI-driven 3D workflows",
@@ -48,6 +39,55 @@ bl_info = {
 _DEFAULT_GATEWAY_PORT = 9765
 
 _draw_handlers: List[Tuple[str, object]] = []
+_server_dispatcher: Any = None
+_server_host: Any = None
+
+
+def _start_server_with_host():
+    """Start the MCP server with a Blender main-thread dispatcher attached."""
+    global _server_dispatcher, _server_host  # noqa: PLW0603
+
+    from dcc_mcp_blender.host import BlenderCallableDispatcher, BlenderHost  # noqa: PLC0415
+    from dcc_mcp_blender.server import get_server, start_server, stop_server  # noqa: PLC0415
+
+    existing = get_server()
+    if existing is not None and getattr(existing, "is_running", False):
+        if _server_host is not None:
+            return existing
+        stop_server()
+
+    dispatcher = BlenderCallableDispatcher()
+    host = BlenderHost(dispatcher)
+    try:
+        server = start_server(dispatcher=dispatcher)
+        host.start()
+    except Exception:
+        with suppress(Exception):
+            stop_server()
+        with suppress(Exception):
+            host.stop()
+        raise
+
+    _server_dispatcher = dispatcher
+    _server_host = host
+    return server
+
+
+def _stop_server_with_host() -> None:
+    """Stop the MCP server and detach the Blender timer/dispatcher."""
+    global _server_dispatcher, _server_host  # noqa: PLW0603
+
+    host = _server_host
+    try:
+        from dcc_mcp_blender.server import stop_server  # noqa: PLC0415
+
+        stop_server()
+    finally:
+        if host is not None:
+            with suppress(Exception):
+                host.stop()
+        _server_host = None
+        _server_dispatcher = None
 
 
 def _running_server():
@@ -187,10 +227,8 @@ class DCCMCP_OT_restart(bpy.types.Operator):
 
     def execute(self, context):
         try:
-            from dcc_mcp_blender.server import start_server, stop_server  # noqa: PLC0415
-
-            stop_server()
-            start_server()
+            _stop_server_with_host()
+            _start_server_with_host()
             self.report({"INFO"}, "MCP server restarted")
         except Exception as exc:  # noqa: BLE001
             logger.exception("restart failed")
@@ -271,10 +309,7 @@ def register() -> None:
         logger.warning("TOPBAR_MT_blender missing — DCC MCP top-bar menu not attached")
 
     try:
-        from dcc_mcp_blender.server import get_server, start_server  # noqa: PLC0415
-
-        start_server()
-        srv = get_server()
+        srv = _start_server_with_host()
         url = getattr(srv, "mcp_url", None) if srv is not None else None
         if url:
             print("[DCC MCP Blender] Server started —", url)
@@ -302,9 +337,7 @@ def unregister() -> None:
             logger.debug("unregister %s: %s", cls, exc)
 
     try:
-        from dcc_mcp_blender.server import stop_server  # noqa: PLC0415
-
-        stop_server()
+        _stop_server_with_host()
         print("[DCC MCP Blender] Server stopped")
     except Exception as exc:  # noqa: BLE001
         print(f"[DCC MCP Blender] Failed to stop server: {exc}")

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -8,11 +8,10 @@ This script:
    ``blender_manifest.toml`` under ``wheels = [...]`` so Blender installs it into
    the extension's isolated ``site-packages`` (no ``sys.path`` hacks, no loose
    ``dcc_mcp_core/`` tree — required for Blender 4.2+ extensions policy).
-4. Bundles ``dcc_mcp_blender/`` (adapter + skills) under the same folder.
+4. Bundles the adapter modules and skills directly in the add-on package root.
 5. Produces ``dcc_mcp_blender_addon_{platform}_v{version}.zip`` — install via
    **Edit → Preferences → Extensions → Install from Disk** (recommended) or
-   legacy add-ons path (extensions layout + wheels is still valid when installed
-   as an extension from disk).
+   Blender's extension package installer.
 
 Version strings in ``pyproject.toml``, ``src/dcc_mcp_blender/__version__.py``, and
 ``packaging/addon_entry/blender_manifest.toml`` are maintained by **release-please**
@@ -45,7 +44,7 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.17.25"
+MIN_CORE_VERSION = "0.17.34"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
 
@@ -55,7 +54,7 @@ ADDON_PLATFORMS = ("win64", "linux", "macos")
 PYPI_URL = "https://pypi.org/pypi/{package}/json"
 
 # Never bundle mistaken local trees (e.g. accidental wheel extracts under src/).
-_SKIPPED_TOP_LEVEL_NAMES = frozenset({"dcc_mcp_blender", "dcc_mcp_core", "__pycache__"})
+_SKIPPED_TOP_LEVEL_NAMES = frozenset({"dcc_mcp_blender", "dcc_mcp_core", "__pycache__", "__init__.py"})
 
 
 def _ignore_for_addon_copy(path: str, names: list[str]) -> set[str]:
@@ -85,6 +84,34 @@ def _verify_skills_payload(staged_pkg: pathlib.Path) -> None:
     ]
     if missing_tools:
         raise RuntimeError(f"Missing tools.yaml for bundled skills: {', '.join(sorted(missing_tools))}")
+
+
+def _copy_adapter_package_into_addon_root(addon_dir: pathlib.Path) -> None:
+    """Copy adapter modules into the add-on package root.
+
+    The release add-on itself is the top-level ``dcc_mcp_blender`` package. If
+    the adapter package is copied below another ``dcc_mcp_blender/`` directory,
+    Blender imports the add-on entrypoint but ``dcc_mcp_blender.server`` cannot
+    resolve from a clean extension install.
+    """
+    for child in SRC_DIR.iterdir():
+        if child.name in _SKIPPED_TOP_LEVEL_NAMES:
+            continue
+        dest = addon_dir / child.name
+        if child.is_dir():
+            shutil.copytree(child, dest, ignore=_ignore_for_addon_copy, dirs_exist_ok=False)
+        else:
+            shutil.copy2(child, dest)
+
+
+def _version_tuple_from_string(version: str) -> tuple[int, int, int]:
+    """Return a Blender ``bl_info`` version tuple from a PEP 440-ish version."""
+    release = version.split("+", 1)[0].split("-", 1)[0]
+    parts = (release.split(".") + ["0", "0", "0"])[:3]
+    try:
+        return int(parts[0]), int(parts[1]), int(parts[2])
+    except ValueError as exc:
+        raise RuntimeError(f"Could not render Blender bl_info version from {version!r}") from exc
 
 
 # ── helpers ────────────────────────────────────────────────────────────────────
@@ -238,11 +265,10 @@ def assemble(platform: str, output_dir: pathlib.Path) -> pathlib.Path:
         addon_dir = tmp_dir / "dcc_mcp_blender"
         addon_dir.mkdir()
 
-        # 1) Copy dcc_mcp_blender package source
+        # 1) Copy dcc_mcp_blender package source into the add-on package root.
         print("Copying dcc_mcp_blender package...")
-        staged_pkg = addon_dir / "dcc_mcp_blender"
-        shutil.copytree(SRC_DIR, staged_pkg, ignore=_ignore_for_addon_copy, dirs_exist_ok=False)
-        _verify_skills_payload(staged_pkg)
+        _copy_adapter_package_into_addon_root(addon_dir)
+        _verify_skills_payload(addon_dir)
 
         # 2) Download and extract dcc-mcp-core
         print(f"Resolving {CORE_PACKAGE}...")
@@ -256,15 +282,16 @@ def assemble(platform: str, output_dir: pathlib.Path) -> pathlib.Path:
         print(f"  Bundled wheel: {staged_wheel.relative_to(addon_dir)}")
 
         # 3) Stage add-on root: ``__init__.py`` + ``blender_manifest.toml`` (4.2+ extensions)
-        _stage_addon_entry(addon_dir)
+        _stage_addon_entry(addon_dir, version=version)
         _inject_wheels_into_manifest(addon_dir / "blender_manifest.toml", [wheel.name])
 
-        # 4) Zip everything
+        # 4) Zip the extension package contents at archive root. Blender's
+        # extension installer expects ``blender_manifest.toml`` at ZIP root.
         print(f"Creating {zip_name}...")
         with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
             for file in addon_dir.rglob("*"):
                 if file.is_file() and "__pycache__" not in str(file):
-                    arcname = file.relative_to(tmp_dir)
+                    arcname = file.relative_to(addon_dir)
                     zf.write(file, arcname)
 
     print(f"Created: {zip_path}")
@@ -280,10 +307,30 @@ def _inject_wheels_into_manifest(manifest_path: pathlib.Path, wheel_basenames: l
     text = re.sub(r"\n+wheels\s*=\s*\[.*?\]\s*", "\n", text, flags=re.DOTALL)
     lines = [f'    "./wheels/{name}"' for name in wheel_basenames]
     block = "\nwheels = [\n" + ",\n".join(lines) + ",\n]\n"
-    manifest_path.write_text(text.rstrip() + block, encoding="utf-8")
+    first_table = re.search(r"\n\[[^\]]+\]", text)
+    if first_table is None:
+        rendered = text.rstrip() + block
+    else:
+        rendered = text[: first_table.start()].rstrip() + block + text[first_table.start() :]
+    manifest_path.write_text(rendered, encoding="utf-8")
 
 
-def _stage_addon_entry(addon_dir: pathlib.Path) -> None:
+def _render_static_bl_info_version(init_path: pathlib.Path, version: str) -> None:
+    """Render the staged add-on entry's static ``bl_info['version']`` tuple."""
+    major, minor, patch = _version_tuple_from_string(version)
+    text = init_path.read_text(encoding="utf-8")
+    rendered, count = re.subn(
+        r'("version"\s*:\s*)\([0-9]+\s*,\s*[0-9]+\s*,\s*[0-9]+\)',
+        rf"\1({major}, {minor}, {patch})",
+        text,
+        count=1,
+    )
+    if count != 1:
+        raise RuntimeError(f"Could not find static bl_info version tuple in {init_path}")
+    init_path.write_text(rendered, encoding="utf-8")
+
+
+def _stage_addon_entry(addon_dir: pathlib.Path, *, version: str) -> None:
     """Copy packaged add-on entry (menu, manifest) into the staged ZIP root."""
     init_src = ADDON_ENTRY_DIR / "__init__.py"
     manifest_src = ADDON_ENTRY_DIR / "blender_manifest.toml"
@@ -293,6 +340,7 @@ def _stage_addon_entry(addon_dir: pathlib.Path) -> None:
         raise RuntimeError(f"Missing blender_manifest.toml: {manifest_src}")
 
     shutil.copy2(init_src, addon_dir / "__init__.py")
+    _render_static_bl_info_version(addon_dir / "__init__.py", version)
     shutil.copy2(manifest_src, addon_dir / "blender_manifest.toml")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ classifiers = [
 ]
 
 dependencies = [
-    # Align with dcc-mcp-core 0.17.25: DccServerOptions composition root,
+    # Align with dcc-mcp-core 0.17.34: DccServerOptions composition root,
     # HostExecutionBridge, diagnostics/resources contracts, gateway capability
     # index expectations, and current skill-management/search/lint contracts.
-    "dcc-mcp-core>=0.17.25,<1.0.0",
+    "dcc-mcp-core>=0.17.34,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -1,0 +1,132 @@
+"""Regression tests for the packaged Blender add-on entrypoint."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import pathlib
+import sys
+import zipfile
+from types import SimpleNamespace
+
+ROOT = pathlib.Path(__file__).parent.parent
+ADDON_ENTRY = ROOT / "packaging" / "addon_entry" / "__init__.py"
+
+
+def _load_assemble_zip_module():
+    path = ROOT / "packaging" / "assemble_zip.py"
+    spec = importlib.util.spec_from_file_location("assemble_zip_for_addon_tests", str(path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_addon_entry_bl_info_version_is_static_tuple_literal():
+    """Blender parses ``bl_info`` via AST, so version must not be computed."""
+    tree = ast.parse(ADDON_ENTRY.read_text(encoding="utf-8"))
+    bl_info = next(node for node in tree.body if isinstance(node, ast.Assign) and node.targets[0].id == "bl_info")
+    version_node = next(
+        value
+        for key, value in zip(bl_info.value.keys, bl_info.value.values)
+        if isinstance(key, ast.Constant) and key.value == "version"
+    )
+
+    assert isinstance(version_node, ast.Tuple)
+    assert ast.literal_eval(version_node) == (0, 1, 4)
+
+
+def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monkeypatch):
+    """The add-on package root must directly contain ``server.py`` and skills."""
+    assemble_zip = _load_assemble_zip_module()
+    fake_wheel = tmp_path / "dcc_mcp_core-0.17.34-cp38-abi3-win_amd64.whl"
+    fake_wheel.write_bytes(b"fake wheel")
+
+    monkeypatch.setattr(assemble_zip, "resolve_core_version", lambda min_version="0.17.34": "0.17.34")
+    monkeypatch.setattr(assemble_zip, "download_core_wheel", lambda version, platform, dest_dir: fake_wheel)
+
+    zip_path = assemble_zip.assemble(platform="win64", output_dir=tmp_path)
+
+    with zipfile.ZipFile(zip_path) as zf:
+        names = set(zf.namelist())
+        addon_init = zf.read("__init__.py").decode("utf-8")
+        manifest = zf.read("blender_manifest.toml").decode("utf-8")
+
+    assert "__init__.py" in names
+    assert "server.py" in names
+    assert "host.py" in names
+    assert "skills/blender-scene/SKILL.md" in names
+    assert not any(name.startswith("dcc_mcp_blender/") for name in names)
+    assert '"version": (0, 1, 4)' in addon_init
+    assert "./wheels/dcc_mcp_core-0.17.34-cp38-abi3-win_amd64.whl" in manifest
+    assert manifest.index("wheels = [") < manifest.index("[permissions]")
+
+
+def test_addon_register_starts_server_with_blender_host(monkeypatch):
+    """GUI add-on enable must wire a host dispatcher before serving main-thread tools."""
+    registered_classes = []
+    menu_callbacks = []
+
+    class _Menu:
+        @staticmethod
+        def append(fn):
+            menu_callbacks.append(fn)
+
+        @staticmethod
+        def remove(fn):
+            menu_callbacks.remove(fn)
+
+    fake_bpy = SimpleNamespace(
+        types=SimpleNamespace(Operator=object, Menu=object, TOPBAR_MT_blender=_Menu),
+        utils=SimpleNamespace(
+            register_class=lambda cls: registered_classes.append(cls),
+            unregister_class=lambda cls: registered_classes.remove(cls),
+        ),
+    )
+
+    spec = importlib.util.spec_from_file_location("addon_entry_for_tests", str(ADDON_ENTRY))
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "bpy", fake_bpy)
+    spec.loader.exec_module(mod)
+
+    import dcc_mcp_blender.host as host_mod
+    import dcc_mcp_blender.server as server_mod
+
+    calls = []
+
+    class _Dispatcher:
+        pass
+
+    class _Host:
+        def __init__(self, dispatcher):
+            self.dispatcher = dispatcher
+
+        def start(self):
+            calls.append(("host.start", self.dispatcher))
+
+        def stop(self):
+            calls.append(("host.stop", self.dispatcher))
+
+    server = SimpleNamespace(is_running=True, mcp_url="http://127.0.0.1:8765/mcp")
+
+    def _start_server(*, dispatcher):
+        calls.append(("start_server", dispatcher))
+        return server
+
+    monkeypatch.setattr(host_mod, "BlenderCallableDispatcher", _Dispatcher)
+    monkeypatch.setattr(host_mod, "BlenderHost", _Host)
+    monkeypatch.setattr(server_mod, "get_server", lambda: None)
+    monkeypatch.setattr(server_mod, "start_server", _start_server)
+    monkeypatch.setattr(server_mod, "stop_server", lambda: calls.append(("stop_server", None)))
+
+    mod.register()
+
+    assert registered_classes == list(mod._CLASSES)
+    assert len(menu_callbacks) == 1
+    assert [call[0] for call in calls] == ["start_server", "host.start"]
+    assert calls[0][1] is calls[1][1]
+
+    mod.unregister()
+
+    assert menu_callbacks == []
+    assert registered_classes == []
+    assert [call[0] for call in calls] == ["start_server", "host.start", "stop_server", "host.stop"]

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -17,10 +17,10 @@ def _load_assemble_zip_module():
     return mod
 
 
-def test_core_dependency_floor_is_01725():
+def test_core_dependency_floor_is_01734():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert '"dcc-mcp-core>=0.17.25,<1.0.0"' in pyproject
+    assert '"dcc-mcp-core>=0.17.34,<1.0.0"' in pyproject
 
 
 def test_packaging_core_floor_matches_pyproject():


### PR DESCRIPTION
## Summary
- bump dcc-mcp-core floor to 0.17.34
- package the Blender extension ZIP with a valid root manifest/wheels layout and no nested adapter package
- start the GUI add-on path with a BlenderHost dispatcher so main-thread tools work after enable
- add packaging regressions for static bl_info, ZIP layout, manifest wheel placement, and GUI dispatcher startup

Fixes #24
Fixes #25

## Validation
- python -m ruff check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py packaging/addon_entry/__init__.py .github/scripts/start_mcp_server.py .github/scripts/start_mcp_server2.py
- python -m ruff format --check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py packaging/addon_entry/__init__.py .github/scripts/start_mcp_server.py .github/scripts/start_mcp_server2.py
- python tools/lint_skills.py --warnings-as-errors
- python -m pytest tests/ -q
- python -m build
- python packaging/assemble_zip.py --platform win64 --output-dir dist_addon
- python packaging/assemble_zip.py --platform linux --output-dir dist_addon
- python packaging/assemble_zip.py --platform macos --output-dir dist_addon
- Blender 4.4.3 clean extension install/enable smoke: installed ZIP, enabled bl_ext.user_default.dcc_mcp_blender, loaded blender-scene, and called blender_scene__get_session_info over MCP HTTP