### PR TITLE
feat: add blender uv operations skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 ├─────────────────────────────────┤
 │  dcc_mcp_blender                │
 │  ├─ BlenderMcpServer            │
-│  ├─ SkillCatalog (55+ tools)    │
+│  ├─ SkillCatalog (65+ tools)    │
 │  ├─ ActionRegistry              │
 │  └─ HTTP Handlers               │
 ├─────────────────────────────────┤
@@ -49,7 +49,7 @@
 ## Features
 
 - **Embedded MCP server** — no external gateway needed; the server runs inside Blender's Python interpreter
-- **55+ pre-built tools** — scene management, object manipulation, materials, rendering, nodes, physics, scripting and more
+- **65+ pre-built tools** — scene management, object manipulation, UVs, materials, rendering, nodes, physics, scripting and more
 - **Extensible skill system** — drop new skill folders alongside built-ins or point to them via env vars
 - **Main-thread host adapter** — `BlenderHost` drives dispatcher ticks through `bpy.app.timers` or a background loop
 - **Streamable HTTP transport** — compatible with any MCP 2025-03-26 client
@@ -64,6 +64,7 @@
 | **blender-scene** | `new_scene`, `open_scene`, `save_scene`, `list_objects`, `get_scene_info`, `get_session_info` |
 | **blender-objects** | `create_object`, `delete_object`, `duplicate_object`, `move_object`, `rotate_object`, `scale_object`, `get_object_info` |
 | **blender-mesh** | `add_modifier`, `apply_modifier`, `list_modifiers`, `get_mesh_info` |
+| **blender-uv-ops** | `list_uv_maps`, `create_uv_map`, `delete_uv_map`, `copy_uv_map`, `get_uv_info`, `get_uv_islands`, `project_uvs`, `unwrap_uvs`, `pack_uvs`, `normalize_uvs` |
 | **blender-materials** | `create_material`, `assign_material`, `set_material_color`, `list_materials`, `delete_material` |
 | **blender-shader-nodes** | `list_material_nodes`, `set_principled_input` |
 | **blender-render** | `render_scene`, `set_render_settings`, `get_render_info`, `capture_viewport` |

