### PR TITLE
feat: add blender rigging and pose operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 ├─────────────────────────────────┤
 │  dcc_mcp_blender                │
 │  ├─ BlenderMcpServer            │
-│  ├─ SkillCatalog (85+ tools)    │
+│  ├─ SkillCatalog (100+ tools)   │
 │  ├─ ActionRegistry              │
 │  └─ HTTP Handlers               │
 ├─────────────────────────────────┤
@@ -49,7 +49,7 @@
 ## Features
 
 - **Embedded MCP server** — no external gateway needed; the server runs inside Blender's Python interpreter
-- **85+ pre-built tools** — scene management, object manipulation, mesh/UV editing, materials, rendering, nodes, physics, scripting and more
+- **100+ pre-built tools** — scene management, object manipulation, mesh/UV editing, rigging, pose libraries, materials, rendering, nodes, physics, scripting and more
 - **Extensible skill system** — drop new skill folders alongside built-ins or point to them via env vars
 - **Main-thread host adapter** — `BlenderHost` drives dispatcher ticks through `bpy.app.timers` or a background loop
 - **Streamable HTTP transport** — compatible with any MCP 2025-03-26 client
@@ -66,11 +66,13 @@
 | **blender-mesh** | `add_modifier`, `apply_modifier`, `list_modifiers`, `get_mesh_info` |
 | **blender-mesh-ops** | `get_poly_count`, `cleanup_mesh`, `triangulate_mesh`, `separate_mesh`, `combine_meshes`, `merge_vertices`, `extract_faces`, `mirror_mesh`, `select_by_material` |
 | **blender-uv-ops** | `list_uv_maps`, `create_uv_map`, `delete_uv_map`, `copy_uv_map`, `get_uv_info`, `get_uv_islands`, `project_uvs`, `unwrap_uvs`, `pack_uvs`, `normalize_uvs` |
+| **blender-rigging** | `create_armature`, `create_bone`, `mirror_bones`, `add_constraint`, `set_constraint_properties`, `bind_mesh_to_armature`, `add_shape_key`, `set_driver`, `retarget_animation` |
+| **blender-pose-library** | `list_poses`, `save_pose`, `load_pose` |
 | **blender-materials** | `create_material`, `assign_material`, `set_material_color`, `list_materials`, `delete_material` |
 | **blender-shader-nodes** | `list_material_nodes`, `set_principled_input` |
 | **blender-render** | `render_scene`, `set_render_settings`, `get_render_info`, `capture_viewport` |
 | **blender-scripting** | `execute_python`, `execute_script_file`, `get_blender_info` |
-| **blender-animation** | `set_keyframe`, `set_frame_range`, `get_frame_range`, `set_current_frame` |
+| **blender-animation** | `set_keyframe`, `set_frame_range`, `get_frame_range`, `set_current_frame`, `get_keyframes`, `delete_keyframes`, `bake_animation` |
 | **blender-lighting** | `create_light`, `set_light_properties`, `list_lights`, `set_world_background` |
 | **blender-camera** | `create_camera`, `set_active_camera`, `set_camera_properties`, `list_cameras` |
 | **blender-collection** | `create_collection`, `link_to_collection`, `list_collections` |

