### PR TITLE
feat: add blender mesh and scene operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 ├─────────────────────────────────┤
 │  dcc_mcp_blender                │
 │  ├─ BlenderMcpServer            │
-│  ├─ SkillCatalog (65+ tools)    │
+│  ├─ SkillCatalog (85+ tools)    │
 │  ├─ ActionRegistry              │
 │  └─ HTTP Handlers               │
 ├─────────────────────────────────┤
@@ -49,7 +49,7 @@
 ## Features
 
 - **Embedded MCP server** — no external gateway needed; the server runs inside Blender's Python interpreter
-- **65+ pre-built tools** — scene management, object manipulation, UVs, materials, rendering, nodes, physics, scripting and more
+- **85+ pre-built tools** — scene management, object manipulation, mesh/UV editing, materials, rendering, nodes, physics, scripting and more
 - **Extensible skill system** — drop new skill folders alongside built-ins or point to them via env vars
 - **Main-thread host adapter** — `BlenderHost` drives dispatcher ticks through `bpy.app.timers` or a background loop
 - **Streamable HTTP transport** — compatible with any MCP 2025-03-26 client
@@ -62,8 +62,9 @@
 | Category | Tools |
 |---|---|
 | **blender-scene** | `new_scene`, `open_scene`, `save_scene`, `list_objects`, `get_scene_info`, `get_session_info` |
-| **blender-objects** | `create_object`, `delete_object`, `duplicate_object`, `move_object`, `rotate_object`, `scale_object`, `get_object_info` |
+| **blender-objects** | `create_object`, `delete_object`, `duplicate_object`, `move_object`, `rotate_object`, `scale_object`, `get_object_info`, `get_selection`, `set_selection`, `select_by_type`, `find_by_pattern`, `rename_object`, `parent_object`, `group_objects`, `set_visibility`, `get_bounding_box`, `center_origin`, `freeze_transforms` |
 | **blender-mesh** | `add_modifier`, `apply_modifier`, `list_modifiers`, `get_mesh_info` |
+| **blender-mesh-ops** | `get_poly_count`, `cleanup_mesh`, `triangulate_mesh`, `separate_mesh`, `combine_meshes`, `merge_vertices`, `extract_faces`, `mirror_mesh`, `select_by_material` |
 | **blender-uv-ops** | `list_uv_maps`, `create_uv_map`, `delete_uv_map`, `copy_uv_map`, `get_uv_info`, `get_uv_islands`, `project_uvs`, `unwrap_uvs`, `pack_uvs`, `normalize_uvs` |
 | **blender-materials** | `create_material`, `assign_material`, `set_material_color`, `list_materials`, `delete_material` |
 | **blender-shader-nodes** | `list_material_nodes`, `set_principled_input` |