--- a/src/dcc_mcp_blender/_uv_ops.py
+++ b/src/dcc_mcp_blender/_uv_ops.py
@@ -1,0 +1,699 @@
+"""Shared implementations for bundled Blender UV skill tools."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from math import isfinite
+from typing import Any, Iterable, Mapping
+
+from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
+
+_AXES = {
+    "x": (1, 2),
+    "y": (0, 2),
+    "z": (0, 1),
+}
+_PROJECT_METHODS = {"planar", "cube", "bounds", "smart", "sphere", "cylinder", "view"}
+_UNWRAP_METHODS = {"angle_based", "conformal", "smart"}
+
+
+def _require_mesh_object(bpy: Any, object_name: str) -> tuple[Any | None, dict | None]:
+    obj = bpy.data.objects.get(object_name)
+    if obj is None:
+        return None, skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+    if getattr(obj, "type", None) != "MESH":
+        return None, skill_error(f"{object_name} is not a mesh", f"Object type is {getattr(obj, 'type', None)}.")
+    return obj, None
+
+
+def _validate_name(value: str, label: str) -> dict | None:
+    if not isinstance(value, str) or not value.strip():
+        return skill_error(f"Invalid {label}", f"{label} must be a non-empty string.")
+    return None
+
+
+def _validate_margin(margin: float) -> dict | None:
+    if not isinstance(margin, (int, float)) or not isfinite(float(margin)):
+        return skill_error("Invalid margin", "margin must be a finite number.")
+    if float(margin) < 0 or float(margin) >= 0.5:
+        return skill_error("Invalid margin", "margin must be in the range [0.0, 0.5).")
+    return None
+
+
+def _uv_layers(mesh: Any) -> Any:
+    return mesh.uv_layers
+
+
+def _get_uv_layer(mesh: Any, name: str | None = None) -> Any | None:
+    layers = _uv_layers(mesh)
+    if name:
+        getter = getattr(layers, "get", None)
+        if callable(getter):
+            return getter(name)
+        for layer in layers:
+            if getattr(layer, "name", None) == name:
+                return layer
+        return None
+    active = getattr(layers, "active", None)
+    if active is not None:
+        return active
+    return next(iter(layers), None)
+
+
+def _ensure_uv_layer(mesh: Any, name: str | None = None, *, set_active: bool = True) -> Any:
+    existing = _get_uv_layer(mesh, name)
+    if existing is not None:
+        if set_active:
+            _set_active_uv_layer(mesh, existing)
+        return existing
+
+    layer_name = name or "UVMap"
+    layer = mesh.uv_layers.new(name=layer_name)
+    if set_active:
+        _set_active_uv_layer(mesh, layer)
+    return layer
+
+
+def _set_active_uv_layer(mesh: Any, layer: Any) -> None:
+    layers = _uv_layers(mesh)
+    try:
+        layers.active = layer
+    except Exception:
+        pass
+    for index, existing in enumerate(layers):
+        if existing is layer or getattr(existing, "name", None) == getattr(layer, "name", None):
+            try:
+                layers.active_index = index
+            except Exception:
+                pass
+            break
+
+
+def _layer_summary(mesh: Any, layer: Any, index: int) -> dict:
+    active = _get_uv_layer(mesh)
+    return {
+        "name": getattr(layer, "name", ""),
+        "index": index,
+        "active": layer is active or getattr(layer, "name", None) == getattr(active, "name", None),
+        "coordinate_count": len(getattr(layer, "data", [])),
+    }
+
+
+def _mesh_uv_context(obj: Any) -> dict:
+    mesh = obj.data
+    layers = list(_uv_layers(mesh))
+    active = _get_uv_layer(mesh)
+    return {
+        "object_name": obj.name,
+        "mesh_name": mesh.name,
+        "uv_map_count": len(layers),
+        "active_uv_map": getattr(active, "name", None),
+        "uv_maps": [_layer_summary(mesh, layer, index) for index, layer in enumerate(layers)],
+    }
+
+
+def _co(value: Any) -> tuple[float, float, float]:
+    return (float(value[0]), float(value[1]), float(value[2]))
+
+
+def _uv_pair(value: Any) -> list[float]:
+    return [float(value[0]), float(value[1])]
+
+
+def _uv_key(value: Any) -> tuple[float, float]:
+    u, v = _uv_pair(value)
+    return (round(u, 6), round(v, 6))
+
+
+def _set_uv(loop_data: Any, u: float, v: float) -> None:
+    try:
+        loop_data.uv = (float(u), float(v))
+    except Exception:
+        loop_data.uv[0] = float(u)
+        loop_data.uv[1] = float(v)
+
+
+def _normalize_pairs(pairs: Mapping[int, tuple[float, float]], margin: float) -> dict[int, tuple[float, float]]:
+    if not pairs:
+        return {}
+    us = [pair[0] for pair in pairs.values()]
+    vs = [pair[1] for pair in pairs.values()]
+    min_u, max_u = min(us), max(us)
+    min_v, max_v = min(vs), max(vs)
+    span_u = max(max_u - min_u, 1e-9)
+    span_v = max(max_v - min_v, 1e-9)
+    scale = max(0.0, 1.0 - (margin * 2.0))
+    return {
+        loop_index: (
+            margin + ((u - min_u) / span_u) * scale,
+            margin + ((v - min_v) / span_v) * scale,
+        )
+        for loop_index, (u, v) in pairs.items()
+    }
+
+
+def _update_mesh(mesh: Any) -> None:
+    update = getattr(mesh, "update", None)
+    if callable(update):
+        update()
+
+
+def list_uv_maps(object_name: str) -> dict:
+    """List UV maps on a mesh object."""
+    try:
+        import bpy
+
+        obj, error = _require_mesh_object(bpy, object_name)
+        if error:
+            return error
+        return skill_success(
+            f"UV maps for {object_name}",
+            **_mesh_uv_context(obj),
+            prompt="Use create_uv_map, copy_uv_map, or get_uv_info for detailed UV work.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to list UV maps for {object_name}")
+
+
+def create_uv_map(object_name: str, name: str, set_active: bool = True) -> dict:
+    """Create a UV map on a mesh object."""
+    name_error = _validate_name(name, "name")
+    if name_error:
+        return name_error
+    try:
+        import bpy
+
+        obj, error = _require_mesh_object(bpy, object_name)
+        if error:
+            return error
+        mesh = obj.data
+        if _get_uv_layer(mesh, name) is not None:
+            return skill_error(f"UV map already exists: {name}", f"{object_name} already has a UV map named '{name}'.")
+
+        layer = mesh.uv_layers.new(name=name)
+        if set_active:
+            _set_active_uv_layer(mesh, layer)
+        _update_mesh(mesh)
+        return skill_success(
+            f"Created UV map {name} on {object_name}",
+            created_uv_map=layer.name,
+            set_active=set_active,
+            **_mesh_uv_context(obj),
+            prompt="Use project_uvs or unwrap_uvs to populate the new UV map.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to create UV map {name} on {object_name}")
+
+
+def delete_uv_map(object_name: str, name: str) -> dict:
+    """Delete a UV map from a mesh object."""
+    name_error = _validate_name(name, "name")
+    if name_error:
+        return name_error
+    try:
+        import bpy
+
+        obj, error = _require_mesh_object(bpy, object_name)
+        if error:
+            return error
+        mesh = obj.data
+        layer = _get_uv_layer(mesh, name)
+        if layer is None:
+            return skill_error(f"UV map not found: {name}", f"{object_name} has no UV map named '{name}'.")
+
+        mesh.uv_layers.remove(layer)
+        _update_mesh(mesh)
+        return skill_success(
+            f"Deleted UV map {name} from {object_name}",
+            deleted_uv_map=name,
+            **_mesh_uv_context(obj),
+            prompt="Use list_uv_maps to confirm the remaining active UV map.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to delete UV map {name} from {object_name}")
+
+
+def copy_uv_map(object_name: str, source: str, target: str) -> dict:
+    """Copy UV coordinates from one UV map to a new UV map."""
+    for value, label in ((source, "source"), (target, "target")):
+        name_error = _validate_name(value, label)
+        if name_error:
+            return name_error
+    try:
+        import bpy
+
+        obj, error = _require_mesh_object(bpy, object_name)
+        if error:
+            return error
+        mesh = obj.data
+        source_layer = _get_uv_layer(mesh, source)
+        if source_layer is None:
+            return skill_error(f"Source UV map not found: {source}", f"{object_name} has no UV map named '{source}'.")
+        if _get_uv_layer(mesh, target) is not None:
+            return skill_error(f"Target UV map already exists: {target}", "Choose a new target UV map name.")
+
+        target_layer = mesh.uv_layers.new(name=target)
+        for src_loop, dst_loop in zip(source_layer.data, target_layer.data):
+            src_u, src_v = _uv_pair(src_loop.uv)
+            _set_uv(dst_loop, src_u, src_v)
+        _set_active_uv_layer(mesh, target_layer)
+        _update_mesh(mesh)
+        return skill_success(
+            f"Copied UV map {source} to {target} on {object_name}",
+            source_uv_map=source,
+            target_uv_map=target,
+            copied_coordinate_count=len(target_layer.data),
+            **_mesh_uv_context(obj),
+            prompt="Use normalize_uvs or pack_uvs to prepare the copied UV map for texturing.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to copy UV map {source} to {target} on {object_name}")
+
+
+def get_uv_info(object_name: str) -> dict:
+    """Return UV map and coordinate statistics for a mesh object."""
+    try:
+        import bpy
+
+        obj, error = _require_mesh_object(bpy, object_name)
+        if error:
+            return error
+        mesh = obj.data
+        active = _get_uv_layer(mesh)
+        polygons = list(getattr(mesh, "polygons", []))
+        loop_count = sum(len(getattr(poly, "loop_indices", [])) for poly in polygons)
+        island_count = len(_calculate_uv_islands(mesh, active)) if active is not None else 0
+        return skill_success(
+            f"UV info for {object_name}",
+            polygon_count=len(polygons),
+            loop_count=loop_count,
+            uv_coordinate_count=len(getattr(active, "data", [])) if active is not None else 0,
+            island_count=island_count,
+            has_uvs=active is not None,
+            **_mesh_uv_context(obj),
+            prompt="Use get_uv_islands for shell bounds or project_uvs/unwrap_uvs for UV generation.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to get UV info for {object_name}")
+
+
+def get_uv_islands(object_name: str, uv_map: str | None = None) -> dict:
+    """Return UV island summaries for a mesh UV map."""
+    try:
+        import bpy
+
+        obj, error = _require_mesh_object(bpy, object_name)
+        if error:
+            return error
+        mesh = obj.data
+        layer = _get_uv_layer(mesh, uv_map)
+        if layer is None:
+            label = uv_map or "active UV map"
+            return skill_error(f"UV map not found: {label}", f"{object_name} has no {label}.")
+
+        islands = _calculate_uv_islands(mesh, layer)
+        return skill_success(
+            f"Found {len(islands)} UV island(s) on {object_name}",
+            object_name=obj.name,
+            mesh_name=mesh.name,
+            uv_map=layer.name,
+            island_count=len(islands),
+            islands=islands,
+            prompt="Use pack_uvs to arrange islands or normalize_uvs to fit coordinates into 0-1 space.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to get UV islands for {object_name}")
+
+
+def _calculate_uv_islands(mesh: Any, layer: Any) -> list[dict]:
+    polygons = list(getattr(mesh, "polygons", []))
+    if not polygons:
+        return []
+
+    parent = list(range(len(polygons)))
+
+    def find(index: int) -> int:
+        while parent[index] != index:
+            parent[index] = parent[parent[index]]
+            index = parent[index]
+        return index
+
+    def union(left: int, right: int) -> None:
+        root_left = find(left)
+        root_right = find(right)
+        if root_left != root_right:
+            parent[root_right] = root_left
+
+    edge_owner: dict[tuple, int] = {}
+    loops = getattr(mesh, "loops", [])
+    for poly_index, poly in enumerate(polygons):
+        loop_indices = list(getattr(poly, "loop_indices", []))
+        for left, right in zip(loop_indices, loop_indices[1:] + loop_indices[:1]):
+            left_loop = loops[left]
+            right_loop = loops[right]
+            key_parts = [
+                (getattr(left_loop, "vertex_index", left), _uv_key(layer.data[left].uv)),
+                (getattr(right_loop, "vertex_index", right), _uv_key(layer.data[right].uv)),
+            ]
+            key = tuple(sorted(key_parts))
+            owner = edge_owner.get(key)
+            if owner is None:
+                edge_owner[key] = poly_index
+            else:
+                union(poly_index, owner)
+
+    groups: dict[int, list[Any]] = defaultdict(list)
+    for poly_index, poly in enumerate(polygons):
+        groups[find(poly_index)].append(poly)
+
+    islands = []
+    for island_index, faces in enumerate(groups.values()):
+        loop_indices = sorted({loop_index for face in faces for loop_index in getattr(face, "loop_indices", [])})
+        coords = [_uv_pair(layer.data[loop_index].uv) for loop_index in loop_indices]
+        min_u = min((coord[0] for coord in coords), default=0.0)
+        max_u = max((coord[0] for coord in coords), default=0.0)
+        min_v = min((coord[1] for coord in coords), default=0.0)
+        max_v = max((coord[1] for coord in coords), default=0.0)
+        islands.append(
+            {
+                "index": island_index,
+                "face_indices": [int(getattr(face, "index", fallback)) for fallback, face in enumerate(faces)],
+                "face_count": len(faces),
+                "loop_count": len(loop_indices),
+                "bounds": {
+                    "min": [min_u, min_v],
+                    "max": [max_u, max_v],
+                    "size": [max_u - min_u, max_v - min_v],
+                },
+            }
+        )
+    return islands
+
+
+def project_uvs(object_name: str, method: str = "planar", axis: str = "z", margin: float = 0.0) -> dict:
+    """Project UV coordinates onto a mesh."""
+    margin_error = _validate_margin(margin)
+    if margin_error:
+        return margin_error
+    method_key = method.lower().replace("-", "_")
+    axis_key = axis.lower()
+    if method_key not in _PROJECT_METHODS:
+        return skill_error("Invalid projection method", f"Use one of: {', '.join(sorted(_PROJECT_METHODS))}.")
+    if axis_key not in _AXES:
+        return skill_error("Invalid axis", "axis must be one of: x, y, z.")
+
+    try:
+        import bpy
+
+        obj, error = _require_mesh_object(bpy, object_name)
+        if error:
+            return error
+        mesh = obj.data
+        layer = _ensure_uv_layer(mesh, set_active=True)
+
+        if method_key in {"smart", "sphere", "cylinder", "view"}:
+            operator_result = _run_projection_operator(bpy, obj, method_key, float(margin))
+            _update_mesh(mesh)
+            return skill_success(
+                f"Projected UVs on {object_name} using {method_key}",
+                uv_map=layer.name,
+                method=method_key,
+                axis=axis_key,
+                margin=float(margin),
+                operator_result=operator_result,
+                **_mesh_uv_context(obj),
+                prompt="Use get_uv_islands or pack_uvs to inspect and arrange the generated UV shells.",
+            )
+
+        assignments = _project_mesh_coordinates(mesh, layer, method_key, axis_key, float(margin))
+        _update_mesh(mesh)
+        return skill_success(
+            f"Projected UVs on {object_name} using {method_key}",
+            uv_map=layer.name,
+            method=method_key,
+            axis=axis_key,
+            margin=float(margin),
+            uv_coordinate_count=len(assignments),
+            **_mesh_uv_context(obj),
+            prompt="Use get_uv_islands or pack_uvs to inspect and arrange the generated UV shells.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to project UVs on {object_name}")
+
+
+def _project_mesh_coordinates(
+    mesh: Any, layer: Any, method: str, axis: str, margin: float
+) -> dict[int, tuple[float, float]]:
+    loops = getattr(mesh, "loops", [])
+    vertices = getattr(mesh, "vertices", [])
+    polygons = list(getattr(mesh, "polygons", []))
+    raw: dict[int, tuple[float, float]] = {}
+
+    if method in {"planar", "bounds"}:
+        axes = _AXES[axis]
+        for poly in polygons:
+            for loop_index in getattr(poly, "loop_indices", []):
+                vertex_index = getattr(loops[loop_index], "vertex_index", loop_index)
+                co = _co(vertices[vertex_index].co)
+                raw[loop_index] = (co[axes[0]], co[axes[1]])
+    elif method == "cube":
+        for poly in polygons:
+            normal = _co(getattr(poly, "normal", (0.0, 0.0, 1.0)))
+            drop_axis = max(range(3), key=lambda index: abs(normal[index]))
+            axes = tuple(index for index in range(3) if index != drop_axis)
+            for loop_index in getattr(poly, "loop_indices", []):
+                vertex_index = getattr(loops[loop_index], "vertex_index", loop_index)
+                co = _co(vertices[vertex_index].co)
+                raw[loop_index] = (co[axes[0]], co[axes[1]])
+
+    assignments = _normalize_pairs(raw, margin)
+    for loop_index, (u, v) in assignments.items():
+        _set_uv(layer.data[loop_index], u, v)
+    return assignments
+
+
+def unwrap_uvs(object_name: str, method: str = "angle_based", margin: float = 0.001) -> dict:
+    """Unwrap a mesh through Blender's UV operators."""
+    margin_error = _validate_margin(margin)
+    if margin_error:
+        return margin_error
+    method_key = method.lower().replace("-", "_")
+    if method_key not in _UNWRAP_METHODS:
+        return skill_error("Invalid unwrap method", f"Use one of: {', '.join(sorted(_UNWRAP_METHODS))}.")
+
+    try:
+        import bpy
+
+        obj, error = _require_mesh_object(bpy, object_name)
+        if error:
+            return error
+        mesh = obj.data
+        layer = _ensure_uv_layer(mesh, set_active=True)
+        if method_key == "smart":
+            operator_result = _run_uv_edit_operator(
+                bpy,
+                obj,
+                "smart_project",
+                island_margin=float(margin),
+                correct_aspect=True,
+            )
+        else:
+            operator_result = _run_uv_edit_operator(
+                bpy,
+                obj,
+                "unwrap",
+                method=method_key.upper(),
+                margin=float(margin),
+            )
+        _update_mesh(mesh)
+        return skill_success(
+            f"Unwrapped UVs on {object_name} using {method_key}",
+            uv_map=layer.name,
+            method=method_key,
+            margin=float(margin),
+            operator_result=operator_result,
+            **_mesh_uv_context(obj),
+            prompt="Use get_uv_islands to inspect shell count or pack_uvs to arrange the unwrap.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to unwrap UVs on {object_name}")
+
+
+def pack_uvs(
+    object_name: str,
+    margin: float = 0.001,
+    rotate: bool = True,
+    normalize: bool = True,
+) -> dict:
+    """Pack UV islands through Blender's UV operator."""
+    margin_error = _validate_margin(margin)
+    if margin_error:
+        return margin_error
+    try:
+        import bpy
+
+        obj, error = _require_mesh_object(bpy, object_name)
+        if error:
+            return error
+        mesh = obj.data
+        layer = _get_uv_layer(mesh)
+        if layer is None:
+            return skill_error(f"No UV maps on {object_name}", "Create or unwrap a UV map before packing islands.")
+
+        operator_result = _run_uv_edit_operator(
+            bpy,
+            obj,
+            "pack_islands",
+            margin=float(margin),
+            rotate=bool(rotate),
+        )
+        if normalize:
+            normalize_result = _normalize_layer(layer, float(margin))
+        else:
+            normalize_result = {"normalized_coordinate_count": 0}
+        _update_mesh(mesh)
+        return skill_success(
+            f"Packed UVs on {object_name}",
+            uv_map=layer.name,
+            margin=float(margin),
+            rotate=bool(rotate),
+            normalize=bool(normalize),
+            operator_result=operator_result,
+            **normalize_result,
+            **_mesh_uv_context(obj),
+            prompt="Use get_uv_info or get_uv_islands to inspect the packed result.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to pack UVs on {object_name}")
+
+
+def normalize_uvs(object_name: str, uv_map: str | None = None) -> dict:
+    """Normalize UV coordinates into 0-1 space."""
+    try:
+        import bpy
+
+        obj, error = _require_mesh_object(bpy, object_name)
+        if error:
+            return error
+        mesh = obj.data
+        layer = _get_uv_layer(mesh, uv_map)
+        if layer is None:
+            label = uv_map or "active UV map"
+            return skill_error(f"UV map not found: {label}", f"{object_name} has no {label}.")
+
+        normalized = _normalize_layer(layer, 0.0)
+        _set_active_uv_layer(mesh, layer)
+        _update_mesh(mesh)
+        return skill_success(
+            f"Normalized UVs on {object_name}",
+            uv_map=layer.name,
+            **normalized,
+            **_mesh_uv_context(obj),
+            prompt="Use pack_uvs if the UV islands still need layout spacing.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to normalize UVs on {object_name}")
+
+
+def _normalize_layer(layer: Any, margin: float) -> dict:
+    pairs = {index: tuple(_uv_pair(loop.uv)) for index, loop in enumerate(getattr(layer, "data", []))}
+    assignments = _normalize_pairs(pairs, margin)
+    for loop_index, (u, v) in assignments.items():
+        _set_uv(layer.data[loop_index], u, v)
+    return {
+        "normalized_coordinate_count": len(assignments),
+        "bounds": _bounds_for_uvs(layer.data),
+    }
+
+
+def _bounds_for_uvs(data: Iterable[Any]) -> dict:
+    coords = [_uv_pair(loop.uv) for loop in data]
+    min_u = min((coord[0] for coord in coords), default=0.0)
+    max_u = max((coord[0] for coord in coords), default=0.0)
+    min_v = min((coord[1] for coord in coords), default=0.0)
+    max_v = max((coord[1] for coord in coords), default=0.0)
+    return {
+        "min": [min_u, min_v],
+        "max": [max_u, max_v],
+        "size": [max_u - min_u, max_v - min_v],
+    }
+
+
+def _run_projection_operator(bpy: Any, obj: Any, method: str, margin: float) -> list[str]:
+    if method == "smart":
+        return _run_uv_edit_operator(bpy, obj, "smart_project", island_margin=margin, correct_aspect=True)
+    if method == "sphere":
+        return _run_uv_edit_operator(bpy, obj, "sphere_project", correct_aspect=True, scale_to_bounds=True)
+    if method == "cylinder":
+        return _run_uv_edit_operator(bpy, obj, "cylinder_project", correct_aspect=True, scale_to_bounds=True)
+    return _run_uv_edit_operator(bpy, obj, "project_from_view", correct_aspect=True, scale_to_bounds=True)
+
+
+def _run_uv_edit_operator(bpy: Any, obj: Any, operator_name: str, **kwargs: Any) -> list[str]:
+    _select_mesh_object(bpy, obj)
+    previous_mode = getattr(obj, "mode", "OBJECT")
+    try:
+        bpy.ops.object.mode_set(mode="EDIT")
+        select_mode = getattr(bpy.ops.mesh, "select_mode", None)
+        if callable(select_mode):
+            _call_operator(select_mode, type="FACE")
+        bpy.ops.mesh.select_all(action="SELECT")
+        operator = getattr(bpy.ops.uv, operator_name)
+        result = _call_operator(operator, **kwargs)
+        return sorted(str(item) for item in result) if isinstance(result, set) else [str(result)]
+    finally:
+        target_mode = previous_mode if previous_mode in {"OBJECT", "EDIT"} else "OBJECT"
+        try:
+            bpy.ops.object.mode_set(mode=target_mode)
+        except Exception:
+            bpy.ops.object.mode_set(mode="OBJECT")
+
+
+def _select_mesh_object(bpy: Any, obj: Any) -> None:
+    select_all = getattr(bpy.ops.object, "select_all", None)
+    if callable(select_all):
+        _call_operator(select_all, action="DESELECT")
+    select_set = getattr(obj, "select_set", None)
+    if callable(select_set):
+        select_set(True)
+    bpy.context.view_layer.objects.active = obj
+
+
+def _call_operator(operator: Any, **kwargs: Any) -> Any:
+    allowed = _operator_property_names(operator)
+    if allowed:
+        kwargs = {key: value for key, value in kwargs.items() if key in allowed}
+    return operator(**kwargs)
+
+
+def _operator_property_names(operator: Any) -> set[str]:
+    try:
+        properties = operator.get_rna_type().properties
+    except Exception:
+        return set()
+    names = set()
+    for prop in properties:
+        identifier = getattr(prop, "identifier", None)
+        if identifier and identifier != "rna_type":
+            names.add(identifier)
+    return names