--- a/src/dcc_mcp_blender/_animation_ops.py
+++ b/src/dcc_mcp_blender/_animation_ops.py
@@ -1,0 +1,204 @@
+"""Shared implementations for expanded Blender animation operation tools."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
+
+_DEFAULT_DATA_PATHS = ["location", "rotation_euler", "scale"]
+
+
+def _object_by_name(bpy: Any, object_name: str) -> tuple[Any | None, dict | None]:
+    obj = bpy.data.objects.get(object_name)
+    if obj is None:
+        return None, skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+    return obj, None
+
+
+def _validate_object_names(object_names: Sequence[str]) -> dict | None:
+    if not isinstance(object_names, Sequence) or isinstance(object_names, str) or not object_names:
+        return skill_error("Invalid object_names", "object_names must be a non-empty list of object names.")
+    if any(not isinstance(name, str) or not name.strip() for name in object_names):
+        return skill_error("Invalid object_names", "Every object name must be a non-empty string.")
+    return None
+
+
+def _action(obj: Any) -> Any | None:
+    return getattr(getattr(obj, "animation_data", None), "action", None)
+
+
+def _frame_from_keyframe(point: Any) -> float:
+    co = getattr(point, "co", None)
+    if co is None:
+        return 0.0
+    if hasattr(co, "x"):
+        return float(co.x)
+    return float(co[0])
+
+
+def _fcurve_matches(fcurve: Any, data_path: str | None) -> bool:
+    return data_path is None or getattr(fcurve, "data_path", None) == data_path
+
+
+def get_keyframes(object_name: str, data_path: str | None = None) -> dict:
+    """Return keyframe times grouped by f-curve."""
+    try:
+        import bpy
+
+        obj, error = _object_by_name(bpy, object_name)
+        if error:
+            return error
+        action = _action(obj)
+        curves = []
+        keyframe_count = 0
+        if action is not None:
+            for fcurve in getattr(action, "fcurves", []):
+                if not _fcurve_matches(fcurve, data_path):
+                    continue
+                frames = [_frame_from_keyframe(point) for point in getattr(fcurve, "keyframe_points", [])]
+                curves.append(
+                    {
+                        "data_path": getattr(fcurve, "data_path", ""),
+                        "array_index": getattr(fcurve, "array_index", 0),
+                        "frames": frames,
+                        "count": len(frames),
+                    }
+                )
+                keyframe_count += len(frames)
+        return skill_success(
+            f"Found {keyframe_count} keyframe(s)",
+            object_name=obj.name,
+            data_path=data_path,
+            action_name=getattr(action, "name", None),
+            fcurves=curves,
+            keyframe_count=keyframe_count,
+            prompt="Use delete_keyframes to remove keys or bake_animation to add sampled keys.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to get keyframes for {object_name}")
+
+
+def delete_keyframes(
+    object_name: str,
+    frame_range: Sequence[float] | None = None,
+    data_path: str | None = None,
+) -> dict:
+    """Delete keyframes for an object, optionally filtered by frame range and data path."""
+    start = None
+    end = None
+    if frame_range is not None:
+        if isinstance(frame_range, (str, bytes)) or len(frame_range) != 2:
+            return skill_error("Invalid frame_range", "frame_range must contain [start, end].")
+        start = float(frame_range[0])
+        end = float(frame_range[1])
+        if start > end:
+            return skill_error("Invalid frame_range", "frame_range start must be <= end.")
+    try:
+        import bpy
+
+        obj, error = _object_by_name(bpy, object_name)
+        if error:
+            return error
+        action = _action(obj)
+        deleted = 0
+        affected_curves = 0
+        if action is not None:
+            for fcurve in list(getattr(action, "fcurves", [])):
+                if not _fcurve_matches(fcurve, data_path):
+                    continue
+                removed_on_curve = 0
+                for point in list(getattr(fcurve, "keyframe_points", [])):
+                    frame = _frame_from_keyframe(point)
+                    if start is not None and (frame < start or frame > end):
+                        continue
+                    try:
+                        fcurve.keyframe_points.remove(point, fast=True)
+                    except TypeError:
+                        fcurve.keyframe_points.remove(point)
+                    deleted += 1
+                    removed_on_curve += 1
+                if removed_on_curve:
+                    affected_curves += 1
+                    update = getattr(fcurve, "update", None)
+                    if callable(update):
+                        update()
+                if not getattr(fcurve, "keyframe_points", []):
+                    remove = getattr(action.fcurves, "remove", None)
+                    if callable(remove):
+                        remove(fcurve)
+        return skill_success(
+            f"Deleted {deleted} keyframe(s)",
+            object_name=obj.name,
+            data_path=data_path,
+            frame_range=[start, end] if start is not None else None,
+            deleted_count=deleted,
+            affected_curve_count=affected_curves,
+            prompt="Use get_keyframes to verify the remaining animation keys.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to delete keyframes for {object_name}")
+
+
+def bake_animation(
+    object_names: Sequence[str],
+    frame_start: int,
+    frame_end: int,
+    step: int = 1,
+    data_paths: Sequence[str] | None = None,
+) -> dict:
+    """Sample objects over a frame range by inserting explicit keyframes."""
+    names_error = _validate_object_names(object_names)
+    if names_error:
+        return names_error
+    if int(frame_start) > int(frame_end):
+        return skill_error("Invalid frame range", "frame_start must be <= frame_end.")
+    if int(step) <= 0:
+        return skill_error("Invalid step", "step must be a positive integer.")
+    paths = list(data_paths or _DEFAULT_DATA_PATHS)
+    if any(not isinstance(path, str) or not path.strip() for path in paths):
+        return skill_error("Invalid data_paths", "data_paths must contain non-empty strings.")
+    try:
+        import bpy
+
+        objects = []
+        missing = []
+        for name in object_names:
+            obj, error = _object_by_name(bpy, name)
+            if error:
+                missing.append(name)
+            else:
+                objects.append(obj)
+        if missing:
+            return skill_error("Object not found", f"Missing object(s): {', '.join(missing)}")
+        inserted = 0
+        frames = list(range(int(frame_start), int(frame_end) + 1, int(step)))
+        for frame in frames:
+            frame_set = getattr(bpy.context.scene, "frame_set", None)
+            if callable(frame_set):
+                frame_set(frame)
+            else:
+                bpy.context.scene.frame_current = frame
+            for obj in objects:
+                for path in paths:
+                    obj.keyframe_insert(data_path=path, frame=frame)
+                    inserted += 1
+        return skill_success(
+            f"Baked {inserted} keyframe sample(s)",
+            object_names=[obj.name for obj in objects],
+            frame_start=int(frame_start),
+            frame_end=int(frame_end),
+            step=int(step),
+            frames=frames,
+            data_paths=paths,
+            inserted_count=inserted,
+            prompt="Use get_keyframes to inspect baked curves or delete_keyframes to trim them.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to bake animation")

--- a/src/dcc_mcp_blender/_pose_ops.py
+++ b/src/dcc_mcp_blender/_pose_ops.py
@@ -1,0 +1,234 @@
+"""Shared implementations for Blender pose library operation tools."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
+
+_POSE_STORE_KEY = "dcc_mcp_poses"
+
+
+def _object_by_name(bpy: Any, object_name: str) -> tuple[Any | None, dict | None]:
+    obj = bpy.data.objects.get(object_name)
+    if obj is None:
+        return None, skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+    return obj, None
+
+
+def _armature(bpy: Any, armature_name: str) -> tuple[Any | None, dict | None]:
+    obj, error = _object_by_name(bpy, armature_name)
+    if error:
+        return None, error
+    if getattr(obj, "type", None) != "ARMATURE":
+        return None, skill_error(f"{armature_name} is not an armature", f"Object type is {getattr(obj, 'type', None)}.")
+    return obj, None
+
+
+def _pose_bones(armature: Any) -> dict[str, Any]:
+    pose = getattr(armature, "pose", None)
+    bones = getattr(pose, "bones", []) if pose is not None else []
+    return {bone.name: bone for bone in bones}
+
+
+def _as_list(value: Any, fallback: list[float]) -> list[float]:
+    try:
+        return [float(item) for item in value]
+    except Exception:
+        return list(fallback)
+
+
+def _capture_bone(bone: Any) -> dict[str, Any]:
+    return {
+        "location": _as_list(getattr(bone, "location", []), [0.0, 0.0, 0.0]),
+        "rotation_mode": getattr(bone, "rotation_mode", "XYZ"),
+        "rotation_euler": _as_list(getattr(bone, "rotation_euler", []), [0.0, 0.0, 0.0]),
+        "rotation_quaternion": _as_list(getattr(bone, "rotation_quaternion", []), [1.0, 0.0, 0.0, 0.0]),
+        "scale": _as_list(getattr(bone, "scale", []), [1.0, 1.0, 1.0]),
+    }
+
+
+def _apply_bone(bone: Any, values: dict[str, Any]) -> None:
+    if "rotation_mode" in values and hasattr(bone, "rotation_mode"):
+        bone.rotation_mode = values["rotation_mode"]
+    for attr in ("location", "rotation_euler", "rotation_quaternion", "scale"):
+        if attr in values and hasattr(bone, attr):
+            setattr(bone, attr, values[attr])
+
+
+def _get_custom_property(obj: Any, key: str, default: Any = None) -> Any:
+    get = getattr(obj, "get", None)
+    if callable(get):
+        return get(key, default)
+    try:
+        return obj[key]
+    except Exception:
+        return default
+
+
+def _set_custom_property(obj: Any, key: str, value: Any) -> None:
+    try:
+        obj[key] = value
+    except Exception:
+        setattr(obj, key, value)
+
+
+def _load_store(armature: Any) -> dict[str, Any]:
+    raw = _get_custom_property(armature, _POSE_STORE_KEY, "{}")
+    if isinstance(raw, dict):
+        return dict(raw)
+    if not isinstance(raw, str):
+        return {}
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _save_store(armature: Any, store: dict[str, Any]) -> None:
+    _set_custom_property(armature, _POSE_STORE_KEY, json.dumps(store, sort_keys=True))
+
+
+def _mirror_name(name: str) -> str:
+    pairs = [
+        (".L", ".R"),
+        ("_L", "_R"),
+        ("-L", "-R"),
+        ("Left", "Right"),
+        ("left", "right"),
+        ("L_", "R_"),
+    ]
+    for left, right in pairs:
+        if name.endswith(left):
+            return name[: -len(left)] + right
+        if name.endswith(right):
+            return name[: -len(right)] + left
+        if name.startswith(left):
+            return right + name[len(left) :]
+        if name.startswith(right):
+            return left + name[len(right) :]
+    return name
+
+
+def _mirrored_values(values: dict[str, Any]) -> dict[str, Any]:
+    mirrored = json.loads(json.dumps(values))
+    if "location" in mirrored and len(mirrored["location"]) >= 1:
+        mirrored["location"][0] = -float(mirrored["location"][0])
+    if "rotation_euler" in mirrored and len(mirrored["rotation_euler"]) >= 3:
+        mirrored["rotation_euler"][1] = -float(mirrored["rotation_euler"][1])
+        mirrored["rotation_euler"][2] = -float(mirrored["rotation_euler"][2])
+    return mirrored
+
+
+def list_poses(armature_name: str | None = None) -> dict:
+    """List saved poses stored on armatures."""
+    try:
+        import bpy
+
+        armatures = []
+        if armature_name:
+            armature, error = _armature(bpy, armature_name)
+            if error:
+                return error
+            armatures = [armature]
+        else:
+            armatures = [obj for obj in bpy.data.objects if getattr(obj, "type", None) == "ARMATURE"]
+        poses = []
+        for armature in armatures:
+            store = _load_store(armature)
+            for pose_name, pose_data in sorted(store.items()):
+                poses.append(
+                    {
+                        "armature_name": armature.name,
+                        "pose_name": pose_name,
+                        "bone_count": len(pose_data.get("bones", {})),
+                    }
+                )
+        return skill_success(
+            f"Found {len(poses)} pose(s)",
+            armature_name=armature_name,
+            poses=poses,
+            count=len(poses),
+            prompt="Use load_pose to apply a saved pose or save_pose to capture the current pose.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list poses")
+
+
+def save_pose(armature_name: str, pose_name: str) -> dict:
+    """Save current pose-bone transforms to an armature-local pose store."""
+    if not pose_name or not pose_name.strip():
+        return skill_error("Invalid pose_name", "pose_name must be a non-empty string.")
+    try:
+        import bpy
+
+        armature, error = _armature(bpy, armature_name)
+        if error:
+            return error
+        bones = _pose_bones(armature)
+        if not bones:
+            return skill_error("No pose bones", f"{armature_name} has no pose bones to save.")
+        store = _load_store(armature)
+        store[pose_name] = {
+            "armature_name": armature.name,
+            "pose_name": pose_name,
+            "bones": {name: _capture_bone(bone) for name, bone in bones.items()},
+        }
+        _save_store(armature, store)
+        return skill_success(
+            f"Saved pose {pose_name}",
+            armature_name=armature.name,
+            pose_name=pose_name,
+            bone_count=len(bones),
+            pose_count=len(store),
+            prompt="Use list_poses to discover saved poses or load_pose to apply this pose.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to save pose {pose_name}")
+
+
+def load_pose(armature_name: str, pose_name: str, mirror: bool = False) -> dict:
+    """Load a saved armature pose."""
+    try:
+        import bpy
+
+        armature, error = _armature(bpy, armature_name)
+        if error:
+            return error
+        store = _load_store(armature)
+        pose_data = store.get(pose_name)
+        if pose_data is None:
+            return skill_error(
+                f"Pose not found: {pose_name}", f"{armature_name} has no saved pose named '{pose_name}'."
+            )
+        bones = _pose_bones(armature)
+        applied = []
+        missing = []
+        for source_name, values in pose_data.get("bones", {}).items():
+            target_name = _mirror_name(source_name) if mirror else source_name
+            bone = bones.get(target_name)
+            if bone is None:
+                missing.append(target_name)
+                continue
+            _apply_bone(bone, _mirrored_values(values) if mirror else values)
+            applied.append(target_name)
+        return skill_success(
+            f"Loaded pose {pose_name}",
+            armature_name=armature.name,
+            pose_name=pose_name,
+            mirror=bool(mirror),
+            applied_bones=applied,
+            missing_bones=missing,
+            applied_count=len(applied),
+            prompt="Use save_pose to capture edits or bake_animation to bake pose changes.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to load pose {pose_name}")