--- a/src/dcc_mcp_blender/_mesh_ops.py
+++ b/src/dcc_mcp_blender/_mesh_ops.py
@@ -1,0 +1,438 @@
+"""Shared implementations for Blender mesh editing operation tools."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
+
+_SEPARATE_MODES = {"selected": "SELECTED", "material": "MATERIAL", "loose": "LOOSE"}
+_MIRROR_AXES = {"x": 0, "y": 1, "z": 2}
+
+
+def _mesh_object(bpy: Any, object_name: str) -> tuple[Any | None, dict | None]:
+    obj = bpy.data.objects.get(object_name)
+    if obj is None:
+        return None, skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+    if getattr(obj, "type", None) != "MESH":
+        return None, skill_error(f"{object_name} is not a mesh", f"Object type is {getattr(obj, 'type', None)}.")
+    return obj, None
+
+
+def _mesh_counts(obj: Any) -> dict:
+    mesh = obj.data
+    return {
+        "object_name": obj.name,
+        "mesh_name": mesh.name,
+        "vertex_count": len(getattr(mesh, "vertices", [])),
+        "edge_count": len(getattr(mesh, "edges", [])),
+        "face_count": len(getattr(mesh, "polygons", [])),
+        "loop_count": len(getattr(mesh, "loops", [])),
+        "material_count": len(getattr(mesh, "materials", [])),
+        "uv_map_count": len(getattr(mesh, "uv_layers", [])),
+    }
+
+
+def _tri_count(obj: Any) -> int:
+    total = 0
+    for poly in getattr(obj.data, "polygons", []):
+        vertices = len(getattr(poly, "vertices", []))
+        total += max(vertices - 2, 0)
+    return total
+
+
+def _select_active(bpy: Any, obj: Any) -> None:
+    try:
+        bpy.ops.object.mode_set(mode="OBJECT")
+    except Exception:
+        pass
+    try:
+        bpy.ops.object.select_all(action="DESELECT")
+    except Exception:
+        pass
+    select_set = getattr(obj, "select_set", None)
+    if callable(select_set):
+        select_set(True)
+    bpy.context.view_layer.objects.active = obj
+    try:
+        bpy.context.active_object = obj
+    except Exception:
+        pass
+
+
+def _edit_select_all(bpy: Any, obj: Any) -> None:
+    _select_active(bpy, obj)
+    bpy.ops.object.mode_set(mode="EDIT")
+    select_mode = getattr(bpy.ops.mesh, "select_mode", None)
+    if callable(select_mode):
+        select_mode(type="FACE")
+    bpy.ops.mesh.select_all(action="SELECT")
+
+
+def _return_object_mode(bpy: Any) -> None:
+    try:
+        bpy.ops.object.mode_set(mode="OBJECT")
+    except Exception:
+        pass
+
+
+def _call_mesh_operator(primary: Any, fallback: Any | None = None, **kwargs: Any) -> Any:
+    try:
+        return primary(**kwargs)
+    except TypeError:
+        filtered = {key: value for key, value in kwargs.items() if key not in {"threshold", "distance"}}
+        try:
+            return primary(**filtered)
+        except TypeError:
+            if fallback is None:
+                raise
+            return fallback(**kwargs)
+
+
+def get_poly_count(object_name: str) -> dict:
+    """Return mesh polygon counts and derived triangle count."""
+    try:
+        import bpy
+
+        obj, error = _mesh_object(bpy, object_name)
+        if error:
+            return error
+        return skill_success(
+            f"Mesh counts for {obj.name}",
+            triangle_count=_tri_count(obj),
+            **_mesh_counts(obj),
+            prompt="Use cleanup_mesh or triangulate_mesh when the topology needs editing.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to get poly count for {object_name}")
+
+
+def cleanup_mesh(
+    object_name: str,
+    remove_doubles: bool = True,
+    fix_normals: bool = True,
+    delete_loose: bool = True,
+    merge_threshold: float = 0.0001,
+) -> dict:
+    """Run common cleanup operators on a mesh."""
+    if merge_threshold < 0:
+        return skill_error("Invalid merge_threshold", "merge_threshold must be non-negative.")
+    try:
+        import bpy
+
+        obj, error = _mesh_object(bpy, object_name)
+        if error:
+            return error
+        before = _mesh_counts(obj)
+        _edit_select_all(bpy, obj)
+        operations = []
+        if remove_doubles:
+            merge = getattr(bpy.ops.mesh, "merge_by_distance", None)
+            remove = getattr(bpy.ops.mesh, "remove_doubles", None)
+            if callable(merge):
+                _call_mesh_operator(merge, distance=merge_threshold)
+            elif callable(remove):
+                _call_mesh_operator(remove, threshold=merge_threshold)
+            operations.append("remove_doubles")
+        if fix_normals:
+            bpy.ops.mesh.normals_make_consistent(inside=False)
+            operations.append("fix_normals")
+        if delete_loose:
+            delete_loose_op = getattr(bpy.ops.mesh, "delete_loose", None)
+            if callable(delete_loose_op):
+                delete_loose_op()
+            operations.append("delete_loose")
+        _return_object_mode(bpy)
+        after = _mesh_counts(obj)
+        return skill_success(
+            f"Cleaned mesh {obj.name}",
+            operations=operations,
+            before=before,
+            after=after,
+            object_name=obj.name,
+            prompt="Use get_poly_count to inspect the cleaned mesh.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        _safe_object_mode()
+        return skill_exception(exc, message=f"Failed to clean mesh {object_name}")
+
+
+def triangulate_mesh(object_name: str) -> dict:
+    """Triangulate mesh faces."""
+    try:
+        import bpy
+
+        obj, error = _mesh_object(bpy, object_name)
+        if error:
+            return error
+        before = _mesh_counts(obj)
+        _edit_select_all(bpy, obj)
+        bpy.ops.mesh.quads_convert_to_tris()
+        _return_object_mode(bpy)
+        after = _mesh_counts(obj)
+        return skill_success(
+            f"Triangulated mesh {obj.name}",
+            before=before,
+            after=after,
+            object_name=obj.name,
+            prompt="Use get_poly_count to inspect the triangulated result.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        _safe_object_mode()
+        return skill_exception(exc, message=f"Failed to triangulate mesh {object_name}")
+
+
+def separate_mesh(object_name: str, mode: str = "loose") -> dict:
+    """Separate a mesh by selected faces, material, or loose parts."""
+    mode_key = mode.lower()
+    if mode_key not in _SEPARATE_MODES:
+        return skill_error("Invalid separate mode", f"Use one of: {', '.join(sorted(_SEPARATE_MODES))}.")
+    try:
+        import bpy
+
+        obj, error = _mesh_object(bpy, object_name)
+        if error:
+            return error
+        before_names = {obj.name for obj in bpy.data.objects}
+        _edit_select_all(bpy, obj)
+        bpy.ops.mesh.separate(type=_SEPARATE_MODES[mode_key])
+        _return_object_mode(bpy)
+        after_names = {obj.name for obj in bpy.data.objects}
+        created = sorted(after_names - before_names)
+        return skill_success(
+            f"Separated mesh {object_name}",
+            object_name=object_name,
+            mode=mode_key,
+            created_objects=created,
+            created_count=len(created),
+            prompt="Use list_objects or set_selection to inspect the separated objects.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        _safe_object_mode()
+        return skill_exception(exc, message=f"Failed to separate mesh {object_name}")
+
+
+def combine_meshes(object_names: Sequence[str], new_name: str | None = None) -> dict:
+    """Join multiple mesh objects into one mesh."""
+    if not object_names or isinstance(object_names, str):
+        return skill_error("Invalid object_names", "object_names must be a non-empty list of mesh object names.")
+    try:
+        import bpy
+
+        objects = []
+        missing = []
+        for name in object_names:
+            obj, error = _mesh_object(bpy, name)
+            if error:
+                missing.append(name)
+            else:
+                objects.append(obj)
+        if missing:
+            return skill_error("Object not found", f"Missing or non-mesh object(s): {', '.join(missing)}")
+        if len(objects) < 2:
+            return skill_error("Need at least two meshes", "combine_meshes requires two or more mesh objects.")
+
+        try:
+            bpy.ops.object.mode_set(mode="OBJECT")
+        except Exception:
+            pass
+        bpy.ops.object.select_all(action="DESELECT")
+        for obj in objects:
+            obj.select_set(True)
+        bpy.context.view_layer.objects.active = objects[0]
+        bpy.ops.object.join()
+        combined = bpy.context.view_layer.objects.active or objects[0]
+        if new_name:
+            combined.name = new_name
+            if getattr(combined, "data", None) is not None:
+                combined.data.name = new_name
+        return skill_success(
+            f"Combined {len(objects)} mesh object(s)",
+            source_objects=list(object_names),
+            combined_count=len(objects),
+            **_mesh_counts(combined),
+            prompt="Use get_poly_count or get_bounding_box to inspect the combined mesh.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to combine meshes")
+
+
+def merge_vertices(object_name: str, threshold: float = 0.0001) -> dict:
+    """Merge nearby mesh vertices by distance."""
+    if threshold < 0:
+        return skill_error("Invalid threshold", "threshold must be non-negative.")
+    try:
+        import bpy
+
+        obj, error = _mesh_object(bpy, object_name)
+        if error:
+            return error
+        before = _mesh_counts(obj)
+        _edit_select_all(bpy, obj)
+        merge = getattr(bpy.ops.mesh, "merge_by_distance", None)
+        remove = getattr(bpy.ops.mesh, "remove_doubles", None)
+        if callable(merge):
+            _call_mesh_operator(merge, distance=threshold)
+        elif callable(remove):
+            _call_mesh_operator(remove, threshold=threshold)
+        else:
+            return skill_error(
+                "Merge operator unavailable", "Neither merge_by_distance nor remove_doubles is available."
+            )
+        _return_object_mode(bpy)
+        after = _mesh_counts(obj)
+        return skill_success(
+            f"Merged vertices on {obj.name}",
+            object_name=obj.name,
+            threshold=threshold,
+            before=before,
+            after=after,
+            prompt="Use get_poly_count to inspect the merged mesh.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        _safe_object_mode()
+        return skill_exception(exc, message=f"Failed to merge vertices on {object_name}")
+
+
+def extract_faces(object_name: str, face_indices: Sequence[int], new_name: str | None = None) -> dict:
+    """Separate selected face indices into a new object."""
+    if not face_indices or isinstance(face_indices, str):
+        return skill_error("Invalid face_indices", "face_indices must be a non-empty list of polygon indices.")
+    try:
+        import bpy
+
+        obj, error = _mesh_object(bpy, object_name)
+        if error:
+            return error
+        polygons = list(obj.data.polygons)
+        invalid = [index for index in face_indices if index < 0 or index >= len(polygons)]
+        if invalid:
+            return skill_error("Invalid face index", f"Out-of-range face index/indices: {invalid}")
+
+        before_names = {obj.name for obj in bpy.data.objects}
+        _select_active(bpy, obj)
+        for poly in polygons:
+            poly.select = int(poly.index) in set(face_indices)
+        bpy.ops.object.mode_set(mode="EDIT")
+        bpy.ops.mesh.separate(type="SELECTED")
+        _return_object_mode(bpy)
+        after_names = {obj.name for obj in bpy.data.objects}
+        created = sorted(after_names - before_names)
+        if new_name and created:
+            new_obj = bpy.data.objects.get(created[0])
+            if new_obj is not None:
+                old = new_obj.name
+                new_obj.name = new_name
+                if getattr(new_obj, "data", None) is not None:
+                    new_obj.data.name = new_name
+                created = [new_name if name == old else name for name in created]
+        return skill_success(
+            f"Extracted {len(face_indices)} face(s) from {object_name}",
+            object_name=object_name,
+            face_indices=list(face_indices),
+            created_objects=created,
+            created_count=len(created),
+            prompt="Use get_poly_count on the returned object to inspect extracted topology.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        _safe_object_mode()
+        return skill_exception(exc, message=f"Failed to extract faces from {object_name}")
+
+
+def mirror_mesh(object_name: str, axis: str = "x", use_modifier: bool = True) -> dict:
+    """Mirror a mesh by adding, and optionally applying, a Mirror modifier."""
+    axis_key = axis.lower()
+    if axis_key not in _MIRROR_AXES:
+        return skill_error("Invalid mirror axis", "axis must be one of: x, y, z.")
+    try:
+        import bpy
+
+        obj, error = _mesh_object(bpy, object_name)
+        if error:
+            return error
+        _select_active(bpy, obj)
+        modifier = obj.modifiers.new(name=f"Mirror_{axis_key.upper()}", type="MIRROR")
+        axes = [False, False, False]
+        axes[_MIRROR_AXES[axis_key]] = True
+        modifier.use_axis = axes
+        modifier_name = modifier.name
+        applied = False
+        if not use_modifier:
+            bpy.ops.object.modifier_apply(modifier=modifier_name)
+            applied = True
+        return skill_success(
+            f"Mirrored mesh {obj.name} on {axis_key.upper()}",
+            object_name=obj.name,
+            axis=axis_key,
+            modifier_name=modifier_name,
+            applied=applied,
+            prompt="Use get_poly_count or list_modifiers to inspect the mirrored mesh.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to mirror mesh {object_name}")
+
+
+def select_by_material(object_name: str, material_name: str) -> dict:
+    """Select mesh faces assigned to a material."""
+    if not material_name or not material_name.strip():
+        return skill_error("Invalid material_name", "material_name must be a non-empty string.")
+    try:
+        import bpy
+
+        obj, error = _mesh_object(bpy, object_name)
+        if error:
+            return error
+        materials = list(getattr(obj.data, "materials", []))
+        material_index = next(
+            (idx for idx, mat in enumerate(materials) if getattr(mat, "name", None) == material_name), None
+        )
+        if material_index is None:
+            return skill_error(
+                f"Material not found: {material_name}", f"{object_name} has no material named '{material_name}'."
+            )
+        _select_active(bpy, obj)
+        selected = 0
+        for poly in obj.data.polygons:
+            is_match = int(getattr(poly, "material_index", -1)) == material_index
+            poly.select = is_match
+            if is_match:
+                selected += 1
+        bpy.ops.object.mode_set(mode="EDIT")
+        return skill_success(
+            f"Selected {selected} face(s) using material {material_name}",
+            object_name=obj.name,
+            material_name=material_name,
+            material_index=material_index,
+            selected_face_count=selected,
+            prompt="Use extract_faces or mesh editing tools on the selected faces.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        _safe_object_mode()
+        return skill_exception(exc, message=f"Failed to select faces by material on {object_name}")
+
+
+def _safe_object_mode() -> None:
+    try:
+        import bpy
+
+        bpy.ops.object.mode_set(mode="OBJECT")
+    except Exception:
+        pass

--- a/src/dcc_mcp_blender/_scene_ops.py
+++ b/src/dcc_mcp_blender/_scene_ops.py
@@ -1,0 +1,460 @@
+"""Shared implementations for Blender object and scene operation tools."""
+
+from __future__ import annotations
+
+import fnmatch
+from typing import Any, Iterable, Sequence
+
+from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
+
+_SELECTION_MODES = {"replace", "add", "remove", "toggle"}
+_ORIGIN_MODES = {
+    "geometry": ("ORIGIN_GEOMETRY", "MEDIAN"),
+    "bounds": ("ORIGIN_GEOMETRY", "BOUNDS"),
+    "cursor": ("ORIGIN_CURSOR", "MEDIAN"),
+    "center_of_mass": ("ORIGIN_CENTER_OF_MASS", "MEDIAN"),
+    "volume": ("ORIGIN_CENTER_OF_VOLUME", "MEDIAN"),
+}
+
+
+def _object_by_name(bpy: Any, object_name: str) -> tuple[Any | None, dict | None]:
+    obj = bpy.data.objects.get(object_name)
+    if obj is None:
+        return None, skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+    return obj, None
+
+
+def _objects_by_name(bpy: Any, object_names: Sequence[str]) -> tuple[list[Any], list[str]]:
+    objects = []
+    missing = []
+    for name in object_names:
+        obj = bpy.data.objects.get(name)
+        if obj is None:
+            missing.append(name)
+        else:
+            objects.append(obj)
+    return objects, missing
+
+
+def _validate_object_names(object_names: Sequence[str]) -> dict | None:
+    if not isinstance(object_names, Sequence) or isinstance(object_names, str) or not object_names:
+        return skill_error("Invalid object_names", "object_names must be a non-empty list of object names.")
+    if any(not isinstance(name, str) or not name.strip() for name in object_names):
+        return skill_error("Invalid object_names", "Every object name must be a non-empty string.")
+    return None
+
+
+def _selected_objects(bpy: Any) -> list[Any]:
+    selected = getattr(bpy.context, "selected_objects", None)
+    if selected is not None:
+        return list(selected)
+    return [obj for obj in bpy.data.objects if getattr(obj, "select_get", lambda: False)()]
+
+
+def _active_object_name(bpy: Any) -> str | None:
+    active = (
+        getattr(bpy.context, "active_object", None)
+        or getattr(bpy.context, "object", None)
+        or getattr(getattr(getattr(bpy.context, "view_layer", None), "objects", None), "active", None)
+    )
+    return getattr(active, "name", None)
+
+
+def _set_active(bpy: Any, obj: Any) -> None:
+    bpy.context.view_layer.objects.active = obj
+    try:
+        bpy.context.active_object = obj
+    except Exception:
+        pass
+
+
+def _clear_selection(bpy: Any) -> None:
+    ops = getattr(bpy, "ops", None)
+    op = getattr(getattr(ops, "object", None), "select_all", None)
+    if callable(op):
+        try:
+            op(action="DESELECT")
+            return
+        except Exception:
+            pass
+    for obj in bpy.data.objects:
+        select_set = getattr(obj, "select_set", None)
+        if callable(select_set):
+            select_set(False)
+
+
+def _select(obj: Any, state: bool) -> None:
+    select_set = getattr(obj, "select_set", None)
+    if callable(select_set):
+        select_set(state)
+
+
+def _select_get(obj: Any) -> bool:
+    select_get = getattr(obj, "select_get", None)
+    if callable(select_get):
+        return bool(select_get())
+    return False
+
+
+def get_selection() -> dict:
+    """Return the current object selection."""
+    try:
+        import bpy
+
+        selected = _selected_objects(bpy)
+        return skill_success(
+            f"Selected objects: {len(selected)}",
+            selected=[obj.name for obj in selected],
+            active_object=_active_object_name(bpy),
+            count=len(selected),
+            prompt="Use set_selection, select_by_type, or find_by_pattern to change the selection.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get Blender selection")
+
+
+def set_selection(object_names: Sequence[str], mode: str = "replace") -> dict:
+    """Set or adjust the selected object set."""
+    names_error = _validate_object_names(object_names)
+    if names_error:
+        return names_error
+    mode_key = mode.lower()
+    if mode_key not in _SELECTION_MODES:
+        return skill_error("Invalid selection mode", f"Use one of: {', '.join(sorted(_SELECTION_MODES))}.")
+
+    try:
+        import bpy
+
+        objects, missing = _objects_by_name(bpy, object_names)
+        if missing:
+            return skill_error("Object not found", f"Missing object(s): {', '.join(missing)}")
+        if mode_key == "replace":
+            _clear_selection(bpy)
+        for obj in objects:
+            if mode_key in {"replace", "add"}:
+                _select(obj, True)
+            elif mode_key == "remove":
+                _select(obj, False)
+            else:
+                _select(obj, not _select_get(obj))
+        if objects:
+            _set_active(bpy, objects[-1])
+
+        selected = _selected_objects(bpy)
+        return skill_success(
+            f"Selection updated: {len(selected)} object(s)",
+            mode=mode_key,
+            requested=list(object_names),
+            selected=[obj.name for obj in selected],
+            active_object=_active_object_name(bpy),
+            count=len(selected),
+            prompt="Use get_selection to inspect or object tools to act on the selection.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set Blender selection")
+
+
+def select_by_type(type: str) -> dict:  # noqa: A002
+    """Select objects matching a Blender object type."""
+    type_key = type.upper()
+    try:
+        import bpy
+
+        matches = [obj for obj in bpy.data.objects if getattr(obj, "type", "").upper() == type_key]
+        _clear_selection(bpy)
+        for obj in matches:
+            _select(obj, True)
+        if matches:
+            _set_active(bpy, matches[0])
+        return skill_success(
+            f"Selected {len(matches)} object(s) of type {type_key}",
+            type=type_key,
+            selected=[obj.name for obj in matches],
+            count=len(matches),
+            active_object=_active_object_name(bpy),
+            prompt="Use get_selection to inspect the selected objects.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to select objects by type {type}")
+
+
+def find_by_pattern(pattern: str, type: str | None = None) -> dict:  # noqa: A002
+    """Find objects by shell-style name pattern and optional type."""
+    if not pattern:
+        return skill_error("Invalid pattern", "pattern must be a non-empty string.")
+    type_key = type.upper() if type else None
+    try:
+        import bpy
+
+        matches = [
+            obj
+            for obj in bpy.data.objects
+            if fnmatch.fnmatchcase(obj.name, pattern)
+            and (type_key is None or getattr(obj, "type", "").upper() == type_key)
+        ]
+        return skill_success(
+            f"Found {len(matches)} object(s) matching {pattern}",
+            pattern=pattern,
+            type=type_key,
+            objects=[{"name": obj.name, "type": getattr(obj, "type", "")} for obj in matches],
+            count=len(matches),
+            prompt="Use set_selection with the returned names to select matches.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to find objects by pattern {pattern}")
+
+
+def rename_object(object_name: str, new_name: str) -> dict:
+    """Rename a Blender object."""
+    if not new_name or not new_name.strip():
+        return skill_error("Invalid new_name", "new_name must be a non-empty string.")
+    try:
+        import bpy
+
+        obj, error = _object_by_name(bpy, object_name)
+        if error:
+            return error
+        old_name = obj.name
+        obj.name = new_name
+        if getattr(obj, "data", None) is not None and getattr(obj.data, "name", None) == old_name:
+            obj.data.name = new_name
+        return skill_success(
+            f"Renamed {old_name} to {obj.name}",
+            old_name=old_name,
+            new_name=obj.name,
+            data_name=getattr(getattr(obj, "data", None), "name", None),
+            prompt="Use get_object_info or find_by_pattern to inspect the renamed object.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to rename {object_name}")
+
+
+def parent_object(child_name: str, parent_name: str | None = None) -> dict:
+    """Parent or unparent an object while preserving its world transform."""
+    try:
+        import bpy
+
+        child, error = _object_by_name(bpy, child_name)
+        if error:
+            return error
+        parent = None
+        if parent_name:
+            parent, error = _object_by_name(bpy, parent_name)
+            if error:
+                return error
+            if parent is child:
+                return skill_error("Invalid parent", "An object cannot be parented to itself.")
+
+        matrix_world = getattr(child, "matrix_world", None)
+        child.parent = parent
+        if matrix_world is not None:
+            try:
+                child.matrix_world = matrix_world
+            except Exception:
+                pass
+        return skill_success(
+            f"Parent updated for {child.name}",
+            child_name=child.name,
+            parent_name=getattr(parent, "name", None),
+            prompt="Use get_bounding_box or get_object_info to verify the resulting transform.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to parent {child_name}")
+
+
+def group_objects(object_names: Sequence[str], collection_name: str | None = None) -> dict:
+    """Link objects into a collection."""
+    names_error = _validate_object_names(object_names)
+    if names_error:
+        return names_error
+    try:
+        import bpy
+
+        objects, missing = _objects_by_name(bpy, object_names)
+        if missing:
+            return skill_error("Object not found", f"Missing object(s): {', '.join(missing)}")
+        target_name = collection_name or "Group"
+        collection = bpy.data.collections.get(target_name)
+        created = False
+        if collection is None:
+            collection = bpy.data.collections.new(target_name)
+            created = True
+        try:
+            bpy.context.scene.collection.children.link(collection)
+        except Exception:
+            pass
+        linked = []
+        for obj in objects:
+            try:
+                collection.objects.link(obj)
+            except Exception:
+                pass
+            linked.append(obj.name)
+        return skill_success(
+            f"Grouped {len(linked)} object(s) into {collection.name}",
+            collection_name=collection.name,
+            created_collection=created,
+            object_names=linked,
+            count=len(linked),
+            prompt="Use blender-collection list tools to inspect collection membership.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to group objects")
+
+
+def set_visibility(
+    object_name: str,
+    visible: bool,
+    viewport: bool = True,
+    render: bool = True,
+) -> dict:
+    """Set viewport and/or render visibility for an object."""
+    try:
+        import bpy
+
+        obj, error = _object_by_name(bpy, object_name)
+        if error:
+            return error
+        if viewport:
+            obj.hide_viewport = not visible
+            hide_set = getattr(obj, "hide_set", None)
+            if callable(hide_set):
+                hide_set(not visible)
+        if render:
+            obj.hide_render = not visible
+        return skill_success(
+            f"Visibility updated for {obj.name}",
+            object_name=obj.name,
+            visible=bool(visible),
+            viewport=bool(viewport),
+            render=bool(render),
+            hide_viewport=getattr(obj, "hide_viewport", None),
+            hide_render=getattr(obj, "hide_render", None),
+            prompt="Use get_object_info or render tools to confirm the visibility state.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to set visibility for {object_name}")
+
+
+def get_bounding_box(object_name: str, world_space: bool = True) -> dict:
+    """Return an object's bounding box."""
+    try:
+        import bpy
+
+        obj, error = _object_by_name(bpy, object_name)
+        if error:
+            return error
+        corners = [_corner_to_world(obj, corner) if world_space else _coords(corner) for corner in obj.bound_box]
+        mins = [min(corner[index] for corner in corners) for index in range(3)]
+        maxs = [max(corner[index] for corner in corners) for index in range(3)]
+        size = [maxs[index] - mins[index] for index in range(3)]
+        center = [(mins[index] + maxs[index]) / 2 for index in range(3)]
+        return skill_success(
+            f"Bounding box for {obj.name}",
+            object_name=obj.name,
+            world_space=bool(world_space),
+            min=mins,
+            max=maxs,
+            size=size,
+            center=center,
+            corners=corners,
+            prompt="Use center_origin or transform tools if the bounds need adjustment.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to get bounding box for {object_name}")
+
+
+def center_origin(object_name: str, mode: str = "geometry") -> dict:
+    """Center or move an object's origin through Blender's origin operator."""
+    mode_key = mode.lower()
+    if mode_key not in _ORIGIN_MODES:
+        return skill_error("Invalid origin mode", f"Use one of: {', '.join(sorted(_ORIGIN_MODES))}.")
+    try:
+        import bpy
+
+        obj, error = _object_by_name(bpy, object_name)
+        if error:
+            return error
+        _clear_selection(bpy)
+        _select(obj, True)
+        _set_active(bpy, obj)
+        origin_type, center = _ORIGIN_MODES[mode_key]
+        bpy.ops.object.origin_set(type=origin_type, center=center)
+        return skill_success(
+            f"Centered origin for {obj.name}",
+            object_name=obj.name,
+            mode=mode_key,
+            prompt="Use get_bounding_box or get_object_info to verify the origin change.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to center origin for {object_name}")
+
+
+def freeze_transforms(
+    object_name: str,
+    location: bool = False,
+    rotation: bool = True,
+    scale: bool = True,
+) -> dict:
+    """Apply object transforms into object data."""
+    try:
+        import bpy
+
+        obj, error = _object_by_name(bpy, object_name)
+        if error:
+            return error
+        _clear_selection(bpy)
+        _select(obj, True)
+        _set_active(bpy, obj)
+        bpy.ops.object.transform_apply(location=bool(location), rotation=bool(rotation), scale=bool(scale))
+        return skill_success(
+            f"Froze transforms for {obj.name}",
+            object_name=obj.name,
+            applied={"location": bool(location), "rotation": bool(rotation), "scale": bool(scale)},
+            prompt="Use get_object_info to inspect the applied transform.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to freeze transforms for {object_name}")
+
+
+def _coords(value: Iterable[Any]) -> list[float]:
+    return [float(coord) for coord in value]
+
+
+def _corner_to_world(obj: Any, corner: Iterable[Any]) -> list[float]:
+    coords = _coords(corner)
+    matrix = getattr(obj, "matrix_world", None)
+    if matrix is None:
+        return coords
+    try:
+        result = matrix @ coords
+    except Exception:
+        try:
+            from mathutils import Vector
+
+            result = matrix @ Vector(coords)
+        except Exception:
+            return coords
+    return _coords(result)