--- a/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
@@ -10,6 +10,7 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | `blender-objects` | scene, authoring | Create, delete, duplicate, transform, and inspect objects. | Load when object-level edits or transforms are requested. | Mutating except object info. | cube, object transform, duplicate, move, rotate, scale |
 | `blender-collection` | scene, organization | Create collections, link objects, and inspect collection structure. | Load when grouping or collection membership matters. | Mutating except collection listing. | collection, group, hierarchy, link object |
 | `blender-mesh` | authoring, modeling | Add/apply/list modifiers and inspect mesh details. | Load when an existing mesh needs modifiers or mesh info. | Mutating except modifier and mesh inspection. | modifier, mesh info, apply, bevel, subdivision |
+| `blender-uv-ops` | authoring, texture prep | Create, copy, inspect, project, unwrap, pack, and normalize UV maps. | Load when texture coordinates or UV islands are requested. | Mutating except UV-map and island inspection. | uv map, unwrap, texture coordinates, projection, pack islands |
 | `blender-geometry` | authoring, interchange, pipeline | Create simple geometry and save/export blend, FBX, or OBJ files. | Load when file output or basic geometry helpers are needed. | Disk-writing and mutating except file existence checks. | sphere, export fbx, export obj, save blend, file exists |
 | `blender-materials` | authoring, lookdev | Create, assign, edit, list, and delete materials. | Load before shader nodes when material slots or colors are enough. | Mutating except material listing. | material, assign, color, shader base, delete material |
 | `blender-shader-nodes` | authoring, node graph, lookdev | Inspect material nodes and edit Principled BSDF inputs. | Load after materials when node-level shader edits are requested. | Mixed: read-only node listing plus shader mutations. | shader nodes, principled, metallic, roughness, sockets |