--- a/src/dcc_mcp_blender/_rigging_ops.py
+++ b/src/dcc_mcp_blender/_rigging_ops.py
@@ -1,0 +1,525 @@
+"""Shared implementations for Blender rigging operation tools."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
+
+_MIRROR_AXES = {"x": 0, "y": 1, "z": 2}
+_BIND_METHODS = {"modifier", "automatic_weights"}
+
+
+def _object_by_name(bpy: Any, object_name: str) -> tuple[Any | None, dict | None]:
+    obj = bpy.data.objects.get(object_name)
+    if obj is None:
+        return None, skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+    return obj, None
+
+
+def _typed_object(bpy: Any, object_name: str, object_type: str) -> tuple[Any | None, dict | None]:
+    obj, error = _object_by_name(bpy, object_name)
+    if error:
+        return None, error
+    if getattr(obj, "type", None) != object_type:
+        return None, skill_error(
+            f"{object_name} is not a {object_type}", f"Object type is {getattr(obj, 'type', None)}."
+        )
+    return obj, None
+
+
+def _vector(
+    value: Sequence[float] | None, label: str, default: Sequence[float] | None = None
+) -> tuple[list[float] | None, dict | None]:
+    raw = default if value is None else value
+    if raw is None:
+        return None, None
+    if isinstance(raw, (str, bytes)) or len(raw) != 3:
+        return None, skill_error(f"Invalid {label}", f"{label} must contain exactly three numbers.")
+    try:
+        coords = [float(coord) for coord in raw]
+    except (TypeError, ValueError):
+        return None, skill_error(f"Invalid {label}", f"{label} must contain numbers.")
+    return coords, None
+
+
+def _set_active(bpy: Any, obj: Any) -> None:
+    try:
+        bpy.ops.object.mode_set(mode="OBJECT")
+    except Exception:
+        pass
+    try:
+        bpy.ops.object.select_all(action="DESELECT")
+    except Exception:
+        pass
+    select_set = getattr(obj, "select_set", None)
+    if callable(select_set):
+        select_set(True)
+    bpy.context.view_layer.objects.active = obj
+    try:
+        bpy.context.active_object = obj
+    except Exception:
+        pass
+
+
+def _object_mode(bpy: Any) -> None:
+    try:
+        bpy.ops.object.mode_set(mode="OBJECT")
+    except Exception:
+        pass
+
+
+def _collection_get(collection: Any, name: str) -> Any | None:
+    get = getattr(collection, "get", None)
+    if callable(get):
+        return get(name)
+    return next((item for item in collection if getattr(item, "name", None) == name), None)
+
+
+def _collection_len(collection: Any) -> int:
+    try:
+        return len(collection)
+    except TypeError:
+        return sum(1 for _ in collection)
+
+
+def _constraint_by_name(obj: Any, constraint_name: str) -> Any | None:
+    return _collection_get(getattr(obj, "constraints", []), constraint_name)
+
+
+def _pose_bone_map(armature: Any) -> dict[str, Any]:
+    pose = getattr(armature, "pose", None)
+    bones = getattr(pose, "bones", []) if pose is not None else []
+    return {bone.name: bone for bone in bones}
+
+
+def _mirror_name(name: str) -> str:
+    pairs = [
+        (".L", ".R"),
+        ("_L", "_R"),
+        ("-L", "-R"),
+        ("Left", "Right"),
+        ("left", "right"),
+        ("L_", "R_"),
+    ]
+    for left, right in pairs:
+        if name.endswith(left):
+            return name[: -len(left)] + right
+        if name.endswith(right):
+            return name[: -len(right)] + left
+        if name.startswith(left):
+            return right + name[len(left) :]
+        if name.startswith(right):
+            return left + name[len(right) :]
+    return f"{name}_mirror"
+
+
+def _mirror_vector(value: Sequence[float], axis: str) -> list[float]:
+    coords = [float(coord) for coord in value]
+    coords[_MIRROR_AXES[axis]] *= -1.0
+    return coords
+
+
+def create_armature(name: str, location: Sequence[float] | None = None) -> dict:
+    """Create an armature object."""
+    if not name or not name.strip():
+        return skill_error("Invalid name", "name must be a non-empty string.")
+    loc, error = _vector(location, "location", default=(0.0, 0.0, 0.0))
+    if error:
+        return error
+    try:
+        import bpy
+
+        _object_mode(bpy)
+        bpy.ops.object.armature_add(enter_editmode=False, align="WORLD", location=tuple(loc))
+        armature = getattr(bpy.context, "active_object", None)
+        if armature is None:
+            armature = getattr(bpy.context, "object", None)
+        if armature is None:
+            return skill_error("Armature creation failed", "Blender did not return an active armature object.")
+        armature.name = name
+        if getattr(armature, "data", None) is not None:
+            armature.data.name = name
+        return skill_success(
+            f"Created armature {armature.name}",
+            armature_name=armature.name,
+            data_name=getattr(getattr(armature, "data", None), "name", None),
+            location=loc,
+            bone_count=_collection_len(getattr(getattr(armature, "data", None), "bones", [])),
+            prompt="Use create_bone to add edit bones or blender-pose-library to capture poses.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to create armature {name}")
+
+
+def create_bone(
+    armature_name: str,
+    bone_name: str,
+    head: Sequence[float],
+    tail: Sequence[float],
+    parent: str | None = None,
+) -> dict:
+    """Create an edit bone in an armature."""
+    if not bone_name or not bone_name.strip():
+        return skill_error("Invalid bone_name", "bone_name must be a non-empty string.")
+    head_vec, error = _vector(head, "head")
+    if error:
+        return error
+    tail_vec, error = _vector(tail, "tail")
+    if error:
+        return error
+    if head_vec == tail_vec:
+        return skill_error("Invalid bone length", "head and tail must not be identical.")
+    try:
+        import bpy
+
+        armature, error = _typed_object(bpy, armature_name, "ARMATURE")
+        if error:
+            return error
+        _set_active(bpy, armature)
+        bpy.ops.object.mode_set(mode="EDIT")
+        edit_bones = armature.data.edit_bones
+        if _collection_get(edit_bones, bone_name) is not None:
+            _object_mode(bpy)
+            return skill_error(
+                f"Bone already exists: {bone_name}", f"{armature_name} already has a bone named '{bone_name}'."
+            )
+        bone = edit_bones.new(bone_name)
+        bone.head = head_vec
+        bone.tail = tail_vec
+        if parent:
+            parent_bone = _collection_get(edit_bones, parent)
+            if parent_bone is None:
+                _object_mode(bpy)
+                return skill_error(
+                    f"Parent bone not found: {parent}", f"{armature_name} has no edit bone named '{parent}'."
+                )
+            bone.parent = parent_bone
+        _object_mode(bpy)
+        return skill_success(
+            f"Created bone {bone_name}",
+            armature_name=armature.name,
+            bone_name=bone_name,
+            parent=parent,
+            head=head_vec,
+            tail=tail_vec,
+            bone_count=_collection_len(getattr(armature.data, "bones", [])),
+            prompt="Use mirror_bones, bind_mesh_to_armature, or save_pose to continue rig setup.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        _object_mode(bpy)
+        return skill_exception(exc, message=f"Failed to create bone {bone_name}")
+
+
+def mirror_bones(armature_name: str, axis: str = "x", naming_rule: str = "suffix") -> dict:
+    """Mirror edit bones by coordinates and left/right naming conventions."""
+    axis_key = axis.lower()
+    if axis_key not in _MIRROR_AXES:
+        return skill_error("Invalid mirror axis", "axis must be one of: x, y, z.")
+    if naming_rule not in {"suffix", "prefix", "auto"}:
+        return skill_error("Invalid naming_rule", "naming_rule must be suffix, prefix, or auto.")
+    try:
+        import bpy
+
+        armature, error = _typed_object(bpy, armature_name, "ARMATURE")
+        if error:
+            return error
+        _set_active(bpy, armature)
+        bpy.ops.object.mode_set(mode="EDIT")
+        edit_bones = armature.data.edit_bones
+        originals = list(edit_bones)
+        existing = {bone.name for bone in originals}
+        created = []
+        skipped = []
+        for source in originals:
+            target_name = _mirror_name(source.name)
+            if target_name in existing:
+                skipped.append(target_name)
+                continue
+            target = edit_bones.new(target_name)
+            target.head = _mirror_vector(source.head, axis_key)
+            target.tail = _mirror_vector(source.tail, axis_key)
+            target.roll = -float(getattr(source, "roll", 0.0))
+            created.append(target_name)
+            existing.add(target_name)
+        _object_mode(bpy)
+        return skill_success(
+            f"Mirrored {len(created)} bone(s)",
+            armature_name=armature.name,
+            axis=axis_key,
+            naming_rule=naming_rule,
+            created_bones=created,
+            skipped_bones=skipped,
+            created_count=len(created),
+            prompt="Use create_bone for manual additions or save_pose after posing the rig.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        _object_mode(bpy)
+        return skill_exception(exc, message=f"Failed to mirror bones on {armature_name}")
+
+
+def add_constraint(object_name: str, constraint_type: str, target: str | None = None) -> dict:
+    """Add a Blender constraint to an object."""
+    if not constraint_type or not constraint_type.strip():
+        return skill_error("Invalid constraint_type", "constraint_type must be a non-empty Blender constraint type.")
+    try:
+        import bpy
+
+        obj, error = _object_by_name(bpy, object_name)
+        if error:
+            return error
+        target_obj = None
+        if target:
+            target_obj, error = _object_by_name(bpy, target)
+            if error:
+                return error
+        constraint = obj.constraints.new(type=constraint_type.upper())
+        if target_obj is not None and hasattr(constraint, "target"):
+            constraint.target = target_obj
+        return skill_success(
+            f"Added {constraint.type} constraint to {obj.name}",
+            object_name=obj.name,
+            constraint_name=constraint.name,
+            constraint_type=constraint.type,
+            target=getattr(target_obj, "name", None),
+            constraint_count=_collection_len(getattr(obj, "constraints", [])),
+            prompt="Use set_constraint_properties to tune the new constraint.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to add constraint to {object_name}")
+
+
+def set_constraint_properties(object_name: str, constraint_name: str, properties: Mapping[str, Any]) -> dict:
+    """Set supported properties on an existing object constraint."""
+    if not isinstance(properties, Mapping) or not properties:
+        return skill_error("Invalid properties", "properties must be a non-empty object.")
+    try:
+        import bpy
+
+        obj, error = _object_by_name(bpy, object_name)
+        if error:
+            return error
+        constraint = _constraint_by_name(obj, constraint_name)
+        if constraint is None:
+            return skill_error(
+                f"Constraint not found: {constraint_name}",
+                f"{object_name} has no constraint named '{constraint_name}'.",
+            )
+        applied = {}
+        ignored = []
+        for key, value in properties.items():
+            if hasattr(constraint, key):
+                setattr(constraint, key, value)
+                applied[key] = value
+            else:
+                ignored.append(key)
+        return skill_success(
+            f"Updated constraint {constraint.name}",
+            object_name=obj.name,
+            constraint_name=constraint.name,
+            applied=applied,
+            ignored=ignored,
+            prompt="Use object inspection or Blender UI to verify constraint behavior.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to set constraint properties on {object_name}")
+
+
+def bind_mesh_to_armature(mesh_name: str, armature_name: str, method: str = "modifier") -> dict:
+    """Bind a mesh to an armature with native Blender behavior."""
+    method_key = method.lower()
+    if method_key not in _BIND_METHODS:
+        return skill_error("Invalid bind method", f"method must be one of: {', '.join(sorted(_BIND_METHODS))}.")
+    try:
+        import bpy
+
+        mesh, error = _typed_object(bpy, mesh_name, "MESH")
+        if error:
+            return error
+        armature, error = _typed_object(bpy, armature_name, "ARMATURE")
+        if error:
+            return error
+        modifier_name = None
+        if method_key == "modifier":
+            modifier = mesh.modifiers.new(name="Armature", type="ARMATURE")
+            modifier.object = armature
+            modifier_name = modifier.name
+        else:
+            _object_mode(bpy)
+            bpy.ops.object.select_all(action="DESELECT")
+            mesh.select_set(True)
+            armature.select_set(True)
+            bpy.context.view_layer.objects.active = armature
+            bpy.ops.object.parent_set(type="ARMATURE_AUTO")
+        return skill_success(
+            f"Bound {mesh.name} to {armature.name}",
+            mesh_name=mesh.name,
+            armature_name=armature.name,
+            method=method_key,
+            modifier_name=modifier_name,
+            parent=getattr(getattr(mesh, "parent", None), "name", None),
+            prompt="Use pose tools or animation tools to test the resulting deformation rig.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to bind {mesh_name} to {armature_name}")
+
+
+def add_shape_key(object_name: str, name: str, from_mix: bool = False) -> dict:
+    """Add a shape key to a mesh object."""
+    if not name or not name.strip():
+        return skill_error("Invalid name", "name must be a non-empty shape key name.")
+    try:
+        import bpy
+
+        obj, error = _typed_object(bpy, object_name, "MESH")
+        if error:
+            return error
+        add = getattr(obj, "shape_key_add", None)
+        if not callable(add):
+            return skill_error("Shape keys unavailable", f"{object_name} does not expose shape_key_add.")
+        key = add(name=name, from_mix=bool(from_mix))
+        keys = getattr(getattr(getattr(obj, "data", None), "shape_keys", None), "key_blocks", [])
+        return skill_success(
+            f"Added shape key {key.name}",
+            object_name=obj.name,
+            shape_key_name=key.name,
+            from_mix=bool(from_mix),
+            shape_key_count=_collection_len(keys),
+            prompt="Use set_driver to drive shape key values or Blender UI to sculpt the key.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to add shape key to {object_name}")
+
+
+def set_driver(
+    object_name: str,
+    data_path: str,
+    expression: str,
+    variables: Sequence[Mapping[str, Any]] | None = None,
+) -> dict:
+    """Create or update a driver on an object data path."""
+    if not data_path or not data_path.strip():
+        return skill_error("Invalid data_path", "data_path must be a non-empty Blender RNA path.")
+    if not expression or not expression.strip():
+        return skill_error("Invalid expression", "expression must be a non-empty driver expression.")
+    try:
+        import bpy
+
+        obj, error = _object_by_name(bpy, object_name)
+        if error:
+            return error
+        fcurve = obj.driver_add(data_path)
+        if isinstance(fcurve, list):
+            fcurve = fcurve[0]
+        driver = fcurve.driver
+        driver.expression = expression
+        added_variables = []
+        for spec in variables or []:
+            variable = driver.variables.new()
+            variable.name = str(spec.get("name", "var"))
+            variable.type = str(spec.get("type", "SINGLE_PROP"))
+            target_spec = variable.targets[0]
+            target_name = spec.get("target_object") or object_name
+            target_obj, error = _object_by_name(bpy, target_name)
+            if error:
+                return error
+            target_spec.id = target_obj
+            if spec.get("target_data_path"):
+                target_spec.data_path = str(spec["target_data_path"])
+            if spec.get("transform_type") and hasattr(target_spec, "transform_type"):
+                target_spec.transform_type = str(spec["transform_type"])
+            added_variables.append(variable.name)
+        return skill_success(
+            f"Set driver on {object_name}.{data_path}",
+            object_name=obj.name,
+            data_path=data_path,
+            expression=expression,
+            variable_count=len(added_variables),
+            variables=added_variables,
+            prompt="Use get_keyframes or Blender's driver editor to inspect the driven channel.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to set driver on {object_name}.{data_path}")
+
+
+def retarget_animation(
+    source_armature: str,
+    target_armature: str,
+    mapping: Mapping[str, str] | None = None,
+) -> dict:
+    """Copy current pose values and action data between compatible armatures."""
+    try:
+        import bpy
+
+        source, error = _typed_object(bpy, source_armature, "ARMATURE")
+        if error:
+            return error
+        target, error = _typed_object(bpy, target_armature, "ARMATURE")
+        if error:
+            return error
+        source_bones = _pose_bone_map(source)
+        target_bones = _pose_bone_map(target)
+        pairs = dict(mapping or {name: name for name in source_bones if name in target_bones})
+        if not pairs:
+            return skill_error("No retarget mapping", "Provide mapping or matching pose-bone names between armatures.")
+        applied = []
+        missing = []
+        for source_name, target_name in pairs.items():
+            src = source_bones.get(source_name)
+            dst = target_bones.get(target_name)
+            if src is None or dst is None:
+                missing.append({"source": source_name, "target": target_name})
+                continue
+            for attr in ("matrix_basis", "location", "rotation_quaternion", "rotation_euler", "scale"):
+                if hasattr(src, attr) and hasattr(dst, attr):
+                    try:
+                        setattr(dst, attr, getattr(src, attr).copy())
+                    except Exception:
+                        try:
+                            setattr(dst, attr, getattr(src, attr))
+                        except Exception:
+                            pass
+            applied.append({"source": source_name, "target": target_name})
+
+        action_copied = False
+        source_action = getattr(getattr(source, "animation_data", None), "action", None)
+        if source_action is not None:
+            action = source_action.copy()
+            if hasattr(action, "name"):
+                action.name = f"{source_action.name}_retarget_{target.name}"
+            animation_data_create = getattr(target, "animation_data_create", None)
+            target_anim = (
+                animation_data_create() if callable(animation_data_create) else getattr(target, "animation_data", None)
+            )
+            if target_anim is not None:
+                target_anim.action = action
+                action_copied = True
+        return skill_success(
+            f"Retargeted {len(applied)} bone mapping(s)",
+            source_armature=source.name,
+            target_armature=target.name,
+            applied_mappings=applied,
+            missing_mappings=missing,
+            action_copied=action_copied,
+            prompt="Use bake_animation to bake the target armature after retargeting if needed.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to retarget {source_armature} to {target_armature}")

--- a/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
@@ -17,7 +17,9 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | `blender-shader-nodes` | authoring, node graph, lookdev | Inspect material nodes and edit Principled BSDF inputs. | Load after materials when node-level shader edits are requested. | Mixed: read-only node listing plus shader mutations. | shader nodes, principled, metallic, roughness, sockets |
 | `blender-geometry-nodes` | authoring, node graph, procedural | Add and list Geometry Nodes modifiers and node groups. | Load for procedural geometry setup or node modifier inspection. | Mixed: modifier creation plus read-only listing. | geometry nodes, procedural, node group, modifier input |
 | `blender-physics` | simulation, authoring | Add, edit, and remove rigid-body physics settings. | Load for rigid-body setup after objects or mesh creation. | Mutating. | rigid body, collision, mass, friction, physics |
-| `blender-animation` | animation, shot | Set keyframes, frame ranges, and the current frame. | Load when timing, frame range, or keyframe work starts. | Mutating except frame-range reads. | keyframe, timeline, frame range, current frame |
+| `blender-rigging` | authoring, animation | Create armatures and bones, add constraints, bind meshes, create shape keys, set drivers, and retarget compatible rigs. | Load for character setup, deformation rigs, constraints, drivers, shape keys, or retargeting. | Mutating. | rigging, armature, bones, constraints, drivers, shape keys, retargeting |
+| `blender-pose-library` | authoring, animation | List, save, load, and mirror reusable armature poses stored on armature objects. | Load after rigging when pose capture or animation handoff needs reusable poses. | Mutating except pose listing. | pose library, save pose, load pose, mirror pose, armature pose |
+| `blender-animation` | animation, shot | Set, inspect, delete, and bake keyframes plus frame ranges and current frame. | Load when timing, frame range, keyframe, curve inspection, deletion, or baking work starts. | Mutating except frame-range and keyframe reads. | keyframe, timeline, frame range, current frame, bake animation |
 | `blender-camera` | shot, layout, render | Create cameras, set the active camera, edit camera properties, and list cameras. | Load when view, shot, or render framing is requested. | Mutating except camera listing. | camera, lens, active camera, shot, framing |
 | `blender-lighting` | lookdev, render | Create lights, edit light properties, list lights, and set world background. | Load when visibility or render quality depends on lighting. | Mutating except light listing. | light, world background, sun, area light, exposure |
 | `blender-render` | render, diagnostics, delivery | Configure renders, render scenes, inspect render settings, and capture viewport images. | Load after scene/camera/lighting setup when output is needed. | Disk/output producing; read-only for render info. | render, viewport capture, image output, resolution |
@@ -31,6 +33,8 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | Build simple geometry | `blender-scene` -> `blender-objects` -> `blender-mesh` or `blender-geometry` |
 | Edit polygon topology | `blender-objects` -> `blender-mesh-ops` -> `blender-mesh` if modifiers are needed |
 | Prepare textured mesh UVs | `blender-mesh-ops` -> `blender-uv-ops` -> `blender-materials` |
+| Character rig setup | `blender-objects` -> `blender-rigging` -> `blender-pose-library` -> `blender-animation` |
+| Animation handoff | `blender-rigging` -> `blender-pose-library` -> `blender-animation` |
 | Material setup | `blender-materials` -> `blender-shader-nodes` -> `blender-render` |
 | Procedural node setup | `blender-objects` -> `blender-geometry-nodes` -> `blender-render` |
 | Physics setup | `blender-objects` -> `blender-mesh` -> `blender-physics` |
@@ -42,6 +46,6 @@ This index helps agents choose typed Blender skills before falling back to raw P
 
 - Prefer typed skills for repeatable operations, structured errors, and MCP annotations.
 - Use `blender-scene` for initial session and scene discovery.
-- Load authoring skills only when the requested task enters that domain; prefer `blender-mesh-ops` for topology and `blender-mesh` for modifiers.
+- Load authoring skills only when the requested task enters that domain; prefer `blender-mesh-ops` for topology, `blender-mesh` for modifiers, and `blender-rigging`/`blender-pose-library` for character setup.
 - Keep `blender-scripting` as the final escape hatch; mention which typed skills were checked first.
 - Treat disk-writing, render, and scripting tools as higher-risk operations and ask for explicit paths or intent when needed.

--- a/src/dcc_mcp_blender/skills/blender-animation/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-animation/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: blender-animation
-description: "Blender animation — keyframes, frame ranges, and actions"
+description: "Blender animation — keyframes, frame ranges, curve inspection, key deletion, and baking"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
 metadata:
   dcc-mcp:
     dcc: blender
     version: "1.0.0"
-    tags: [blender, animation, keyframes]
-    search-hint: "keyframe, animation, frame range, action, timeline"
+    tags: [blender, animation, keyframes, curves, baking, timeline]
+    search-hint: "keyframe, animation, frame range, action, timeline, fcurve, delete keyframes, bake animation"
     tools: tools.yaml
 ---
 
 # blender-animation
 
-Blender animation keyframe and timeline skill.
+Blender animation keyframe and timeline skill. Use it for frame ranges,
+current-frame changes, inserting keys, inspecting f-curves, deleting keyframes,
+and baking transform samples. Prefer `blender-rigging` for rig construction and
+`blender-pose-library` for reusable armature poses.

--- a/src/dcc_mcp_blender/skills/blender-animation/scripts/bake_animation.py
+++ b/src/dcc_mcp_blender/skills/blender-animation/scripts/bake_animation.py
@@ -1,0 +1,19 @@
+"""Bake Blender animation by inserting sampled keyframes."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._animation_ops import bake_animation
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`bake_animation`."""
+    return bake_animation(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-animation/scripts/delete_keyframes.py
+++ b/src/dcc_mcp_blender/skills/blender-animation/scripts/delete_keyframes.py
@@ -1,0 +1,19 @@
+"""Delete Blender keyframes for an object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._animation_ops import delete_keyframes
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`delete_keyframes`."""
+    return delete_keyframes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-animation/scripts/get_keyframes.py
+++ b/src/dcc_mcp_blender/skills/blender-animation/scripts/get_keyframes.py
@@ -1,0 +1,19 @@
+"""Get Blender keyframes for an object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._animation_ops import get_keyframes
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_keyframes`."""
+    return get_keyframes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-animation/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-animation/tools.yaml
@@ -31,3 +31,120 @@ tools:
     read_only: false
     destructive: false
     idempotent: true
+  - name: get_keyframes
+    description: "Return keyframe times grouped by f-curve for an object."
+    source_file: scripts/get_keyframes.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Object name.
+        data_path:
+          type: string
+          minLength: 1
+          description: Optional f-curve data path filter.
+    output_schema: &animation_result_schema
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+  - name: delete_keyframes
+    description: "Delete keyframes on an object, optionally filtered by frame range and data path."
+    source_file: scripts/delete_keyframes.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Object name.
+        frame_range:
+          type: array
+          minItems: 2
+          maxItems: 2
+          items:
+            type: number
+          description: Optional [start, end] frame range to delete.
+        data_path:
+          type: string
+          minLength: 1
+          description: Optional f-curve data path filter.
+    output_schema: *animation_result_schema
+    read_only: false
+    destructive: true
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: true
+      open_world_hint: false
+  - name: bake_animation
+    description: "Sample objects over a frame range by inserting explicit keyframes."
+    source_file: scripts/bake_animation.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_names, frame_start, frame_end]
+      properties:
+        object_names:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            minLength: 1
+          description: Objects to bake.
+        frame_start:
+          type: integer
+          description: First frame to sample.
+        frame_end:
+          type: integer
+          description: Last frame to sample.
+        step:
+          type: integer
+          minimum: 1
+          default: 1
+          description: Sampling step in frames.
+        data_paths:
+          type: array
+          items:
+            type: string
+            minLength: 1
+          description: Optional data paths to key; defaults to transforms.
+    output_schema: *animation_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false

--- a/src/dcc_mcp_blender/skills/blender-pose-library/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-pose-library/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: blender-pose-library
+description: >-
+  Blender pose library skill for listing, saving, loading, and mirroring
+  reusable armature poses stored on Blender armature objects.
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: blender
+    layer: domain
+    stage: authoring
+    version: "1.0.0"
+    tags: [blender, pose, pose-library, armature, animation, retargeting]
+    search-hint: >-
+      pose library, save pose, load pose, list poses, mirror pose, armature pose,
+      character animation handoff
+    tools: tools.yaml
+---
+
+# blender-pose-library
+
+Typed pose capture and playback tools for Blender armatures. Poses are stored
+as JSON in armature custom properties, so they work without third-party rigging
+addons and travel with the `.blend` file.
+
+Prefer `blender-rigging` for armature construction and `blender-animation` for
+keyframes, baking, and timeline edits.

--- a/src/dcc_mcp_blender/skills/blender-pose-library/scripts/list_poses.py
+++ b/src/dcc_mcp_blender/skills/blender-pose-library/scripts/list_poses.py
@@ -1,0 +1,19 @@
+"""List poses saved on Blender armatures."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._pose_ops import list_poses
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_poses`."""
+    return list_poses(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-pose-library/scripts/load_pose.py
+++ b/src/dcc_mcp_blender/skills/blender-pose-library/scripts/load_pose.py
@@ -1,0 +1,19 @@
+"""Load a saved pose onto a Blender armature."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._pose_ops import load_pose
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`load_pose`."""
+    return load_pose(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-pose-library/scripts/save_pose.py
+++ b/src/dcc_mcp_blender/skills/blender-pose-library/scripts/save_pose.py
@@ -1,0 +1,19 @@
+"""Save the current pose of a Blender armature."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._pose_ops import save_pose
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`save_pose`."""
+    return save_pose(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-pose-library/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-pose-library/tools.yaml
@@ -1,0 +1,96 @@
+tools:
+  - name: list_poses
+    description: "List poses saved on one armature or all armatures."
+    source_file: scripts/list_poses.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        armature_name:
+          type: string
+          minLength: 1
+          description: Optional armature object name.
+    output_schema: &pose_result_schema
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: save_pose
+    description: "Save the current pose-bone transforms on an armature under a reusable pose name."
+    source_file: scripts/save_pose.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [armature_name, pose_name]
+      properties:
+        armature_name:
+          type: string
+          minLength: 1
+          description: Armature object name.
+        pose_name:
+          type: string
+          minLength: 1
+          description: Pose name to save.
+    output_schema: *pose_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: load_pose
+    description: "Load a saved pose onto an armature, optionally mirrored left/right."
+    source_file: scripts/load_pose.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [armature_name, pose_name]
+      properties:
+        armature_name:
+          type: string
+          minLength: 1
+          description: Armature object name.
+        pose_name:
+          type: string
+          minLength: 1
+          description: Saved pose name.
+        mirror:
+          type: boolean
+          default: false
+          description: Mirror left/right pose names and X-axis values.
+    output_schema: *pose_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false

--- a/src/dcc_mcp_blender/skills/blender-rigging/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-rigging/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: blender-rigging
+description: >-
+  Blender authoring skill for armatures, bones, constraints, armature binding,
+  shape keys, drivers, and simple retargeting. Use this for character setup
+  before falling back to blender-scripting.
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: blender
+    layer: domain
+    stage: authoring
+    version: "1.0.0"
+    tags: [blender, rigging, armature, pose, constraints, drivers, shape-keys, retargeting]
+    search-hint: >-
+      rigging, armature, bones, create bone, constraints, skinning, armature
+      modifier, shape keys, drivers, retarget animation
+    tools: tools.yaml
+---
+
+# blender-rigging
+
+Typed rigging tools for Blender armatures and character setup. Load this skill
+when creating armatures or bones, binding meshes, adding constraints, creating
+shape keys or drivers, or copying pose/action data between compatible rigs.
+
+Prefer `blender-pose-library` for saving and loading reusable poses,
+`blender-animation` for keyframe editing and baking, and `blender-scripting`
+only after checking this typed surface.

--- a/src/dcc_mcp_blender/skills/blender-rigging/scripts/add_constraint.py
+++ b/src/dcc_mcp_blender/skills/blender-rigging/scripts/add_constraint.py
@@ -1,0 +1,19 @@
+"""Add a Blender object constraint."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._rigging_ops import add_constraint
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`add_constraint`."""
+    return add_constraint(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-rigging/scripts/add_shape_key.py
+++ b/src/dcc_mcp_blender/skills/blender-rigging/scripts/add_shape_key.py
@@ -1,0 +1,19 @@
+"""Add a shape key to a Blender mesh."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._rigging_ops import add_shape_key
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`add_shape_key`."""
+    return add_shape_key(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-rigging/scripts/bind_mesh_to_armature.py
+++ b/src/dcc_mcp_blender/skills/blender-rigging/scripts/bind_mesh_to_armature.py
@@ -1,0 +1,19 @@
+"""Bind a mesh object to a Blender armature."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._rigging_ops import bind_mesh_to_armature
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`bind_mesh_to_armature`."""
+    return bind_mesh_to_armature(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-rigging/scripts/create_armature.py
+++ b/src/dcc_mcp_blender/skills/blender-rigging/scripts/create_armature.py
@@ -1,0 +1,19 @@
+"""Create a Blender armature."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._rigging_ops import create_armature
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_armature`."""
+    return create_armature(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-rigging/scripts/create_bone.py
+++ b/src/dcc_mcp_blender/skills/blender-rigging/scripts/create_bone.py
@@ -1,0 +1,19 @@
+"""Create an edit bone in a Blender armature."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._rigging_ops import create_bone
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_bone`."""
+    return create_bone(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-rigging/scripts/mirror_bones.py
+++ b/src/dcc_mcp_blender/skills/blender-rigging/scripts/mirror_bones.py
@@ -1,0 +1,19 @@
+"""Mirror edit bones in a Blender armature."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._rigging_ops import mirror_bones
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`mirror_bones`."""
+    return mirror_bones(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-rigging/scripts/retarget_animation.py
+++ b/src/dcc_mcp_blender/skills/blender-rigging/scripts/retarget_animation.py
@@ -1,0 +1,19 @@
+"""Retarget pose/action data between Blender armatures."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._rigging_ops import retarget_animation
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`retarget_animation`."""
+    return retarget_animation(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-rigging/scripts/set_constraint_properties.py
+++ b/src/dcc_mcp_blender/skills/blender-rigging/scripts/set_constraint_properties.py
@@ -1,0 +1,19 @@
+"""Set properties on a Blender object constraint."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._rigging_ops import set_constraint_properties
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_constraint_properties`."""
+    return set_constraint_properties(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-rigging/scripts/set_driver.py
+++ b/src/dcc_mcp_blender/skills/blender-rigging/scripts/set_driver.py
@@ -1,0 +1,19 @@
+"""Create or update a Blender driver."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._rigging_ops import set_driver
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_driver`."""
+    return set_driver(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-rigging/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-rigging/tools.yaml
@@ -1,0 +1,330 @@
+tools:
+  - name: create_armature
+    description: "Create a Blender armature object."
+    source_file: scripts/create_armature.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: Armature object name.
+        location:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items:
+            type: number
+          description: Optional world location.
+    output_schema: &rig_result_schema
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: create_bone
+    description: "Create an edit bone in an armature with optional parent bone."
+    source_file: scripts/create_bone.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [armature_name, bone_name, head, tail]
+      properties:
+        armature_name:
+          type: string
+          minLength: 1
+          description: Armature object name.
+        bone_name:
+          type: string
+          minLength: 1
+          description: New bone name.
+        head:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items:
+            type: number
+          description: Bone head coordinates.
+        tail:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items:
+            type: number
+          description: Bone tail coordinates.
+        parent:
+          type: string
+          minLength: 1
+          description: Optional parent bone name.
+    output_schema: *rig_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: mirror_bones
+    description: "Mirror armature edit bones across an axis using common left/right naming conventions."
+    source_file: scripts/mirror_bones.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [armature_name]
+      properties:
+        armature_name:
+          type: string
+          minLength: 1
+          description: Armature object name.
+        axis:
+          type: string
+          enum: [x, y, z]
+          default: x
+          description: Mirror axis.
+        naming_rule:
+          type: string
+          enum: [suffix, prefix, auto]
+          default: suffix
+          description: Naming convention hint.
+    output_schema: *rig_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: add_constraint
+    description: "Add a Blender object constraint and optionally assign a target object."
+    source_file: scripts/add_constraint.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name, constraint_type]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Object receiving the constraint.
+        constraint_type:
+          type: string
+          minLength: 1
+          description: Blender constraint type, such as COPY_LOCATION or TRACK_TO.
+        target:
+          type: string
+          minLength: 1
+          description: Optional target object name.
+    output_schema: *rig_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: set_constraint_properties
+    description: "Set supported RNA properties on an existing object constraint."
+    source_file: scripts/set_constraint_properties.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name, constraint_name, properties]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Constrained object name.
+        constraint_name:
+          type: string
+          minLength: 1
+          description: Constraint name.
+        properties:
+          type: object
+          additionalProperties: true
+          description: Properties to apply to the constraint.
+    output_schema: *rig_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: bind_mesh_to_armature
+    description: "Bind a mesh to an armature with an Armature modifier or Blender automatic weights."
+    source_file: scripts/bind_mesh_to_armature.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [mesh_name, armature_name]
+      properties:
+        mesh_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        armature_name:
+          type: string
+          minLength: 1
+          description: Armature object name.
+        method:
+          type: string
+          enum: [modifier, automatic_weights]
+          default: modifier
+          description: Binding method.
+    output_schema: *rig_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: add_shape_key
+    description: "Add a shape key to a mesh object."
+    source_file: scripts/add_shape_key.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name, name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Mesh object name.
+        name:
+          type: string
+          minLength: 1
+          description: Shape key name.
+        from_mix:
+          type: boolean
+          default: false
+          description: Create from current mix.
+    output_schema: *rig_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: set_driver
+    description: "Create or update a driver on an object data path."
+    source_file: scripts/set_driver.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name, data_path, expression]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+          description: Object receiving the driver.
+        data_path:
+          type: string
+          minLength: 1
+          description: RNA data path to drive, such as location.x or scale.
+        expression:
+          type: string
+          minLength: 1
+          description: Driver expression.
+        variables:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+          description: Optional driver variable specs.
+    output_schema: *rig_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: retarget_animation
+    description: "Copy current pose values and action data from one armature to another by bone mapping."
+    source_file: scripts/retarget_animation.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [source_armature, target_armature]
+      properties:
+        source_armature:
+          type: string
+          minLength: 1
+          description: Source armature object name.
+        target_armature:
+          type: string
+          minLength: 1
+          description: Target armature object name.
+        mapping:
+          type: object
+          additionalProperties:
+            type: string
+          description: Optional source-bone to target-bone mapping.
+    output_schema: *rig_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false

--- a/tests/e2e/test_rigging_pose_animation_e2e.py
+++ b/tests/e2e/test_rigging_pose_animation_e2e.py
@@ -1,0 +1,71 @@
+"""E2E tests for Blender rigging, pose-library, and expanded animation skills.
+
+Requires a real Blender Python interpreter.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+bpy = pytest.importorskip("bpy", reason="bpy not available - run inside Blender Python interpreter")
+
+pytestmark = pytest.mark.e2e
+
+from tests.e2e.conftest import load_skill  # noqa: E402
+
+
+def _new_scene():
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+
+
+class TestRiggingPoseAnimationE2E:
+    def setup_method(self):
+        _new_scene()
+
+    def test_armature_pose_and_keyframe_workflow(self):
+        create_armature_mod = load_skill("blender-rigging", "create_armature")
+        armature = create_armature_mod.create_armature(name="AgentRig", location=[0, 0, 0])
+        assert armature["success"] is True
+
+        create_bone_mod = load_skill("blender-rigging", "create_bone")
+        bone = create_bone_mod.create_bone(
+            armature_name="AgentRig",
+            bone_name="spine",
+            head=[0, 0, 0],
+            tail=[0, 0, 2],
+        )
+        assert bone["success"] is True
+
+        pose_bone = bpy.data.objects["AgentRig"].pose.bones["spine"]
+        pose_bone.location = [0.25, 0.0, 0.0]
+
+        save_pose_mod = load_skill("blender-pose-library", "save_pose")
+        saved = save_pose_mod.save_pose(armature_name="AgentRig", pose_name="Reach")
+        assert saved["success"] is True
+
+        pose_bone.location = [0.0, 0.0, 0.0]
+        load_pose_mod = load_skill("blender-pose-library", "load_pose")
+        loaded = load_pose_mod.load_pose(armature_name="AgentRig", pose_name="Reach")
+        assert loaded["success"] is True
+        assert list(pose_bone.location) == [0.25, 0.0, 0.0]
+
+        bake_mod = load_skill("blender-animation", "bake_animation")
+        baked = bake_mod.bake_animation(
+            object_names=["AgentRig"],
+            frame_start=1,
+            frame_end=3,
+            step=2,
+            data_paths=["location"],
+        )
+        assert baked["success"] is True
+        assert baked["context"]["inserted_count"] == 2
+
+        get_keys_mod = load_skill("blender-animation", "get_keyframes")
+        keys = get_keys_mod.get_keyframes(object_name="AgentRig", data_path="location")
+        assert keys["success"] is True
+        assert keys["context"]["keyframe_count"] == 6
+
+        delete_keys_mod = load_skill("blender-animation", "delete_keyframes")
+        deleted = delete_keys_mod.delete_keyframes(object_name="AgentRig", frame_range=[1, 1], data_path="location")
+        assert deleted["success"] is True
+        assert deleted["context"]["deleted_count"] == 3