--- a/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
@@ -7,9 +7,10 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | Skill | Stage | Purpose | Default-load policy | Side-effect profile | Discovery terms |
 |---|---|---|---|---|---|
 | `blender-scene` | bootstrap, scene, diagnostics | Start, open, save, list, and inspect scenes. | Load first for scene discovery or session checks. | Mixed: read-only inspection plus scene/file mutations. | session, scene info, open blend, save blend, list objects |
-| `blender-objects` | scene, authoring | Create, delete, duplicate, transform, and inspect objects. | Load when object-level edits or transforms are requested. | Mutating except object info. | cube, object transform, duplicate, move, rotate, scale |
+| `blender-objects` | scene, authoring | Create, delete, duplicate, transform, select, rename, group, parent, hide, bound, and inspect objects. | Load when object-level edits, selection, transforms, visibility, or bounds are requested. | Mutating except object info, selection reads, name searches, and bounds. | cube, object transform, duplicate, select, find, rename, parent, bounds |
 | `blender-collection` | scene, organization | Create collections, link objects, and inspect collection structure. | Load when grouping or collection membership matters. | Mutating except collection listing. | collection, group, hierarchy, link object |
 | `blender-mesh` | authoring, modeling | Add/apply/list modifiers and inspect mesh details. | Load when an existing mesh needs modifiers or mesh info. | Mutating except modifier and mesh inspection. | modifier, mesh info, apply, bevel, subdivision |