@@ -27,6 +28,7 @@ This index helps agents choose typed Blender skills before falling back to raw P
 |---|---|
 | Inspect a new session | `blender-scene` -> `blender-objects` -> `blender-mesh` |
 | Build simple geometry | `blender-scene` -> `blender-objects` -> `blender-mesh` or `blender-geometry` |
+| Prepare textured mesh UVs | `blender-mesh` -> `blender-uv-ops` -> `blender-materials` |
 | Material setup | `blender-materials` -> `blender-shader-nodes` -> `blender-render` |
 | Procedural node setup | `blender-objects` -> `blender-geometry-nodes` -> `blender-render` |
 | Physics setup | `blender-objects` -> `blender-mesh` -> `blender-physics` |

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: blender-uv-ops
+description: >-
+  Blender authoring skill for UV maps, texture coordinate projection, unwraps,
+  island inspection, packing, and normalization. Use this before falling back to
+  blender-scripting whenever a task touches UVs or texture coordinates.
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: blender
+    layer: domain
+    stage: authoring
+    version: "1.0.0"
+    tags: [blender, uv, texture, mesh, authoring]
+    search-hint: >-
+      uv map, texture coordinates, unwrap uv, smart project, planar projection,
+      cube projection, uv islands, pack islands, normalize uv, copy uv map
+    tools: tools.yaml
+---
+
+# blender-uv-ops
+
+Typed UV authoring tools for Blender meshes. Load this skill when a workflow
+needs UV maps, texture-coordinate projection, unwraps, UV island diagnostics,
+packing, or normalization.
+
+Prefer `blender-mesh` for topology and modifier work, `blender-materials` for
+material slots, and `blender-shader-nodes` for shader graph edits. Use
+`blender-scripting` only after checking this typed surface.

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/copy_uv_map.py
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/copy_uv_map.py
@@ -1,0 +1,19 @@
+"""Copy UV coordinates between Blender mesh UV maps."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._uv_ops import copy_uv_map
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`copy_uv_map`."""
+    return copy_uv_map(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/create_uv_map.py
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/create_uv_map.py
@@ -1,0 +1,19 @@
+"""Create a UV map on a Blender mesh object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._uv_ops import create_uv_map
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_uv_map`."""
+    return create_uv_map(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/delete_uv_map.py
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/delete_uv_map.py
@@ -1,0 +1,19 @@
+"""Delete a UV map from a Blender mesh object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._uv_ops import delete_uv_map
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`delete_uv_map`."""
+    return delete_uv_map(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/get_uv_info.py
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/get_uv_info.py
@@ -1,0 +1,19 @@
+"""Get UV statistics for a Blender mesh object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._uv_ops import get_uv_info
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_uv_info`."""
+    return get_uv_info(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/get_uv_islands.py
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/get_uv_islands.py
@@ -1,0 +1,19 @@
+"""Get UV island summaries for a Blender mesh object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._uv_ops import get_uv_islands
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_uv_islands`."""
+    return get_uv_islands(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/list_uv_maps.py
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/list_uv_maps.py
@@ -1,0 +1,19 @@
+"""List UV maps on a Blender mesh object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._uv_ops import list_uv_maps
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_uv_maps`."""
+    return list_uv_maps(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/normalize_uvs.py
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/normalize_uvs.py
@@ -1,0 +1,19 @@
+"""Normalize UV coordinates for a Blender mesh object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._uv_ops import normalize_uvs
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`normalize_uvs`."""
+    return normalize_uvs(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/pack_uvs.py
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/pack_uvs.py
@@ -1,0 +1,19 @@
+"""Pack UV islands for a Blender mesh object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._uv_ops import pack_uvs
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`pack_uvs`."""
+    return pack_uvs(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/project_uvs.py
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/project_uvs.py
@@ -1,0 +1,19 @@
+"""Project UV coordinates for a Blender mesh object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._uv_ops import project_uvs
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`project_uvs`."""
+    return project_uvs(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/unwrap_uvs.py
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/unwrap_uvs.py
@@ -1,0 +1,19 @@
+"""Unwrap UVs for a Blender mesh object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._uv_ops import unwrap_uvs
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`unwrap_uvs`."""
+    return unwrap_uvs(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/tools.yaml
@@ -1,0 +1,329 @@
+tools:
+  - name: list_uv_maps
+    description: "List UV maps on a mesh object, including active map and coordinate counts."
+    source_file: scripts/list_uv_maps.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+    output_schema: &uv_result_schema
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: create_uv_map
+    description: "Create a UV map on a mesh object and optionally make it active."
+    source_file: scripts/create_uv_map.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name, name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        name:
+          type: string
+          minLength: 1
+          description: New UV map name.
+        set_active:
+          type: boolean
+          default: true
+          description: Make the created UV map active.
+    output_schema: *uv_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: delete_uv_map
+    description: "Delete a named UV map from a mesh object."
+    source_file: scripts/delete_uv_map.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name, name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        name:
+          type: string
+          minLength: 1
+          description: UV map to delete.
+    output_schema: *uv_result_schema
+    read_only: false
+    destructive: true
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: copy_uv_map
+    description: "Copy UV coordinates from one UV map into a newly-created target map."
+    source_file: scripts/copy_uv_map.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name, source, target]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        source:
+          type: string
+          minLength: 1
+          description: Existing UV map name to copy from.
+        target:
+          type: string
+          minLength: 1
+          description: New UV map name to create.
+    output_schema: *uv_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: get_uv_info
+    description: "Return UV map, coordinate, loop, polygon, and island statistics for a mesh object."
+    source_file: scripts/get_uv_info.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+    output_schema: *uv_result_schema
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: get_uv_islands
+    description: "Summarize UV islands and their face membership and 2D bounds."
+    source_file: scripts/get_uv_islands.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        uv_map:
+          type: string
+          minLength: 1
+          description: Optional UV map name. Defaults to the active UV map.
+    output_schema: *uv_result_schema
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: project_uvs
+    description: "Generate UV coordinates using planar, cube, bounds, smart, sphere, cylinder, or view projection."
+    source_file: scripts/project_uvs.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        method:
+          type: string
+          enum: [planar, cube, bounds, smart, sphere, cylinder, view]
+          default: planar
+          description: Projection method.
+        axis:
+          type: string
+          enum: [x, y, z]
+          default: z
+          description: Projection axis for planar and bounds projection.
+        margin:
+          type: number
+          minimum: 0
+          exclusiveMaximum: 0.5
+          default: 0
+          description: Margin reserved inside 0-1 UV space.
+    output_schema: *uv_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: unwrap_uvs
+    description: "Unwrap selected mesh faces through Blender's smart, angle-based, or conformal UV operators."
+    source_file: scripts/unwrap_uvs.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        method:
+          type: string
+          enum: [angle_based, conformal, smart]
+          default: angle_based
+          description: Blender unwrap method.
+        margin:
+          type: number
+          minimum: 0
+          exclusiveMaximum: 0.5
+          default: 0.001
+          description: Island margin.
+    output_schema: *uv_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: pack_uvs
+    description: "Pack UV islands through Blender's UV packing operator and optionally normalize the result."
+    source_file: scripts/pack_uvs.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        margin:
+          type: number
+          minimum: 0
+          exclusiveMaximum: 0.5
+          default: 0.001
+          description: Island margin.
+        rotate:
+          type: boolean
+          default: true
+          description: Allow island rotation while packing.
+        normalize:
+          type: boolean
+          default: true
+          description: Fit packed coordinates back into 0-1 space.
+    output_schema: *uv_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: normalize_uvs
+    description: "Normalize an active or named UV map into 0-1 UV space."
+    source_file: scripts/normalize_uvs.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        uv_map:
+          type: string
+          minLength: 1
+          description: Optional UV map name. Defaults to the active UV map.
+    output_schema: *uv_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false

--- a/tests/e2e/test_uv_ops_e2e.py
+++ b/tests/e2e/test_uv_ops_e2e.py
@@ -1,0 +1,47 @@
+"""E2E tests for blender-uv-ops skill.
+
+Requires a real Blender Python interpreter.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+bpy = pytest.importorskip("bpy", reason="bpy not available - run inside Blender Python interpreter")
+
+pytestmark = pytest.mark.e2e
+
+from tests.e2e.conftest import load_skill  # noqa: E402
+
+
+def _new_scene():
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+
+
+class TestUvOpsE2E:
+    def setup_method(self):
+        _new_scene()
+
+    def test_project_inspect_and_normalize_uvs(self):
+        bpy.ops.mesh.primitive_cube_add()
+        cube_name = bpy.context.active_object.name
+
+        create_mod = load_skill("blender-uv-ops", "create_uv_map")
+        create_result = create_mod.create_uv_map(object_name=cube_name, name="AgentUV")
+        assert create_result["success"] is True
+
+        project_mod = load_skill("blender-uv-ops", "project_uvs")
+        project_result = project_mod.project_uvs(object_name=cube_name, method="cube", axis="z", margin=0.05)
+        assert project_result["success"] is True
+
+        info_mod = load_skill("blender-uv-ops", "get_uv_info")
+        info_result = info_mod.get_uv_info(object_name=cube_name)
+        assert info_result["success"] is True
+        assert info_result["context"]["active_uv_map"] == "AgentUV"
+        assert info_result["context"]["uv_coordinate_count"] > 0
+
+        normalize_mod = load_skill("blender-uv-ops", "normalize_uvs")
+        normalize_result = normalize_mod.normalize_uvs(object_name=cube_name, uv_map="AgentUV")
+        assert normalize_result["success"] is True
+        assert normalize_result["context"]["bounds"]["min"] == [0.0, 0.0]
+        assert normalize_result["context"]["bounds"]["max"] == [1.0, 1.0]

--- a/tests/test_skills_uv_ops.py
+++ b/tests/test_skills_uv_ops.py
@@ -1,0 +1,280 @@
+"""Unit tests for blender-uv-ops skill scripts (bpy mocked)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import yaml
+
+from tests.conftest import load_and_call, make_mock_bpy
+
+SKILL_DIR = Path(__file__).parent.parent / "src" / "dcc_mcp_blender" / "skills" / "blender-uv-ops"
+
+
+class FakeVertex:
+    def __init__(self, co):
+        self.co = co
+
+
+class FakeLoop:
+    def __init__(self, vertex_index):
+        self.vertex_index = vertex_index
+
+
+class FakePolygon:
+    def __init__(self, index, loop_indices, normal=(0.0, 0.0, 1.0)):
+        self.index = index
+        self.loop_indices = loop_indices
+        self.normal = normal
+
+
+class FakeUVData:
+    def __init__(self, uv=(0.0, 0.0)):
+        self.uv = list(uv)
+
+
+class FakeUVLayer:
+    def __init__(self, name, loop_count, coords=None):
+        self.name = name
+        values = coords or [(0.0, 0.0)] * loop_count
+        self.data = [FakeUVData(uv) for uv in values]
+
+
+class FakeUVLayers:
+    def __init__(self, loop_count, layers=None):
+        self._loop_count = loop_count
+        self._layers = layers or []
+        self.active = self._layers[0] if self._layers else None
+        self.active_index = 0
+
+    def __iter__(self):
+        return iter(self._layers)
+
+    def __len__(self):
+        return len(self._layers)
+
+    def get(self, name):
+        return next((layer for layer in self._layers if layer.name == name), None)
+
+    def new(self, name):
+        layer = FakeUVLayer(name, self._loop_count)
+        self._layers.append(layer)
+        self.active = layer
+        self.active_index = len(self._layers) - 1
+        return layer
+
+    def remove(self, layer):
+        self._layers.remove(layer)
+        self.active = self._layers[0] if self._layers else None
+        self.active_index = 0
+
+
+class FakeMesh:
+    def __init__(self, name="Plane", two_islands=False, with_uv=True):
+        self.name = name
+        if two_islands:
+            self.vertices = [
+                FakeVertex((0.0, 0.0, 0.0)),
+                FakeVertex((1.0, 0.0, 0.0)),
+                FakeVertex((1.0, 1.0, 0.0)),
+                FakeVertex((0.0, 1.0, 0.0)),
+                FakeVertex((3.0, 0.0, 0.0)),
+                FakeVertex((4.0, 0.0, 0.0)),
+                FakeVertex((4.0, 1.0, 0.0)),
+                FakeVertex((3.0, 1.0, 0.0)),
+            ]
+            self.loops = [FakeLoop(index) for index in range(8)]
+            self.polygons = [FakePolygon(0, [0, 1, 2, 3]), FakePolygon(1, [4, 5, 6, 7])]
+            coords = [
+                (0.0, 0.0),
+                (1.0, 0.0),
+                (1.0, 1.0),
+                (0.0, 1.0),
+                (2.0, 0.0),
+                (3.0, 0.0),
+                (3.0, 1.0),
+                (2.0, 1.0),
+            ]
+        else:
+            self.vertices = [
+                FakeVertex((0.0, 0.0, 0.0)),
+                FakeVertex((2.0, 0.0, 0.0)),
+                FakeVertex((2.0, 1.0, 0.0)),
+                FakeVertex((0.0, 1.0, 0.0)),
+            ]
+            self.loops = [FakeLoop(index) for index in range(4)]
+            self.polygons = [FakePolygon(0, [0, 1, 2, 3])]
+            coords = [(2.0, 5.0), (4.0, 5.0), (4.0, 7.0), (2.0, 7.0)]
+        layers = [FakeUVLayer("UVMap", len(self.loops), coords)] if with_uv else []
+        self.uv_layers = FakeUVLayers(len(self.loops), layers=layers)
+        self.update = MagicMock()
+
+
+def _mesh_obj(mesh=None, name="Plane"):
+    obj = MagicMock()
+    obj.name = name
+    obj.type = "MESH"
+    obj.data = mesh or FakeMesh(name)
+    obj.mode = "OBJECT"
+    obj.select_set = MagicMock()
+    return obj
+
+
+def _bpy_for(obj):
+    bpy = make_mock_bpy()
+    bpy.data.objects.get.return_value = obj
+    bpy.ops.uv = MagicMock()
+    bpy.ops.uv.smart_project.return_value = {"FINISHED"}
+    bpy.ops.uv.pack_islands.return_value = {"FINISHED"}
+    return bpy
+
+
+def test_tools_yaml_declares_modern_contract():
+    doc = yaml.safe_load((SKILL_DIR / "tools.yaml").read_text(encoding="utf-8"))
+    expected = {
+        "list_uv_maps",
+        "create_uv_map",
+        "delete_uv_map",
+        "copy_uv_map",
+        "get_uv_info",
+        "get_uv_islands",
+        "project_uvs",
+        "unwrap_uvs",
+        "pack_uvs",
+        "normalize_uvs",
+    }
+    tools = {tool["name"]: tool for tool in doc["tools"]}
+    assert set(tools) == expected
+    for name, tool in tools.items():
+        assert tool["source_file"].startswith("scripts/")
+        assert (SKILL_DIR / tool["source_file"]).exists(), name
+        assert tool["input_schema"]["type"] == "object"
+        assert tool["output_schema"]["properties"]["success"]["type"] == "boolean"
+        assert tool["execution"] == "sync"
+        assert tool["affinity"] == "main"
+        assert isinstance(tool["timeout_hint_secs"], int)
+        assert "annotations" in tool
+
+
+def test_list_and_create_uv_maps():
+    obj = _mesh_obj(FakeMesh(with_uv=False))
+    bpy = _bpy_for(obj)
+
+    result = load_and_call("blender-uv-ops/scripts/create_uv_map.py", bpy, object_name="Plane", name="Lightmap")
+
+    assert result["success"] is True
+    assert result["context"]["created_uv_map"] == "Lightmap"
+    assert result["context"]["active_uv_map"] == "Lightmap"
+
+    result = load_and_call("blender-uv-ops/scripts/list_uv_maps.py", bpy, object_name="Plane")
+    assert result["context"]["uv_map_count"] == 1
+
+
+def test_copy_and_delete_uv_map():
+    obj = _mesh_obj(FakeMesh())
+    bpy = _bpy_for(obj)
+
+    result = load_and_call(
+        "blender-uv-ops/scripts/copy_uv_map.py",
+        bpy,
+        object_name="Plane",
+        source="UVMap",
+        target="UVCopy",
+    )
+
+    assert result["success"] is True
+    copied = obj.data.uv_layers.get("UVCopy")
+    assert copied is not None
+    assert list(copied.data[0].uv) == [2.0, 5.0]
+
+    result = load_and_call("blender-uv-ops/scripts/delete_uv_map.py", bpy, object_name="Plane", name="UVCopy")
+    assert result["success"] is True
+    assert obj.data.uv_layers.get("UVCopy") is None
+
+
+def test_get_uv_info_and_islands():
+    obj = _mesh_obj(FakeMesh(two_islands=True))
+    bpy = _bpy_for(obj)
+
+    info = load_and_call("blender-uv-ops/scripts/get_uv_info.py", bpy, object_name="Plane")
+    assert info["success"] is True
+    assert info["context"]["island_count"] == 2
+    assert info["context"]["uv_coordinate_count"] == 8
+
+    islands = load_and_call("blender-uv-ops/scripts/get_uv_islands.py", bpy, object_name="Plane")
+    assert islands["success"] is True
+    assert islands["context"]["island_count"] == 2
+    assert islands["context"]["islands"][0]["face_count"] == 1
+
+
+def test_project_planar_uvs_writes_normalized_coordinates():
+    obj = _mesh_obj(FakeMesh(with_uv=False))
+    bpy = _bpy_for(obj)
+
+    result = load_and_call(
+        "blender-uv-ops/scripts/project_uvs.py",
+        bpy,
+        object_name="Plane",
+        method="planar",
+        axis="z",
+        margin=0.1,
+    )
+
+    assert result["success"] is True
+    layer = obj.data.uv_layers.active
+    coords = [coord for loop in layer.data for coord in loop.uv]
+    assert min(coords) >= 0.1
+    assert max(coords) <= 0.9
+
+
+def test_unwrap_smart_uses_blender_uv_operator():
+    obj = _mesh_obj(FakeMesh())
+    bpy = _bpy_for(obj)
+
+    result = load_and_call(
+        "blender-uv-ops/scripts/unwrap_uvs.py",
+        bpy,
+        object_name="Plane",
+        method="smart",
+        margin=0.01,
+    )
+
+    assert result["success"] is True
+    bpy.ops.uv.smart_project.assert_called_once()
+    bpy.ops.object.mode_set.assert_any_call(mode="EDIT")
+    bpy.ops.object.mode_set.assert_any_call(mode="OBJECT")
+
+
+def test_pack_and_normalize_uvs():
+    obj = _mesh_obj(FakeMesh())
+    bpy = _bpy_for(obj)
+
+    packed = load_and_call(
+        "blender-uv-ops/scripts/pack_uvs.py",
+        bpy,
+        object_name="Plane",
+        margin=0.05,
+        rotate=False,
+        normalize=True,
+    )
+    assert packed["success"] is True
+    bpy.ops.uv.pack_islands.assert_called_once()
+
+    normalized = load_and_call("blender-uv-ops/scripts/normalize_uvs.py", bpy, object_name="Plane")
+    assert normalized["success"] is True
+    assert normalized["context"]["bounds"]["min"] == [0.0, 0.0]
+    assert normalized["context"]["bounds"]["max"] == [1.0, 1.0]
+
+
+def test_missing_and_non_mesh_objects_return_errors():
+    bpy = make_mock_bpy()
+    bpy.data.objects.get.return_value = None
+    missing = load_and_call("blender-uv-ops/scripts/list_uv_maps.py", bpy, object_name="Ghost")
+    assert missing["success"] is False
+
+    obj = MagicMock()
+    obj.type = "LIGHT"
+    bpy.data.objects.get.return_value = obj
+    non_mesh = load_and_call("blender-uv-ops/scripts/get_uv_info.py", bpy, object_name="Sun")
+    assert non_mesh["success"] is False


### PR DESCRIPTION
## Summary

- Add bundled lender-uv-ops with typed UV-map, projection, unwrap, packing, normalization, and island inspection tools.
- Document the UV skill in the README and staged skills index.
- Add mocked unit coverage plus a real Blender UV E2E smoke.

## Validation

- python -m ruff check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py packaging/addon_entry/__init__.py .github/scripts/start_mcp_server.py .github/scripts/start_mcp_server2.py
- python -m ruff format --check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py packaging/addon_entry/__init__.py .github/scripts/start_mcp_server.py .github/scripts/start_mcp_server2.py
- python tools/lint_skills.py --warnings-as-errors
- python -m pytest tests/ -q
- Blender 4.4.3 background E2E: 	ests/e2e/test_uv_ops_e2e.py
- Local MCP HTTP smoke: create cube -> create/project/inspect/normalize UVs (HTTP_UV_SMOKE_OK 99 24)
- python -m build
- python packaging/assemble_zip.py --platform win64 --output-dir dist_addon

## Notes

- Opened loonghao/dcc-mcp-core#1267 for the core async main-thread job dispatch wire issue found during HTTP validation. The UV tools keep explicit 	imeout_hint_secs: 0 until core's positive-timeout async lane is fixed.

Fixes #27