--- a/tests/test_skills_rigging_pose_animation_ops.py
+++ b/tests/test_skills_rigging_pose_animation_ops.py
@@ -1,0 +1,426 @@
+"""Unit tests for Blender rigging, pose-library, and expanded animation tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import yaml
+
+from tests.conftest import load_and_call, make_mock_bpy
+
+SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_blender" / "skills"
+RIGGING_DIR = SKILLS_ROOT / "blender-rigging"
+POSE_DIR = SKILLS_ROOT / "blender-pose-library"
+ANIMATION_DIR = SKILLS_ROOT / "blender-animation"
+
+RIGGING_TOOLS = {
+    "create_armature",
+    "create_bone",
+    "mirror_bones",
+    "add_constraint",
+    "set_constraint_properties",
+    "bind_mesh_to_armature",
+    "add_shape_key",
+    "set_driver",
+    "retarget_animation",
+}
+
+POSE_TOOLS = {"list_poses", "save_pose", "load_pose"}
+NEW_ANIMATION_TOOLS = {"get_keyframes", "delete_keyframes", "bake_animation"}
+
+
+class FakeObjects(list):
+    def get(self, name):
+        return next((obj for obj in self if obj.name == name), None)
+
+
+class FakeBone:
+    def __init__(self, name):
+        self.name = name
+        self.head = [0.0, 0.0, 0.0]
+        self.tail = [0.0, 0.0, 1.0]
+        self.roll = 0.0
+        self.parent = None
+
+
+class FakeBones(list):
+    def get(self, name):
+        return next((bone for bone in self if bone.name == name), None)
+
+    def new(self, name):
+        bone = FakeBone(name)
+        self.append(bone)
+        return bone
+
+
+class FakePoseBone:
+    def __init__(self, name):
+        self.name = name
+        self.location = [0.0, 0.0, 0.0]
+        self.rotation_mode = "XYZ"
+        self.rotation_euler = [0.0, 0.0, 0.0]
+        self.rotation_quaternion = [1.0, 0.0, 0.0, 0.0]
+        self.scale = [1.0, 1.0, 1.0]
+        self.matrix_basis = MagicMock()
+
+
+class FakePoseBones(list):
+    def get(self, name):
+        return next((bone for bone in self if bone.name == name), None)
+
+
+class FakeArmature(dict):
+    def __init__(self, name="Rig"):
+        super().__init__()
+        self.name = name
+        self.type = "ARMATURE"
+        self.data = MagicMock()
+        self.data.name = name
+        self.data.edit_bones = FakeBones([FakeBone("root.L")])
+        self.data.bones = self.data.edit_bones
+        self.pose = MagicMock()
+        self.pose.bones = FakePoseBones([FakePoseBone("root.L"), FakePoseBone("root.R")])
+        self.constraints = FakeConstraints()
+        self.modifiers = FakeModifiers()
+        self.animation_data = None
+        self._selected = False
+
+    def select_set(self, state):
+        self._selected = bool(state)
+
+    def animation_data_create(self):
+        self.animation_data = MagicMock()
+        return self.animation_data
+
+
+class FakeMeshObject:
+    def __init__(self, name="Mesh"):
+        self.name = name
+        self.type = "MESH"
+        self.constraints = FakeConstraints()
+        self.modifiers = FakeModifiers()
+        self.data = MagicMock()
+        self.data.shape_keys = MagicMock()
+        self.data.shape_keys.key_blocks = []
+        self.keyframe_insert = MagicMock()
+        self._selected = False
+
+    def select_set(self, state):
+        self._selected = bool(state)
+
+    def shape_key_add(self, name, from_mix=False):
+        key = MagicMock()
+        key.name = name
+        self.data.shape_keys.key_blocks.append(key)
+        return key
+
+    def driver_add(self, data_path):
+        fcurve = FakeFcurve(data_path, 0, [])
+        fcurve.driver = FakeDriver()
+        return fcurve
+
+
+class FakeConstraint:
+    def __init__(self, type):
+        self.type = type
+        self.name = type.title()
+        self.influence = 1.0
+        self.target = None
+
+
+class FakeConstraints(list):
+    def get(self, name):
+        return next((constraint for constraint in self if constraint.name == name), None)
+
+    def new(self, type):
+        constraint = FakeConstraint(type)
+        self.append(constraint)
+        return constraint
+
+
+class FakeModifier:
+    def __init__(self, name, type):
+        self.name = name
+        self.type = type
+        self.object = None
+
+
+class FakeModifiers(list):
+    def new(self, name, type):
+        modifier = FakeModifier(name, type)
+        self.append(modifier)
+        return modifier
+
+
+class FakeDriverTarget:
+    def __init__(self):
+        self.id = None
+        self.data_path = ""
+
+
+class FakeDriverVariable:
+    def __init__(self):
+        self.name = "var"
+        self.type = "SINGLE_PROP"
+        self.targets = [FakeDriverTarget()]
+
+
+class FakeDriverVariables(list):
+    def new(self):
+        variable = FakeDriverVariable()
+        self.append(variable)
+        return variable
+
+
+class FakeDriver:
+    def __init__(self):
+        self.expression = ""
+        self.variables = FakeDriverVariables()
+
+
+class FakeKeyframe:
+    def __init__(self, frame):
+        self.co = [float(frame), 0.0]
+
+
+class FakeKeyframes(list):
+    def remove(self, point, fast=False):
+        super().remove(point)
+
+
+class FakeFcurve:
+    def __init__(self, data_path, array_index, frames):
+        self.data_path = data_path
+        self.array_index = array_index
+        self.keyframe_points = FakeKeyframes(FakeKeyframe(frame) for frame in frames)
+        self.update = MagicMock()
+
+
+class FakeAction:
+    def __init__(self):
+        self.name = "Action"
+        self.fcurves = [FakeFcurve("location", 0, [1, 10]), FakeFcurve("scale", 0, [5])]
+
+    def copy(self):
+        return FakeAction()
+
+
+def _bpy_with_objects(objects):
+    bpy = make_mock_bpy()
+    bpy.data.objects = FakeObjects(objects)
+    return bpy
+
+
+def test_rigging_pose_and_animation_tools_yaml_declares_modern_contracts():
+    for skill_dir, expected in (
+        (RIGGING_DIR, RIGGING_TOOLS),
+        (POSE_DIR, POSE_TOOLS),
+    ):
+        doc = yaml.safe_load((skill_dir / "tools.yaml").read_text(encoding="utf-8"))
+        tools = {tool["name"]: tool for tool in doc["tools"]}
+        assert set(tools) == expected
+        for name, tool in tools.items():
+            assert (skill_dir / tool["source_file"]).exists(), name
+            assert tool["execution"] == "sync"
+            assert tool["affinity"] == "main"
+            assert isinstance(tool["timeout_hint_secs"], int)
+            assert tool["input_schema"]["type"] == "object"
+            assert tool["output_schema"]["properties"]["success"]["type"] == "boolean"
+            assert "annotations" in tool
+
+    animation = yaml.safe_load((ANIMATION_DIR / "tools.yaml").read_text(encoding="utf-8"))
+    animation_tools = {tool["name"]: tool for tool in animation["tools"]}
+    assert NEW_ANIMATION_TOOLS <= set(animation_tools)
+    for name in NEW_ANIMATION_TOOLS:
+        tool = animation_tools[name]
+        assert (ANIMATION_DIR / tool["source_file"]).exists(), name
+        assert tool["input_schema"]["type"] == "object"
+        assert "annotations" in tool
+
+
+def test_create_armature_create_bone_and_mirror_bones():
+    armature = FakeArmature("Rig")
+    bpy = _bpy_with_objects([armature])
+    bpy.context.active_object = armature
+
+    created = load_and_call("blender-rigging/scripts/create_armature.py", bpy, name="AgentRig")
+    assert created["success"] is True
+    assert armature.name == "AgentRig"
+
+    bone = load_and_call(
+        "blender-rigging/scripts/create_bone.py",
+        bpy,
+        armature_name="AgentRig",
+        bone_name="spine",
+        head=[0, 0, 0],
+        tail=[0, 0, 2],
+        parent="root.L",
+    )
+    assert bone["success"] is True
+    assert armature.data.edit_bones.get("spine").parent.name == "root.L"
+
+    mirrored = load_and_call("blender-rigging/scripts/mirror_bones.py", bpy, armature_name="AgentRig")
+    assert mirrored["success"] is True
+    assert "root.R" in mirrored["context"]["created_bones"] or "root.R" in mirrored["context"]["skipped_bones"]
+
+    invalid = load_and_call(
+        "blender-rigging/scripts/create_bone.py",
+        bpy,
+        armature_name="AgentRig",
+        bone_name="bad",
+        head=[0, 0, 0],
+        tail=[0, 0, 0],
+    )
+    assert invalid["success"] is False
+
+
+def test_constraints_binding_shape_key_driver_and_error_paths():
+    mesh = FakeMeshObject("Mesh")
+    target = FakeMeshObject("Target")
+    armature = FakeArmature("Rig")
+    bpy = _bpy_with_objects([mesh, target, armature])
+
+    constraint = load_and_call(
+        "blender-rigging/scripts/add_constraint.py",
+        bpy,
+        object_name="Mesh",
+        constraint_type="copy_location",
+        target="Target",
+    )
+    assert constraint["success"] is True
+    assert mesh.constraints[0].target is target
+
+    updated = load_and_call(
+        "blender-rigging/scripts/set_constraint_properties.py",
+        bpy,
+        object_name="Mesh",
+        constraint_name=mesh.constraints[0].name,
+        properties={"influence": 0.5, "missing_prop": True},
+    )
+    assert updated["success"] is True
+    assert updated["context"]["applied"] == {"influence": 0.5}
+    assert updated["context"]["ignored"] == ["missing_prop"]
+
+    bound = load_and_call(
+        "blender-rigging/scripts/bind_mesh_to_armature.py",
+        bpy,
+        mesh_name="Mesh",
+        armature_name="Rig",
+    )
+    assert bound["success"] is True
+    assert mesh.modifiers[0].object is armature
+
+    shape_key = load_and_call("blender-rigging/scripts/add_shape_key.py", bpy, object_name="Mesh", name="Smile")
+    assert shape_key["success"] is True
+    assert mesh.data.shape_keys.key_blocks[0].name == "Smile"
+
+    driver = load_and_call(
+        "blender-rigging/scripts/set_driver.py",
+        bpy,
+        object_name="Mesh",
+        data_path="location",
+        expression="frame / 10",
+    )
+    assert driver["success"] is True
+
+    missing_constraint = load_and_call(
+        "blender-rigging/scripts/set_constraint_properties.py",
+        bpy,
+        object_name="Mesh",
+        constraint_name="Ghost",
+        properties={"influence": 1},
+    )
+    assert missing_constraint["success"] is False
+
+    non_armature = load_and_call(
+        "blender-rigging/scripts/bind_mesh_to_armature.py",
+        bpy,
+        mesh_name="Mesh",
+        armature_name="Target",
+    )
+    assert non_armature["success"] is False
+
+
+def test_pose_library_save_list_load_and_missing_pose():
+    armature = FakeArmature("Rig")
+    bpy = _bpy_with_objects([armature])
+    armature.pose.bones.get("root.L").location = [1.0, 0.0, 0.0]
+
+    saved = load_and_call("blender-pose-library/scripts/save_pose.py", bpy, armature_name="Rig", pose_name="Reach")
+    assert saved["success"] is True
+    assert saved["context"]["bone_count"] == 2
+
+    listed = load_and_call("blender-pose-library/scripts/list_poses.py", bpy, armature_name="Rig")
+    assert listed["success"] is True
+    assert listed["context"]["poses"][0]["pose_name"] == "Reach"
+
+    armature.pose.bones.get("root.L").location = [0.0, 0.0, 0.0]
+    loaded = load_and_call("blender-pose-library/scripts/load_pose.py", bpy, armature_name="Rig", pose_name="Reach")
+    assert loaded["success"] is True
+    assert armature.pose.bones.get("root.L").location == [1.0, 0.0, 0.0]
+
+    missing = load_and_call("blender-pose-library/scripts/load_pose.py", bpy, armature_name="Rig", pose_name="Missing")
+    assert missing["success"] is False
+
+
+def test_retarget_animation_copies_pose_and_action():
+    source = FakeArmature("SourceRig")
+    target = FakeArmature("TargetRig")
+    source.animation_data = MagicMock()
+    source.animation_data.action = FakeAction()
+    source.pose.bones.get("root.L").location = [3.0, 0.0, 0.0]
+    bpy = _bpy_with_objects([source, target])
+
+    result = load_and_call(
+        "blender-rigging/scripts/retarget_animation.py",
+        bpy,
+        source_armature="SourceRig",
+        target_armature="TargetRig",
+        mapping={"root.L": "root.R"},
+    )
+    assert result["success"] is True
+    assert target.pose.bones.get("root.R").location == [3.0, 0.0, 0.0]
+    assert target.animation_data.action is not None
+
+
+def test_get_delete_and_bake_animation_keyframes():
+    obj = FakeMeshObject("Cube")
+    obj.animation_data = MagicMock()
+    obj.animation_data.action = FakeAction()
+    bpy = _bpy_with_objects([obj])
+
+    keys = load_and_call("blender-animation/scripts/get_keyframes.py", bpy, object_name="Cube", data_path="location")
+    assert keys["success"] is True
+    assert keys["context"]["keyframe_count"] == 2
+
+    deleted = load_and_call(
+        "blender-animation/scripts/delete_keyframes.py",
+        bpy,
+        object_name="Cube",
+        frame_range=[1, 1],
+        data_path="location",
+    )
+    assert deleted["success"] is True
+    assert deleted["context"]["deleted_count"] == 1
+
+    invalid = load_and_call(
+        "blender-animation/scripts/delete_keyframes.py",
+        bpy,
+        object_name="Cube",
+        frame_range=[10, 1],
+    )
+    assert invalid["success"] is False
+
+    baked = load_and_call(
+        "blender-animation/scripts/bake_animation.py",
+        bpy,
+        object_names=["Cube"],
+        frame_start=1,
+        frame_end=3,
+        step=2,
+        data_paths=["location"],
+    )
+    assert baked["success"] is True
+    assert baked["context"]["inserted_count"] == 2
+    assert obj.keyframe_insert.call_count == 2


### PR DESCRIPTION
## Summary
- Add `blender-rigging` for armatures, bones, constraints, armature binding, shape keys, drivers, and simple retargeting.
- Add `blender-pose-library` for listing, saving, loading, and mirroring armature poses stored on Blender armature objects.
- Expand `blender-animation` with keyframe inspection/deletion and transform bake tools, plus README and skill-index guidance for character workflows.

## Validation
- `python -m ruff check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py packaging/addon_entry/__init__.py .github/scripts/start_mcp_server.py .github/scripts/start_mcp_server2.py`
- `python -m ruff format --check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py packaging/addon_entry/__init__.py .github/scripts/start_mcp_server.py .github/scripts/start_mcp_server2.py`
- `python tools/lint_skills.py --warnings-as-errors`
- `python -m pytest tests/ -q`
- Blender 4.4.3 background E2E for rigging, pose, and animation workflow
- Local HTTP/MCP smoke for create_armature -> create_bone -> save_pose -> load_pose -> bake_animation -> get_keyframes -> delete_keyframes
- `python -m build`
- `python packaging/assemble_zip.py --platform win64 --output-dir dist_addon`

Closes #31.