+| `blender-mesh-ops` | authoring, modeling | Inspect, clean, triangulate, combine, separate, mirror, extract, and select polygon mesh data. | Load when topology or face-level mesh editing is requested. | Mutating except polygon count. | polygon count, cleanup mesh, triangulate, combine meshes, merge vertices, extract faces |
 | `blender-uv-ops` | authoring, texture prep | Create, copy, inspect, project, unwrap, pack, and normalize UV maps. | Load when texture coordinates or UV islands are requested. | Mutating except UV-map and island inspection. | uv map, unwrap, texture coordinates, projection, pack islands |
 | `blender-geometry` | authoring, interchange, pipeline | Create simple geometry and save/export blend, FBX, or OBJ files. | Load when file output or basic geometry helpers are needed. | Disk-writing and mutating except file existence checks. | sphere, export fbx, export obj, save blend, file exists |
 | `blender-materials` | authoring, lookdev | Create, assign, edit, list, and delete materials. | Load before shader nodes when material slots or colors are enough. | Mutating except material listing. | material, assign, color, shader base, delete material |
@@ -28,7 +29,8 @@ This index helps agents choose typed Blender skills before falling back to raw P
 |---|---|
 | Inspect a new session | `blender-scene` -> `blender-objects` -> `blender-mesh` |
 | Build simple geometry | `blender-scene` -> `blender-objects` -> `blender-mesh` or `blender-geometry` |
-| Prepare textured mesh UVs | `blender-mesh` -> `blender-uv-ops` -> `blender-materials` |
+| Edit polygon topology | `blender-objects` -> `blender-mesh-ops` -> `blender-mesh` if modifiers are needed |
+| Prepare textured mesh UVs | `blender-mesh-ops` -> `blender-uv-ops` -> `blender-materials` |
 | Material setup | `blender-materials` -> `blender-shader-nodes` -> `blender-render` |
 | Procedural node setup | `blender-objects` -> `blender-geometry-nodes` -> `blender-render` |
 | Physics setup | `blender-objects` -> `blender-mesh` -> `blender-physics` |
@@ -40,6 +42,6 @@ This index helps agents choose typed Blender skills before falling back to raw P
 
 - Prefer typed skills for repeatable operations, structured errors, and MCP annotations.
 - Use `blender-scene` for initial session and scene discovery.
-- Load authoring skills only when the requested task enters that domain.
+- Load authoring skills only when the requested task enters that domain; prefer `blender-mesh-ops` for topology and `blender-mesh` for modifiers.
 - Keep `blender-scripting` as the final escape hatch; mention which typed skills were checked first.
 - Treat disk-writing, render, and scripting tools as higher-risk operations and ask for explicit paths or intent when needed.

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: blender-mesh-ops
+description: >-
+  Blender authoring skill for polygon mesh inspection, cleanup, topology
+  mutations, mesh extraction, mirroring, and material-based face selection. Use
+  this before falling back to blender-scripting whenever a workflow edits mesh
+  topology directly.
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: blender
+    layer: domain
+    stage: authoring
+    version: "1.0.0"
+    tags: [blender, mesh, polygon, topology, modeling]
+    search-hint: >-
+      mesh topology, polygon count, cleanup mesh, triangulate, combine meshes,
+      separate mesh, merge vertices, extract faces, mirror mesh, select by material
+    tools: tools.yaml
+---
+
+# blender-mesh-ops
+
+Typed polygon mesh editing tools for Blender. Load this skill when an existing
+mesh needs topology inspection, cleanup, combine/separate operations, face
+extraction, vertex merging, mirroring, or material-based face selection.
+
+Prefer `blender-objects` for object transforms and selection, `blender-mesh` for
+modifier management, `blender-uv-ops` for UVs, and `blender-scripting` only
+after checking this typed surface.

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/cleanup_mesh.py
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/cleanup_mesh.py
@@ -1,0 +1,19 @@
+"""Clean up Blender mesh topology."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._mesh_ops import cleanup_mesh
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`cleanup_mesh`."""
+    return cleanup_mesh(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/combine_meshes.py
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/combine_meshes.py
@@ -1,0 +1,19 @@
+"""Combine Blender mesh objects."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._mesh_ops import combine_meshes
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`combine_meshes`."""
+    return combine_meshes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/extract_faces.py
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/extract_faces.py
@@ -1,0 +1,19 @@
+"""Extract selected face indices from a Blender mesh."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._mesh_ops import extract_faces
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`extract_faces`."""
+    return extract_faces(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/get_poly_count.py
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/get_poly_count.py
@@ -1,0 +1,19 @@
+"""Get polygon counts and topology statistics for a Blender mesh."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._mesh_ops import get_poly_count
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_poly_count`."""
+    return get_poly_count(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/merge_vertices.py
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/merge_vertices.py
@@ -1,0 +1,19 @@
+"""Merge nearby vertices on a Blender mesh."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._mesh_ops import merge_vertices
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`merge_vertices`."""
+    return merge_vertices(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/mirror_mesh.py
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/mirror_mesh.py
@@ -1,0 +1,19 @@
+"""Mirror a Blender mesh with a Mirror modifier."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._mesh_ops import mirror_mesh
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`mirror_mesh`."""
+    return mirror_mesh(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/select_by_material.py
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/select_by_material.py
@@ -1,0 +1,19 @@
+"""Select Blender mesh faces by material name."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._mesh_ops import select_by_material
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`select_by_material`."""
+    return select_by_material(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/separate_mesh.py
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/separate_mesh.py
@@ -1,0 +1,19 @@
+"""Separate Blender mesh data into new objects."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._mesh_ops import separate_mesh
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`separate_mesh`."""
+    return separate_mesh(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/triangulate_mesh.py
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/triangulate_mesh.py
@@ -1,0 +1,19 @@
+"""Triangulate Blender mesh faces."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._mesh_ops import triangulate_mesh
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`triangulate_mesh`."""
+    return triangulate_mesh(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/tools.yaml
@@ -1,0 +1,293 @@
+tools:
+  - name: get_poly_count
+    description: "Return mesh vertex, edge, face, loop, material, UV-map, and derived triangle counts."
+    source_file: scripts/get_poly_count.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+    output_schema: &mesh_result_schema
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: cleanup_mesh
+    description: "Run common Blender mesh cleanup operators: merge doubles, fix normals, and delete loose geometry."
+    source_file: scripts/cleanup_mesh.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        remove_doubles:
+          type: boolean
+          default: true
+          description: Merge coincident or near-coincident vertices.
+        fix_normals:
+          type: boolean
+          default: true
+          description: Recalculate normals consistently outside.
+        delete_loose:
+          type: boolean
+          default: true
+          description: Delete loose geometry when Blender's delete_loose operator is available.
+        merge_threshold:
+          type: number
+          minimum: 0
+          default: 0.0001
+          description: Merge distance used by remove-doubles cleanup.
+    output_schema: *mesh_result_schema
+    read_only: false
+    destructive: true
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: triangulate_mesh
+    description: "Convert selected or all mesh faces to triangles."
+    source_file: scripts/triangulate_mesh.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+    output_schema: *mesh_result_schema
+    read_only: false
+    destructive: true
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: separate_mesh
+    description: "Separate a mesh into new objects by selected faces, material, or loose parts."
+    source_file: scripts/separate_mesh.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        mode:
+          type: string
+          enum: [selected, material, loose]
+          default: loose
+          description: Blender mesh separation mode.
+    output_schema: *mesh_result_schema
+    read_only: false
+    destructive: true
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: combine_meshes
+    description: "Join two or more mesh objects into a single mesh object."
+    source_file: scripts/combine_meshes.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_names]
+      properties:
+        object_names:
+          type: array
+          minItems: 2
+          items:
+            type: string
+            minLength: 1
+          description: Mesh object names to join.
+        new_name:
+          type: string
+          minLength: 1
+          description: Optional name for the joined object and mesh data.
+    output_schema: *mesh_result_schema
+    read_only: false
+    destructive: true
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: merge_vertices
+    description: "Merge vertices within a distance threshold on a mesh object."
+    source_file: scripts/merge_vertices.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        threshold:
+          type: number
+          minimum: 0
+          default: 0.0001
+          description: Merge distance.
+    output_schema: *mesh_result_schema
+    read_only: false
+    destructive: true
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: extract_faces
+    description: "Extract face indices from a mesh into a newly separated object."
+    source_file: scripts/extract_faces.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name, face_indices]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        face_indices:
+          type: array
+          minItems: 1
+          items:
+            type: integer
+            minimum: 0
+          description: Polygon indices to extract.
+        new_name:
+          type: string
+          minLength: 1
+          description: Optional name for the extracted object and mesh data.
+    output_schema: *mesh_result_schema
+    read_only: false
+    destructive: true
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: mirror_mesh
+    description: "Add a Mirror modifier on an axis and optionally apply it immediately."
+    source_file: scripts/mirror_mesh.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        axis:
+          type: string
+          enum: [x, y, z]
+          default: x
+          description: Mirror axis.
+        use_modifier:
+          type: boolean
+          default: true
+          description: Keep the Mirror modifier live instead of applying it.
+    output_schema: *mesh_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: select_by_material
+    description: "Select mesh faces assigned to a named material slot."
+    source_file: scripts/select_by_material.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name, material_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        material_name:
+          type: string
+          minLength: 1
+          description: Material name to match.
+    output_schema: *mesh_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false

--- a/src/dcc_mcp_blender/skills/blender-objects/scripts/center_origin.py
+++ b/src/dcc_mcp_blender/skills/blender-objects/scripts/center_origin.py
@@ -1,0 +1,19 @@
+"""Center or move a Blender object's origin."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._scene_ops import center_origin
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`center_origin`."""
+    return center_origin(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-objects/scripts/find_by_pattern.py
+++ b/src/dcc_mcp_blender/skills/blender-objects/scripts/find_by_pattern.py
@@ -1,0 +1,19 @@
+"""Find Blender objects by name pattern."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._scene_ops import find_by_pattern
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`find_by_pattern`."""
+    return find_by_pattern(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-objects/scripts/freeze_transforms.py
+++ b/src/dcc_mcp_blender/skills/blender-objects/scripts/freeze_transforms.py
@@ -1,0 +1,19 @@
+"""Freeze Blender object transforms."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._scene_ops import freeze_transforms
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`freeze_transforms`."""
+    return freeze_transforms(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-objects/scripts/get_bounding_box.py
+++ b/src/dcc_mcp_blender/skills/blender-objects/scripts/get_bounding_box.py
@@ -1,0 +1,19 @@
+"""Get a Blender object's bounding box."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._scene_ops import get_bounding_box
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_bounding_box`."""
+    return get_bounding_box(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-objects/scripts/get_selection.py
+++ b/src/dcc_mcp_blender/skills/blender-objects/scripts/get_selection.py
@@ -1,0 +1,19 @@
+"""Get the current Blender object selection."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._scene_ops import get_selection
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_selection`."""
+    return get_selection(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-objects/scripts/group_objects.py
+++ b/src/dcc_mcp_blender/skills/blender-objects/scripts/group_objects.py
@@ -1,0 +1,19 @@
+"""Group Blender objects into a collection."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._scene_ops import group_objects
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`group_objects`."""
+    return group_objects(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-objects/scripts/parent_object.py
+++ b/src/dcc_mcp_blender/skills/blender-objects/scripts/parent_object.py
@@ -1,0 +1,19 @@
+"""Parent or unparent a Blender object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._scene_ops import parent_object
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`parent_object`."""
+    return parent_object(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-objects/scripts/rename_object.py
+++ b/src/dcc_mcp_blender/skills/blender-objects/scripts/rename_object.py
@@ -1,0 +1,19 @@
+"""Rename a Blender object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._scene_ops import rename_object
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`rename_object`."""
+    return rename_object(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-objects/scripts/select_by_type.py
+++ b/src/dcc_mcp_blender/skills/blender-objects/scripts/select_by_type.py
@@ -1,0 +1,19 @@
+"""Select Blender objects by type."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._scene_ops import select_by_type
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`select_by_type`."""
+    return select_by_type(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-objects/scripts/set_selection.py
+++ b/src/dcc_mcp_blender/skills/blender-objects/scripts/set_selection.py
@@ -1,0 +1,19 @@
+"""Set the Blender object selection."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._scene_ops import set_selection
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_selection`."""
+    return set_selection(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-objects/scripts/set_visibility.py
+++ b/src/dcc_mcp_blender/skills/blender-objects/scripts/set_visibility.py
@@ -1,0 +1,19 @@
+"""Set Blender object visibility."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._scene_ops import set_visibility
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_visibility`."""
+    return set_visibility(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-objects/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-objects/tools.yaml
@@ -55,3 +55,342 @@ tools:
     read_only: true
     destructive: false
     idempotent: true
+
+  - name: get_selection
+    description: "Return the current Blender object selection and active object."
+    source_file: scripts/get_selection.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties: {}
+    output_schema: &object_result_schema
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: set_selection
+    description: "Replace, add, remove, or toggle Blender object selection by object name."
+    source_file: scripts/set_selection.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_names]
+      properties:
+        object_names:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            minLength: 1
+          description: Object names to select or adjust.
+        mode:
+          type: string
+          enum: [replace, add, remove, toggle]
+          default: replace
+          description: Selection update mode.
+    output_schema: *object_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: select_by_type
+    description: "Select all objects whose Blender object type matches the requested type."
+    source_file: scripts/select_by_type.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [type]
+      properties:
+        type:
+          type: string
+          minLength: 1
+          description: Blender object type, such as MESH, LIGHT, CAMERA, or EMPTY.
+    output_schema: *object_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: find_by_pattern
+    description: "Find objects by shell-style name pattern and optional Blender object type."
+    source_file: scripts/find_by_pattern.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [pattern]
+      properties:
+        pattern:
+          type: string
+          minLength: 1
+          description: Shell-style pattern, such as mcp_* or Cube.???.
+        type:
+          type: string
+          minLength: 1
+          description: Optional Blender object type filter.
+    output_schema: *object_result_schema
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: rename_object
+    description: "Rename a Blender object and matching object-data block when appropriate."
+    source_file: scripts/rename_object.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name, new_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Existing object name.
+        new_name:
+          type: string
+          minLength: 1
+          description: New object name.
+    output_schema: *object_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: parent_object
+    description: "Parent or unparent an object while preserving its world transform when possible."
+    source_file: scripts/parent_object.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [child_name]
+      properties:
+        child_name:
+          type: string
+          minLength: 1
+          description: Child object name.
+        parent_name:
+          type: string
+          minLength: 1
+          description: Optional parent object name; omit to unparent.
+    output_schema: *object_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: group_objects
+    description: "Link objects into a named collection, creating the collection if needed."
+    source_file: scripts/group_objects.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_names]
+      properties:
+        object_names:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            minLength: 1
+          description: Object names to link into the collection.
+        collection_name:
+          type: string
+          minLength: 1
+          description: Optional target collection name.
+    output_schema: *object_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: set_visibility
+    description: "Set viewport and/or render visibility for a Blender object."
+    source_file: scripts/set_visibility.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name, visible]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Object name.
+        visible:
+          type: boolean
+          description: Desired visible state.
+        viewport:
+          type: boolean
+          default: true
+          description: Update viewport visibility.
+        render:
+          type: boolean
+          default: true
+          description: Update render visibility.
+    output_schema: *object_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: get_bounding_box
+    description: "Return local or world-space object bounding-box corners, min/max, center, and size."
+    source_file: scripts/get_bounding_box.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Object name.
+        world_space:
+          type: boolean
+          default: true
+          description: Return world-space bounds when true.
+    output_schema: *object_result_schema
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: center_origin
+    description: "Move an object's origin using Blender's origin-set operator."
+    source_file: scripts/center_origin.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Object name.
+        mode:
+          type: string
+          enum: [geometry, bounds, cursor, center_of_mass, volume]
+          default: geometry
+          description: Origin mode.
+    output_schema: *object_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: freeze_transforms
+    description: "Apply location, rotation, and/or scale into object data."
+    source_file: scripts/freeze_transforms.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Object name.
+        location:
+          type: boolean
+          default: false
+          description: Apply location transforms.
+        rotation:
+          type: boolean
+          default: true
+          description: Apply rotation transforms.
+        scale:
+          type: boolean
+          default: true
+          description: Apply scale transforms.
+    output_schema: *object_result_schema
+    read_only: false
+    destructive: true
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: true
+      open_world_hint: false

--- a/tests/e2e/test_mesh_scene_ops_e2e.py
+++ b/tests/e2e/test_mesh_scene_ops_e2e.py
@@ -1,0 +1,60 @@
+"""E2E tests for expanded Blender scene/object and mesh operation skills.
+
+Requires a real Blender Python interpreter.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+bpy = pytest.importorskip("bpy", reason="bpy not available - run inside Blender Python interpreter")
+
+pytestmark = pytest.mark.e2e
+
+from tests.e2e.conftest import load_skill  # noqa: E402
+
+
+def _new_scene():
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+
+
+class TestMeshSceneOpsE2E:
+    def setup_method(self):
+        _new_scene()
+
+    def test_scene_selection_visibility_bounds_and_mesh_mutation(self):
+        bpy.ops.mesh.primitive_cube_add()
+        cube_name = bpy.context.active_object.name
+
+        rename_mod = load_skill("blender-objects", "rename_object")
+        renamed = rename_mod.rename_object(object_name=cube_name, new_name="AgentCube")
+        assert renamed["success"] is True
+
+        selection_mod = load_skill("blender-objects", "set_selection")
+        selection = selection_mod.set_selection(object_names=["AgentCube"])
+        assert selection["success"] is True
+        assert selection["context"]["selected"] == ["AgentCube"]
+
+        bounds_mod = load_skill("blender-objects", "get_bounding_box")
+        bounds = bounds_mod.get_bounding_box(object_name="AgentCube", world_space=True)
+        assert bounds["success"] is True
+        assert bounds["context"]["size"] == [2.0, 2.0, 2.0]
+
+        visibility_mod = load_skill("blender-objects", "set_visibility")
+        visibility = visibility_mod.set_visibility(object_name="AgentCube", visible=False, viewport=False, render=True)
+        assert visibility["success"] is True
+        assert bpy.data.objects["AgentCube"].hide_render is True
+
+        count_mod = load_skill("blender-mesh-ops", "get_poly_count")
+        before = count_mod.get_poly_count(object_name="AgentCube")
+        assert before["success"] is True
+        assert before["context"]["face_count"] == 6
+
+        triangulate_mod = load_skill("blender-mesh-ops", "triangulate_mesh")
+        triangulated = triangulate_mod.triangulate_mesh(object_name="AgentCube")
+        assert triangulated["success"] is True
+
+        after = count_mod.get_poly_count(object_name="AgentCube")
+        assert after["success"] is True
+        assert after["context"]["face_count"] == 12
+        assert after["context"]["triangle_count"] == 12

--- a/tests/test_skills_mesh_scene_ops.py
+++ b/tests/test_skills_mesh_scene_ops.py
@@ -1,0 +1,337 @@
+"""Unit tests for expanded Blender object and mesh operation skill scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import yaml
+
+from tests.conftest import load_and_call, make_mock_bpy
+
+SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_blender" / "skills"
+OBJECTS_DIR = SKILLS_ROOT / "blender-objects"
+MESH_OPS_DIR = SKILLS_ROOT / "blender-mesh-ops"
+
+NEW_OBJECT_TOOLS = {
+    "get_selection",
+    "set_selection",
+    "select_by_type",
+    "find_by_pattern",
+    "rename_object",
+    "parent_object",
+    "group_objects",
+    "set_visibility",
+    "get_bounding_box",
+    "center_origin",
+    "freeze_transforms",
+}
+
+MESH_OPS_TOOLS = {
+    "get_poly_count",
+    "cleanup_mesh",
+    "triangulate_mesh",
+    "separate_mesh",
+    "combine_meshes",
+    "merge_vertices",
+    "extract_faces",
+    "mirror_mesh",
+    "select_by_material",
+}
+
+
+class FakeObjects(list):
+    def get(self, name):
+        return next((obj for obj in self if obj.name == name), None)
+
+
+class FakeCollectionObjects(list):
+    def link(self, obj):
+        if obj not in self:
+            self.append(obj)
+
+
+class FakeCollection:
+    def __init__(self, name):
+        self.name = name
+        self.objects = FakeCollectionObjects()
+
+
+class FakeCollections(list):
+    def get(self, name):
+        return next((collection for collection in self if collection.name == name), None)
+
+    def new(self, name):
+        collection = FakeCollection(name)
+        self.append(collection)
+        return collection
+
+
+class FakeMesh:
+    def __init__(self, name="Mesh", polygon_vertices=None):
+        self.name = name
+        self.vertices = [object()] * 4
+        self.edges = [object()] * 4
+        self.loops = [object()] * 4
+        self.polygons = [
+            FakePolygon(index, vertices) for index, vertices in enumerate(polygon_vertices or [(0, 1, 2, 3)])
+        ]
+        self.materials = []
+        self.uv_layers = []
+
+
+class FakePolygon:
+    def __init__(self, index, vertices):
+        self.index = index
+        self.vertices = vertices
+        self.material_index = 0
+        self.select = False
+
+
+class FakeObject:
+    def __init__(self, name="Cube", obj_type="MESH", mesh=None):
+        self.name = name
+        self.type = obj_type
+        self.data = mesh or FakeMesh(name)
+        self.mode = "OBJECT"
+        self.parent = None
+        self.hide_viewport = False
+        self.hide_render = False
+        self.bound_box = [
+            (-1.0, -1.0, -1.0),
+            (-1.0, -1.0, 1.0),
+            (-1.0, 1.0, -1.0),
+            (-1.0, 1.0, 1.0),
+            (1.0, -1.0, -1.0),
+            (1.0, -1.0, 1.0),
+            (1.0, 1.0, -1.0),
+            (1.0, 1.0, 1.0),
+        ]
+        self.matrix_world = None
+        self.modifiers = FakeModifiers()
+        self._selected = False
+
+    def select_set(self, state):
+        self._selected = bool(state)
+
+    def select_get(self):
+        return self._selected
+
+    def hide_set(self, state):
+        self.hide_viewport = bool(state)
+
+
+class FakeModifier:
+    def __init__(self, name, type):
+        self.name = name
+        self.type = type
+        self.use_axis = [False, False, False]
+
+
+class FakeModifiers(list):
+    def new(self, name, type):
+        modifier = FakeModifier(name, type)
+        self.append(modifier)
+        return modifier
+
+
+def _bpy_for_objects(objects):
+    bpy = make_mock_bpy()
+    bpy.data.objects = FakeObjects(objects)
+    bpy.context.selected_objects = None
+
+    def select_all(action="DESELECT"):
+        if action == "DESELECT":
+            for obj in objects:
+                obj.select_set(False)
+        return {"FINISHED"}
+
+    bpy.ops.object.select_all.side_effect = select_all
+    return bpy
+
+
+def test_object_tools_yaml_declares_modern_contract_for_new_tools():
+    doc = yaml.safe_load((OBJECTS_DIR / "tools.yaml").read_text(encoding="utf-8"))
+    tools = {tool["name"]: tool for tool in doc["tools"]}
+    assert NEW_OBJECT_TOOLS <= set(tools)
+
+    for name in NEW_OBJECT_TOOLS:
+        tool = tools[name]
+        assert (OBJECTS_DIR / tool["source_file"]).exists(), name
+        assert tool["execution"] == "sync"
+        assert tool["affinity"] == "main"
+        assert isinstance(tool["timeout_hint_secs"], int)
+        assert tool["input_schema"]["type"] == "object"
+        assert tool["output_schema"]["properties"]["success"]["type"] == "boolean"
+        assert "annotations" in tool
+
+
+def test_mesh_ops_yaml_declares_modern_contract():
+    doc = yaml.safe_load((MESH_OPS_DIR / "tools.yaml").read_text(encoding="utf-8"))
+    tools = {tool["name"]: tool for tool in doc["tools"]}
+    assert set(tools) == MESH_OPS_TOOLS
+
+    for name, tool in tools.items():
+        assert (MESH_OPS_DIR / tool["source_file"]).exists(), name
+        assert tool["execution"] == "sync"
+        assert tool["affinity"] == "main"
+        assert isinstance(tool["timeout_hint_secs"], int)
+        assert tool["input_schema"]["type"] == "object"
+        assert tool["output_schema"]["properties"]["success"]["type"] == "boolean"
+        assert "annotations" in tool
+
+
+def test_selection_find_rename_parent_visibility_and_bounds():
+    cube = FakeObject("Cube")
+    light = FakeObject("KeyLight", "LIGHT", mesh=None)
+    bpy = _bpy_for_objects([cube, light])
+
+    selected = load_and_call("blender-objects/scripts/set_selection.py", bpy, object_names=["Cube"])
+    assert selected["success"] is True
+    assert selected["context"]["selected"] == ["Cube"]
+    assert cube.select_get() is True
+
+    by_type = load_and_call("blender-objects/scripts/select_by_type.py", bpy, type="light")
+    assert by_type["success"] is True
+    assert by_type["context"]["selected"] == ["KeyLight"]
+
+    found = load_and_call("blender-objects/scripts/find_by_pattern.py", bpy, pattern="Key*", type="LIGHT")
+    assert found["success"] is True
+    assert found["context"]["objects"] == [{"name": "KeyLight", "type": "LIGHT"}]
+
+    renamed = load_and_call("blender-objects/scripts/rename_object.py", bpy, object_name="Cube", new_name="HeroCube")
+    assert renamed["success"] is True
+    assert cube.name == "HeroCube"
+    assert cube.data.name == "HeroCube"
+
+    parented = load_and_call(
+        "blender-objects/scripts/parent_object.py", bpy, child_name="HeroCube", parent_name="KeyLight"
+    )
+    assert parented["success"] is True
+    assert cube.parent is light
+
+    visibility = load_and_call("blender-objects/scripts/set_visibility.py", bpy, object_name="HeroCube", visible=False)
+    assert visibility["success"] is True
+    assert cube.hide_viewport is True
+    assert cube.hide_render is True
+
+    bounds = load_and_call(
+        "blender-objects/scripts/get_bounding_box.py", bpy, object_name="HeroCube", world_space=False
+    )
+    assert bounds["success"] is True
+    assert bounds["context"]["size"] == [2.0, 2.0, 2.0]
+
+
+def test_group_origin_freeze_and_scene_error_paths():
+    cube = FakeObject("Cube")
+    bpy = _bpy_for_objects([cube])
+    bpy.data.collections = FakeCollections()
+
+    grouped = load_and_call(
+        "blender-objects/scripts/group_objects.py",
+        bpy,
+        object_names=["Cube"],
+        collection_name="Agents",
+    )
+    assert grouped["success"] is True
+    assert bpy.data.collections.get("Agents").objects == [cube]
+
+    centered = load_and_call("blender-objects/scripts/center_origin.py", bpy, object_name="Cube", mode="bounds")
+    assert centered["success"] is True
+    bpy.ops.object.origin_set.assert_called_once_with(type="ORIGIN_GEOMETRY", center="BOUNDS")
+
+    frozen = load_and_call("blender-objects/scripts/freeze_transforms.py", bpy, object_name="Cube", scale=True)
+    assert frozen["success"] is True
+    bpy.ops.object.transform_apply.assert_called_once_with(location=False, rotation=True, scale=True)
+
+    missing = load_and_call("blender-objects/scripts/set_selection.py", bpy, object_names=["Ghost"])
+    assert missing["success"] is False
+
+    invalid_mode = load_and_call("blender-objects/scripts/center_origin.py", bpy, object_name="Cube", mode="sideways")
+    assert invalid_mode["success"] is False
+
+
+def test_mesh_count_cleanup_triangulate_and_errors():
+    mesh = FakeMesh("QuadMesh")
+    cube = FakeObject("Cube", mesh=mesh)
+    bpy = _bpy_for_objects([cube])
+
+    counts = load_and_call("blender-mesh-ops/scripts/get_poly_count.py", bpy, object_name="Cube")
+    assert counts["success"] is True
+    assert counts["context"]["face_count"] == 1
+    assert counts["context"]["triangle_count"] == 2
+
+    cleaned = load_and_call("blender-mesh-ops/scripts/cleanup_mesh.py", bpy, object_name="Cube")
+    assert cleaned["success"] is True
+    bpy.ops.mesh.merge_by_distance.assert_called_once()
+    bpy.ops.mesh.normals_make_consistent.assert_called_once_with(inside=False)
+
+    triangulated = load_and_call("blender-mesh-ops/scripts/triangulate_mesh.py", bpy, object_name="Cube")
+    assert triangulated["success"] is True
+    bpy.ops.mesh.quads_convert_to_tris.assert_called_once()
+
+    missing = load_and_call("blender-mesh-ops/scripts/get_poly_count.py", bpy, object_name="Ghost")
+    assert missing["success"] is False
+
+    light = FakeObject("Light", "LIGHT", mesh=None)
+    bpy = _bpy_for_objects([light])
+    non_mesh = load_and_call("blender-mesh-ops/scripts/get_poly_count.py", bpy, object_name="Light")
+    assert non_mesh["success"] is False
+
+    invalid_threshold = load_and_call(
+        "blender-mesh-ops/scripts/merge_vertices.py", bpy, object_name="Light", threshold=-1
+    )
+    assert invalid_threshold["success"] is False
+
+
+def test_mesh_combine_extract_mirror_select_material_and_invalid_modes():
+    cube = FakeObject("Cube")
+    sphere = FakeObject("Sphere")
+    bpy = _bpy_for_objects([cube, sphere])
+
+    combined = load_and_call(
+        "blender-mesh-ops/scripts/combine_meshes.py",
+        bpy,
+        object_names=["Cube", "Sphere"],
+        new_name="Combined",
+    )
+    assert combined["success"] is True
+    assert combined["context"]["object_name"] == "Combined"
+    bpy.ops.object.join.assert_called_once()
+
+    invalid_separate = load_and_call(
+        "blender-mesh-ops/scripts/separate_mesh.py", bpy, object_name="Combined", mode="explode"
+    )
+    assert invalid_separate["success"] is False
+
+    invalid_face = load_and_call(
+        "blender-mesh-ops/scripts/extract_faces.py",
+        bpy,
+        object_name="Combined",
+        face_indices=[99],
+    )
+    assert invalid_face["success"] is False
+
+    mirrored = load_and_call(
+        "blender-mesh-ops/scripts/mirror_mesh.py",
+        bpy,
+        object_name="Combined",
+        axis="y",
+        use_modifier=False,
+    )
+    assert mirrored["success"] is True
+    assert cube.modifiers[0].use_axis == [False, True, False]
+    bpy.ops.object.modifier_apply.assert_called_once_with(modifier="Mirror_Y")
+
+    material = MagicMock()
+    material.name = "Red"
+    cube.data.materials = [material]
+    cube.data.polygons[0].material_index = 0
+    selected = load_and_call(
+        "blender-mesh-ops/scripts/select_by_material.py",
+        bpy,
+        object_name="Combined",
+        material_name="Red",
+    )
+    assert selected["success"] is True
+    assert cube.data.polygons[0].select is True


### PR DESCRIPTION
## Summary
- Add typed object/scene operations for selection, search, rename, parenting, grouping, visibility, bounds, origins, and transform freezing.
- Add a `blender-mesh-ops` skill for polygon counts, cleanup, triangulation, separation, combining, vertex merging, face extraction, mirroring, and material-based face selection.
- Update the bundled skills index and README tool catalog, with unit and Blender E2E coverage for the new surfaces.

## Validation
- `python -m ruff check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py packaging/addon_entry/__init__.py .github/scripts/start_mcp_server.py .github/scripts/start_mcp_server2.py`
- `python -m ruff format --check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py packaging/addon_entry/__init__.py .github/scripts/start_mcp_server.py .github/scripts/start_mcp_server2.py`
- `python tools/lint_skills.py --warnings-as-errors`
- `python -m pytest tests/ -q`
- Blender 4.4.3 background E2E for mesh/scene ops
- Local HTTP/MCP smoke for create -> rename -> select -> bounds -> poly count -> triangulate -> poly count
- `python -m build`
- `python packaging/assemble_zip.py --platform win64 --output-dir dist_addon`

Closes #29.