### PR TITLE
feat: add blender interchange export tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 ├─────────────────────────────────┤
 │  dcc_mcp_blender                │
 │  ├─ BlenderMcpServer            │
-│  ├─ SkillCatalog (100+ tools)   │
+│  ├─ SkillCatalog (110+ tools)   │
 │  ├─ ActionRegistry              │
 │  └─ HTTP Handlers               │
 ├─────────────────────────────────┤
@@ -49,7 +49,7 @@
 ## Features
 
 - **Embedded MCP server** — no external gateway needed; the server runs inside Blender's Python interpreter
-- **100+ pre-built tools** — scene management, object manipulation, mesh/UV editing, rigging, pose libraries, materials, rendering, nodes, physics, scripting and more
+- **110+ pre-built tools** — scene management, object manipulation, mesh/UV editing, rigging, pose libraries, interchange, materials, rendering, nodes, physics, scripting and more
 - **Extensible skill system** — drop new skill folders alongside built-ins or point to them via env vars
 - **Main-thread host adapter** — `BlenderHost` drives dispatcher ticks through `bpy.app.timers` or a background loop
 - **Streamable HTTP transport** — compatible with any MCP 2025-03-26 client
@@ -68,6 +68,9 @@
 | **blender-uv-ops** | `list_uv_maps`, `create_uv_map`, `delete_uv_map`, `copy_uv_map`, `get_uv_info`, `get_uv_islands`, `project_uvs`, `unwrap_uvs`, `pack_uvs`, `normalize_uvs` |
 | **blender-rigging** | `create_armature`, `create_bone`, `mirror_bones`, `add_constraint`, `set_constraint_properties`, `bind_mesh_to_armature`, `add_shape_key`, `set_driver`, `retarget_animation` |
 | **blender-pose-library** | `list_poses`, `save_pose`, `load_pose` |
+| **blender-interchange** | `import_file`, `import_fbx`, `import_obj`, `export_gltf`, `export_usd`, `export_alembic`, `batch_export` |
+| **blender-export-preset** | `list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset` |
+| **blender-shot-export** | `get_shot_info`, `export_camera` |
 | **blender-materials** | `create_material`, `assign_material`, `set_material_color`, `list_materials`, `delete_material` |
 | **blender-shader-nodes** | `list_material_nodes`, `set_principled_input` |
 | **blender-render** | `render_scene`, `set_render_settings`, `get_render_info`, `capture_viewport` |

--- a/src/dcc_mcp_blender/_interchange_ops.py
+++ b/src/dcc_mcp_blender/_interchange_ops.py
@@ -1,0 +1,626 @@
+"""Shared implementations for Blender interchange, export preset, and shot export tools."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
+
+_PRESET_STORE_KEY = "dcc_mcp_export_presets"
+_IMPORT_FORMATS = {"fbx", "obj"}
+_EXPORT_FORMATS = {"fbx", "obj", "gltf", "usd", "alembic"}
+_FORMAT_EXTENSIONS = {
+    ".fbx": "fbx",
+    ".obj": "obj",
+    ".gltf": "gltf",
+    ".glb": "gltf",
+    ".usd": "usd",
+    ".usda": "usd",
+    ".usdc": "usd",
+    ".abc": "alembic",
+}
+
+
+def _mapping(value: Mapping[str, Any] | None, label: str) -> tuple[dict[str, Any] | None, dict | None]:
+    if value is None:
+        return {}, None
+    if not isinstance(value, Mapping):
+        return None, skill_error(f"Invalid {label}", f"{label} must be an object.")
+    return dict(value), None
+
+
+def _path(path: str, *, must_exist: bool = False, create_parent: bool = False) -> tuple[Path | None, dict | None]:
+    if not path or not str(path).strip():
+        return None, skill_error("Invalid path", "path must be a non-empty file path.")
+    target = Path(path).expanduser()
+    if not target.is_absolute():
+        target = target.resolve()
+    if must_exist and not target.is_file():
+        return None, skill_error(f"File not found: {target}", f"No file exists at '{target}'.")
+    if create_parent:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    return target, None
+
+
+def _format_from_path(path: Path, format: str | None = None) -> tuple[str | None, dict | None]:  # noqa: A002
+    if format:
+        key = format.lower()
+    else:
+        key = _FORMAT_EXTENSIONS.get(path.suffix.lower())
+    if key is None:
+        return None, skill_error("Unsupported format", f"Could not infer format from extension '{path.suffix}'.")
+    if key not in _IMPORT_FORMATS | _EXPORT_FORMATS:
+        return None, skill_error("Unsupported format", f"Format '{key}' is not supported.")
+    return key, None
+
+
+def _object_names(bpy: Any) -> set[str]:
+    return {obj.name for obj in bpy.data.objects}
+
+
+def _objects_by_name(bpy: Any, object_names: Sequence[str] | None) -> tuple[list[Any], list[str], dict | None]:
+    if object_names is None:
+        return [], [], None
+    if isinstance(object_names, (str, bytes)) or not object_names:
+        return [], [], skill_error("Invalid object_names", "object_names must be a non-empty list when provided.")
+    objects = []
+    missing = []
+    for name in object_names:
+        obj = bpy.data.objects.get(name)
+        if obj is None:
+            missing.append(name)
+        else:
+            objects.append(obj)
+    return objects, missing, None
+
+
+def _select_objects(bpy: Any, object_names: Sequence[str] | None) -> tuple[bool, list[str], dict | None]:
+    objects, missing, error = _objects_by_name(bpy, object_names)
+    if error:
+        return False, [], error
+    if missing:
+        return False, [], skill_error("Object not found", f"Missing object(s): {', '.join(missing)}")
+    if not objects:
+        return False, [], None
+    try:
+        bpy.ops.object.mode_set(mode="OBJECT")
+    except Exception:
+        pass
+    bpy.ops.object.select_all(action="DESELECT")
+    for obj in objects:
+        obj.select_set(True)
+    bpy.context.view_layer.objects.active = objects[0]
+    return True, [obj.name for obj in objects], None
+
+
+def _call_with_options(operator: Any, base: dict[str, Any], options: dict[str, Any], warnings: list[str]) -> None:
+    payload = dict(base)
+    payload.update(options)
+    try:
+        operator(**payload)
+    except TypeError as exc:
+        if options:
+            warnings.append(f"Retried without unsupported options: {sorted(options)}")
+            operator(**base)
+        else:
+            raise exc
+
+
+def _has_nonempty_file(path: Path) -> bool:
+    return path.is_file() and path.stat().st_size > 0
+
+
+def _iter_mesh_objects(bpy: Any, object_names: Sequence[str] | None = None):
+    allowed = set(object_names) if object_names else None
+    for obj in bpy.data.objects:
+        if allowed is not None and obj.name not in allowed:
+            continue
+        if getattr(obj, "type", None) == "MESH" and getattr(obj, "data", None) is not None:
+            yield obj
+
+
+def _coordinate(obj: Any, vertex: Any) -> tuple[float, float, float]:
+    co = getattr(vertex, "co", vertex)
+    matrix = getattr(obj, "matrix_world", None)
+    if matrix is not None:
+        try:
+            co = matrix @ co
+        except Exception:
+            pass
+    return (float(co[0]), float(co[1]), float(co[2]))
+
+
+def _write_basic_obj(bpy: Any, path: Path, object_names: Sequence[str] | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    vertex_offset = 1
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write("# Exported by dcc-mcp-blender\n")
+        for obj in _iter_mesh_objects(bpy, object_names):
+            mesh = obj.data
+            vertices = list(getattr(mesh, "vertices", []))
+            polygons = list(getattr(mesh, "polygons", []))
+            handle.write(f"o {getattr(obj, 'name', 'Object')}\n")
+            for vertex in vertices:
+                x, y, z = _coordinate(obj, vertex)
+                handle.write(f"v {x:.9g} {y:.9g} {z:.9g}\n")
+            for polygon in polygons:
+                indices = [str(vertex_offset + int(index)) for index in getattr(polygon, "vertices", [])]
+                if len(indices) >= 3:
+                    handle.write(f"f {' '.join(indices)}\n")
+            vertex_offset += len(vertices)
+
+
+def _import_by_format(
+    bpy: Any,
+    target: Path,
+    format: str,  # noqa: A002
+    options: dict[str, Any],
+) -> tuple[list[str], list[str], dict | None]:
+    before = _object_names(bpy)
+    warnings = []
+    try:
+        if format == "fbx":
+            _call_with_options(bpy.ops.import_scene.fbx, {"filepath": str(target)}, options, warnings)
+        elif format == "obj":
+            wm_import = getattr(bpy.ops.wm, "obj_import", None)
+            scene_import = getattr(getattr(bpy.ops, "import_scene", None), "obj", None)
+            operator = wm_import if callable(wm_import) else scene_import
+            if not callable(operator):
+                return (
+                    [],
+                    warnings,
+                    skill_error("OBJ import unavailable", "No Blender OBJ import operator is available."),
+                )
+            _call_with_options(operator, {"filepath": str(target)}, options, warnings)
+        else:
+            return [], warnings, skill_error("Unsupported import format", f"Format '{format}' is not importable.")
+    except Exception as exc:
+        return [], warnings, skill_exception(exc, message=f"Failed to import {target}")
+    after = _object_names(bpy)
+    return sorted(after - before), warnings, None
+
+
+def _export_by_format(
+    bpy: Any,
+    target: Path,
+    format: str,  # noqa: A002
+    object_names: Sequence[str] | None,
+    options: dict[str, Any],
+    frame_range: Sequence[int] | None = None,
+) -> tuple[list[str], list[str], dict | None]:
+    selected, selected_names, error = _select_objects(bpy, object_names)
+    if error:
+        return [], [], error
+    warnings = []
+    try:
+        if format == "fbx":
+            _call_with_options(
+                bpy.ops.export_scene.fbx, {"filepath": str(target), "use_selection": selected}, options, warnings
+            )
+        elif format == "obj":
+            wm_export = getattr(bpy.ops.wm, "obj_export", None)
+            scene_export = getattr(getattr(bpy.ops, "export_scene", None), "obj", None)
+            try:
+                if callable(wm_export):
+                    _call_with_options(
+                        wm_export,
+                        {"filepath": str(target), "export_selected_objects": selected},
+                        options,
+                        warnings,
+                    )
+                elif callable(scene_export):
+                    _call_with_options(
+                        scene_export, {"filepath": str(target), "use_selection": selected}, options, warnings
+                    )
+                else:
+                    raise RuntimeError("No OBJ export operator is available")
+                if not _has_nonempty_file(target):
+                    raise RuntimeError("OBJ exporter produced no file")
+            except Exception:
+                warnings.append("Used basic OBJ fallback writer")
+                _write_basic_obj(bpy, target, selected_names if selected else None)
+        elif format == "gltf":
+            _call_with_options(
+                bpy.ops.export_scene.gltf, {"filepath": str(target), "use_selection": selected}, options, warnings
+            )
+        elif format == "usd":
+            _call_with_options(
+                bpy.ops.wm.usd_export, {"filepath": str(target), "selected_objects_only": selected}, options, warnings
+            )
+        elif format == "alembic":
+            base = {"filepath": str(target), "selected": selected}
+            if frame_range is not None:
+                base.update({"start": int(frame_range[0]), "end": int(frame_range[1])})
+            _call_with_options(bpy.ops.wm.alembic_export, base, options, warnings)
+        else:
+            return [], warnings, skill_error("Unsupported export format", f"Format '{format}' is not exportable.")
+    except Exception as exc:
+        return [], warnings, skill_exception(exc, message=f"Failed to export {target}")
+    written = [str(target)] if target.exists() else []
+    return written, warnings, None
+
+
+def _result_for_export(
+    label: str, target: Path, written: list[str], warnings: list[str], options: dict[str, Any]
+) -> dict:
+    return skill_success(
+        label,
+        filepath=str(target),
+        written_files=written,
+        warnings=warnings,
+        normalized_options=options,
+        prompt="Use import_file or downstream validation tools to inspect exported data.",
+    )
+
+
+def import_file(
+    path: str,
+    format: str | None = None,  # noqa: A002
+    collection_name: str | None = None,
+    options: Mapping[str, Any] | None = None,
+) -> dict:
+    """Import an FBX or OBJ file with Blender-native operators."""
+    opts, error = _mapping(options, "options")
+    if error:
+        return error
+    target, error = _path(path, must_exist=True)
+    if error:
+        return error
+    format_key, error = _format_from_path(target, format)
+    if error:
+        return error
+    if format_key not in _IMPORT_FORMATS:
+        return skill_error("Unsupported import format", f"Format '{format_key}' is not importable.")
+    try:
+        import bpy
+
+        imported, warnings, error = _import_by_format(bpy, target, format_key, opts)
+        if error:
+            return error
+        if collection_name and imported:
+            collection = bpy.data.collections.get(collection_name) or bpy.data.collections.new(collection_name)
+            try:
+                bpy.context.scene.collection.children.link(collection)
+            except Exception:
+                pass
+            for name in imported:
+                obj = bpy.data.objects.get(name)
+                if obj is not None:
+                    try:
+                        collection.objects.link(obj)
+                    except Exception:
+                        pass
+        return skill_success(
+            f"Imported {format_key.upper()}: {target}",
+            filepath=str(target),
+            format=format_key,
+            collection_name=collection_name,
+            imported_object_names=imported,
+            imported_count=len(imported),
+            warnings=warnings,
+            normalized_options=opts,
+            prompt="Use scene or object tools to inspect imported objects.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to import {target}")
+
+
+def import_fbx(path: str, options: Mapping[str, Any] | None = None) -> dict:
+    """Import an FBX file."""
+    return import_file(path=path, format="fbx", options=options)
+
+
+def import_obj(path: str, options: Mapping[str, Any] | None = None) -> dict:
+    """Import an OBJ file."""
+    return import_file(path=path, format="obj", options=options)
+
+
+def export_file(
+    path: str,
+    format: str,  # noqa: A002
+    object_names: Sequence[str] | None = None,
+    options: Mapping[str, Any] | None = None,
+    frame_range: Sequence[int] | None = None,
+) -> dict:
+    """Export the current scene or selected objects."""
+    opts, error = _mapping(options, "options")
+    if error:
+        return error
+    target, error = _path(path, create_parent=True)
+    if error:
+        return error
+    format_key, error = _format_from_path(target, format)
+    if error:
+        return error
+    if format_key not in _EXPORT_FORMATS:
+        return skill_error("Unsupported export format", f"Format '{format_key}' is not exportable.")
+    if frame_range is not None:
+        if isinstance(frame_range, (str, bytes)) or len(frame_range) != 2 or int(frame_range[0]) > int(frame_range[1]):
+            return skill_error("Invalid frame_range", "frame_range must contain [start, end] with start <= end.")
+    try:
+        import bpy
+
+        written, warnings, error = _export_by_format(bpy, target, format_key, object_names, opts, frame_range)
+        if error:
+            return error
+        return _result_for_export(f"Exported {format_key.upper()}: {target}", target, written, warnings, opts)
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to export {target}")
+
+
+def export_fbx(path: str, object_names: Sequence[str] | None = None, options: Mapping[str, Any] | None = None) -> dict:
+    """Export FBX."""
+    return export_file(path=path, format="fbx", object_names=object_names, options=options)
+
+
+def export_obj(path: str, object_names: Sequence[str] | None = None, options: Mapping[str, Any] | None = None) -> dict:
+    """Export OBJ."""
+    return export_file(path=path, format="obj", object_names=object_names, options=options)
+
+
+def export_gltf(path: str, object_names: Sequence[str] | None = None, options: Mapping[str, Any] | None = None) -> dict:
+    """Export glTF or GLB."""
+    return export_file(path=path, format="gltf", object_names=object_names, options=options)
+
+
+def export_usd(path: str, object_names: Sequence[str] | None = None, options: Mapping[str, Any] | None = None) -> dict:
+    """Export USD."""
+    return export_file(path=path, format="usd", object_names=object_names, options=options)
+
+
+def export_alembic(
+    path: str,
+    object_names: Sequence[str] | None = None,
+    frame_range: Sequence[int] | None = None,
+    options: Mapping[str, Any] | None = None,
+) -> dict:
+    """Export Alembic."""
+    return export_file(path=path, format="alembic", object_names=object_names, options=options, frame_range=frame_range)
+
+
+def _get_store(scene: Any) -> dict[str, Any]:
+    raw = scene.get(_PRESET_STORE_KEY, "{}") if callable(getattr(scene, "get", None)) else "{}"
+    if isinstance(raw, dict):
+        return dict(raw)
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _save_store(scene: Any, store: dict[str, Any]) -> None:
+    scene[_PRESET_STORE_KEY] = json.dumps(store, sort_keys=True)
+
+
+def list_export_presets() -> dict:
+    """List scene-stored export presets."""
+    try:
+        import bpy
+
+        store = _get_store(bpy.context.scene)
+        presets = [
+            {"name": name, "format": data.get("format"), "option_count": len(data.get("options", {}))}
+            for name, data in sorted(store.items())
+        ]
+        return skill_success(
+            f"Found {len(presets)} export preset(s)",
+            presets=presets,
+            count=len(presets),
+            prompt="Use load_export_preset to inspect options or batch_export to apply a preset.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list export presets")
+
+
+def save_export_preset(name: str, format: str, options: Mapping[str, Any]) -> dict:  # noqa: A002
+    """Save a scene-stored export preset."""
+    if not name or not name.strip():
+        return skill_error("Invalid name", "name must be a non-empty preset name.")
+    opts, error = _mapping(options, "options")
+    if error:
+        return error
+    format_key = format.lower()
+    if format_key not in _EXPORT_FORMATS:
+        return skill_error("Unsupported export format", f"Format '{format_key}' is not exportable.")
+    try:
+        import bpy
+
+        store = _get_store(bpy.context.scene)
+        store[name] = {"name": name, "format": format_key, "options": opts}
+        _save_store(bpy.context.scene, store)
+        return skill_success(
+            f"Saved export preset {name}",
+            name=name,
+            format=format_key,
+            normalized_options=opts,
+            preset_count=len(store),
+            prompt="Use batch_export with preset_name to reuse these options.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to save export preset {name}")
+
+
+def load_export_preset(name: str) -> dict:
+    """Load a scene-stored export preset."""
+    try:
+        import bpy
+
+        store = _get_store(bpy.context.scene)
+        preset = store.get(name)
+        if preset is None:
+            return skill_error(f"Preset not found: {name}", f"No export preset named '{name}'.")
+        return skill_success(
+            f"Loaded export preset {name}",
+            name=name,
+            format=preset.get("format"),
+            normalized_options=preset.get("options", {}),
+            prompt="Use batch_export or a format-specific export tool with these options.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to load export preset {name}")
+
+
+def delete_export_preset(name: str) -> dict:
+    """Delete a scene-stored export preset."""
+    try:
+        import bpy
+
+        store = _get_store(bpy.context.scene)
+        if name not in store:
+            return skill_error(f"Preset not found: {name}", f"No export preset named '{name}'.")
+        del store[name]
+        _save_store(bpy.context.scene, store)
+        return skill_success(
+            f"Deleted export preset {name}",
+            name=name,
+            preset_count=len(store),
+            prompt="Use list_export_presets to inspect remaining presets.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to delete export preset {name}")
+
+
+def batch_export(items: Sequence[Mapping[str, Any]], preset_name: str | None = None) -> dict:
+    """Run multiple exports with optional preset options."""
+    if isinstance(items, (str, bytes)) or not items:
+        return skill_error("Invalid items", "items must be a non-empty list of export item objects.")
+    try:
+        import bpy
+
+        preset = {}
+        if preset_name:
+            store = _get_store(bpy.context.scene)
+            preset = store.get(preset_name)
+            if preset is None:
+                return skill_error(f"Preset not found: {preset_name}", f"No export preset named '{preset_name}'.")
+        results = []
+        written_files = []
+        warnings = []
+        for item in items:
+            if not isinstance(item, Mapping):
+                return skill_error("Invalid batch item", "Every batch export item must be an object.")
+            path = item.get("path")
+            if not path:
+                return skill_error("Invalid batch item", "Every batch export item must include a non-empty path.")
+            format_key = str(item.get("format") or preset.get("format") or "").lower()
+            options = dict(preset.get("options", {}))
+            options.update(dict(item.get("options") or {}))
+            target, error = _path(str(path), create_parent=True)
+            if error:
+                return error
+            format_key, error = _format_from_path(target, format_key)
+            if error:
+                return error
+            written, item_warnings, error = _export_by_format(
+                bpy,
+                target,
+                format_key,
+                item.get("object_names"),
+                options,
+                item.get("frame_range"),
+            )
+            if error:
+                return error
+            written_files.extend(written)
+            warnings.extend(item_warnings)
+            results.append(
+                {"path": str(target), "format": format_key, "written_files": written, "warnings": item_warnings}
+            )
+        return skill_success(
+            f"Batch exported {len(results)} item(s)",
+            preset_name=preset_name,
+            results=results,
+            written_files=written_files,
+            warnings=warnings,
+            count=len(results),
+            prompt="Use file_exists or import_file to validate exported files.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to run batch export")
+
+
+def _camera_info(camera: Any) -> dict[str, Any]:
+    data = getattr(camera, "data", None)
+    return {
+        "camera_name": camera.name,
+        "data_name": getattr(data, "name", None),
+        "lens": getattr(data, "lens", None),
+        "sensor_width": getattr(data, "sensor_width", None),
+        "location": [float(value) for value in getattr(camera, "location", [0.0, 0.0, 0.0])],
+        "rotation_euler": [float(value) for value in getattr(camera, "rotation_euler", [0.0, 0.0, 0.0])],
+    }
+
+
+def get_shot_info(camera_name: str | None = None, frame_range: Sequence[int] | None = None) -> dict:
+    """Return camera, frame-range, and render metadata for shot export."""
+    if frame_range is not None:
+        if isinstance(frame_range, (str, bytes)) or len(frame_range) != 2 or int(frame_range[0]) > int(frame_range[1]):
+            return skill_error("Invalid frame_range", "frame_range must contain [start, end] with start <= end.")
+    try:
+        import bpy
+
+        scene = bpy.context.scene
+        camera = bpy.data.objects.get(camera_name) if camera_name else getattr(scene, "camera", None)
+        if camera is None:
+            return skill_error(
+                "Camera not found",
+                f"No camera named '{camera_name}'." if camera_name else "Scene has no active camera.",
+            )
+        if getattr(camera, "type", None) != "CAMERA":
+            return skill_error(f"{camera.name} is not a camera", f"Object type is {getattr(camera, 'type', None)}.")
+        frames = list(frame_range) if frame_range else [int(scene.frame_start), int(scene.frame_end)]
+        return skill_success(
+            f"Shot info for {camera.name}",
+            camera=_camera_info(camera),
+            frame_range=frames,
+            fps=getattr(scene.render, "fps", None),
+            resolution=[getattr(scene.render, "resolution_x", None), getattr(scene.render, "resolution_y", None)],
+            prompt="Use export_camera to write camera metadata or export_alembic/export_fbx for animated shots.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get shot info")
+
+
+def export_camera(camera_name: str, path: str, format: str = "json", frame_range: Sequence[int] | None = None) -> dict:  # noqa: A002
+    """Write camera and shot metadata to a JSON file."""
+    if format.lower() != "json":
+        return skill_error("Unsupported camera export format", "Only json camera export is currently supported.")
+    target, error = _path(path, create_parent=True)
+    if error:
+        return error
+    try:
+        info = get_shot_info(camera_name=camera_name, frame_range=frame_range)
+        if not info.get("success"):
+            return info
+        payload = info["context"]
+        target.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        return skill_success(
+            f"Exported camera metadata: {target}",
+            camera_name=camera_name,
+            filepath=str(target),
+            format="json",
+            written_files=[str(target)],
+            shot_info=payload,
+            prompt="Use the JSON file with downstream shot, camera, or layout tooling.",
+        )
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to export camera metadata to {target}")

--- a/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
@@ -13,6 +13,9 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | `blender-mesh-ops` | authoring, modeling | Inspect, clean, triangulate, combine, separate, mirror, extract, and select polygon mesh data. | Load when topology or face-level mesh editing is requested. | Mutating except polygon count. | polygon count, cleanup mesh, triangulate, combine meshes, merge vertices, extract faces |
 | `blender-uv-ops` | authoring, texture prep | Create, copy, inspect, project, unwrap, pack, and normalize UV maps. | Load when texture coordinates or UV islands are requested. | Mutating except UV-map and island inspection. | uv map, unwrap, texture coordinates, projection, pack islands |
 | `blender-geometry` | authoring, interchange, pipeline | Create simple geometry and save/export blend, FBX, or OBJ files. | Load when file output or basic geometry helpers are needed. | Disk-writing and mutating except file existence checks. | sphere, export fbx, export obj, save blend, file exists |
+| `blender-interchange` | interchange, pipeline | Import FBX/OBJ files and export GLTF, USD, Alembic, or batch export jobs. | Load when assets move between DCC/game/pipeline formats. | Disk-writing and scene mutation for imports. | import file, import fbx, import obj, export gltf, export usd, export alembic |
+| `blender-export-preset` | interchange, pipeline | Save, list, load, and delete reusable scene-stored export option presets. | Load when export settings need repeatable named presets. | Mutating except preset listing/loading. | export preset, batch export, reusable export options |
+| `blender-shot-export` | interchange, shot | Inspect shot metadata and export camera metadata JSON. | Load for camera, shot, and animation delivery metadata. | Disk-writing except shot info. | shot export, camera metadata, frame range, camera json |
 | `blender-materials` | authoring, lookdev | Create, assign, edit, list, and delete materials. | Load before shader nodes when material slots or colors are enough. | Mutating except material listing. | material, assign, color, shader base, delete material |
 | `blender-shader-nodes` | authoring, node graph, lookdev | Inspect material nodes and edit Principled BSDF inputs. | Load after materials when node-level shader edits are requested. | Mixed: read-only node listing plus shader mutations. | shader nodes, principled, metallic, roughness, sockets |
 | `blender-geometry-nodes` | authoring, node graph, procedural | Add and list Geometry Nodes modifiers and node groups. | Load for procedural geometry setup or node modifier inspection. | Mixed: modifier creation plus read-only listing. | geometry nodes, procedural, node group, modifier input |
@@ -39,7 +42,8 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | Procedural node setup | `blender-objects` -> `blender-geometry-nodes` -> `blender-render` |
 | Physics setup | `blender-objects` -> `blender-mesh` -> `blender-physics` |
 | Shot and render delivery | `blender-camera` -> `blender-lighting` -> `blender-render` |
-| File interchange | `blender-scene` -> `blender-geometry` |
+| File interchange | `blender-scene` -> `blender-interchange` -> `blender-export-preset` when settings repeat |
+| Shot delivery | `blender-camera` -> `blender-animation` -> `blender-shot-export` -> `blender-interchange` |
 | Custom fallback | Typed domain skill -> `blender-scripting` only for the missing operation |
 
 ## Loading Guidance
@@ -47,5 +51,6 @@ This index helps agents choose typed Blender skills before falling back to raw P
 - Prefer typed skills for repeatable operations, structured errors, and MCP annotations.
 - Use `blender-scene` for initial session and scene discovery.
 - Load authoring skills only when the requested task enters that domain; prefer `blender-mesh-ops` for topology, `blender-mesh` for modifiers, and `blender-rigging`/`blender-pose-library` for character setup.
+- Use `blender-interchange` and `blender-shot-export` for import/export and delivery before writing custom Python exporters.
 - Keep `blender-scripting` as the final escape hatch; mention which typed skills were checked first.
 - Treat disk-writing, render, and scripting tools as higher-risk operations and ask for explicit paths or intent when needed.

--- a/src/dcc_mcp_blender/skills/blender-export-preset/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-export-preset/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: blender-export-preset
+description: >-
+  Blender export preset skill for saving, loading, listing, and deleting
+  reusable scene-stored export options for interchange workflows.
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: blender
+    layer: domain
+    stage: interchange
+    version: "1.0.0"
+    tags: [blender, export, preset, interchange, pipeline]
+    search-hint: >-
+      export preset, save export options, list export presets, load export preset,
+      delete export preset, repeatable export settings
+    tools: tools.yaml
+---
+
+# blender-export-preset
+
+Scene-stored export preset management for repeatable interchange settings.
+Presets are saved in Blender scene custom properties and can be reused by
+`blender-interchange` batch exports.

--- a/src/dcc_mcp_blender/skills/blender-export-preset/scripts/delete_export_preset.py
+++ b/src/dcc_mcp_blender/skills/blender-export-preset/scripts/delete_export_preset.py
@@ -1,16 +1,16 @@
-"""Export the current Blender scene or selected objects to OBJ."""
+"""Delete a Blender export preset."""
 
 from __future__ import annotations
 
 from dcc_mcp_core.skill import skill_entry
 
-from dcc_mcp_blender._interchange_ops import export_obj
+from dcc_mcp_blender._interchange_ops import delete_export_preset
 
 
 @skill_entry
 def main(**kwargs) -> dict:
-    """Entry point; delegates to :func:`export_obj`."""
-    return export_obj(**kwargs)
+    """Entry point; delegates to :func:`delete_export_preset`."""
+    return delete_export_preset(**kwargs)
 
 
 if __name__ == "__main__":

--- a/src/dcc_mcp_blender/skills/blender-export-preset/scripts/list_export_presets.py
+++ b/src/dcc_mcp_blender/skills/blender-export-preset/scripts/list_export_presets.py
@@ -1,16 +1,16 @@
-"""Export the current Blender scene or selected objects to OBJ."""
+"""List Blender export presets."""
 
 from __future__ import annotations
 
 from dcc_mcp_core.skill import skill_entry
 
-from dcc_mcp_blender._interchange_ops import export_obj
+from dcc_mcp_blender._interchange_ops import list_export_presets
 
 
 @skill_entry
 def main(**kwargs) -> dict:
-    """Entry point; delegates to :func:`export_obj`."""
-    return export_obj(**kwargs)
+    """Entry point; delegates to :func:`list_export_presets`."""
+    return list_export_presets(**kwargs)
 
 
 if __name__ == "__main__":

--- a/src/dcc_mcp_blender/skills/blender-export-preset/scripts/load_export_preset.py
+++ b/src/dcc_mcp_blender/skills/blender-export-preset/scripts/load_export_preset.py
@@ -1,16 +1,16 @@
-"""Export the current Blender scene or selected objects to OBJ."""
+"""Load a Blender export preset."""
 
 from __future__ import annotations
 
 from dcc_mcp_core.skill import skill_entry
 
-from dcc_mcp_blender._interchange_ops import export_obj
+from dcc_mcp_blender._interchange_ops import load_export_preset
 
 
 @skill_entry
 def main(**kwargs) -> dict:
-    """Entry point; delegates to :func:`export_obj`."""
-    return export_obj(**kwargs)
+    """Entry point; delegates to :func:`load_export_preset`."""
+    return load_export_preset(**kwargs)
 
 
 if __name__ == "__main__":

--- a/src/dcc_mcp_blender/skills/blender-export-preset/scripts/save_export_preset.py
+++ b/src/dcc_mcp_blender/skills/blender-export-preset/scripts/save_export_preset.py
@@ -1,16 +1,16 @@
-"""Export the current Blender scene or selected objects to OBJ."""
+"""Save a Blender export preset."""
 
 from __future__ import annotations
 
 from dcc_mcp_core.skill import skill_entry
 
-from dcc_mcp_blender._interchange_ops import export_obj
+from dcc_mcp_blender._interchange_ops import save_export_preset
 
 
 @skill_entry
 def main(**kwargs) -> dict:
-    """Entry point; delegates to :func:`export_obj`."""
-    return export_obj(**kwargs)
+    """Entry point; delegates to :func:`save_export_preset`."""
+    return save_export_preset(**kwargs)
 
 
 if __name__ == "__main__":

--- a/src/dcc_mcp_blender/skills/blender-export-preset/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-export-preset/tools.yaml
@@ -1,0 +1,113 @@
+tools:
+  - name: list_export_presets
+    description: "List export presets stored on the current Blender scene."
+    source_file: scripts/list_export_presets.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties: {}
+    output_schema: &preset_result_schema
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: save_export_preset
+    description: "Save reusable export options on the current Blender scene."
+    source_file: scripts/save_export_preset.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [name, format, options]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: Preset name.
+        format:
+          type: string
+          enum: [fbx, obj, gltf, usd, alembic]
+          description: Export format.
+        options:
+          type: object
+          additionalProperties: true
+          description: Export operator options.
+    output_schema: *preset_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: load_export_preset
+    description: "Load a scene-stored export preset."
+    source_file: scripts/load_export_preset.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: Preset name.
+    output_schema: *preset_result_schema
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: delete_export_preset
+    description: "Delete a scene-stored export preset."
+    source_file: scripts/delete_export_preset.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: Preset name.
+    output_schema: *preset_result_schema
+    read_only: false
+    destructive: true
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: true
+      open_world_hint: false

--- a/src/dcc_mcp_blender/skills/blender-geometry/scripts/export_fbx.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry/scripts/export_fbx.py
@@ -1,21 +1,10 @@
-"""Export the current Blender scene to FBX."""
+"""Export the current Blender scene or selected objects to FBX."""
 
 from __future__ import annotations
 
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry
 
-
-def export_fbx(path: str) -> dict:
-    """Export the current scene using ``bpy.ops.export_scene.fbx``."""
-    try:
-        import bpy
-
-        bpy.ops.export_scene.fbx(filepath=path)
-        return skill_success(f"Exported FBX: {path}", filepath=path, prompt="FBX exported.")
-    except ImportError:
-        return skill_error("Blender not available", "bpy could not be imported")
-    except Exception as exc:
-        return skill_exception(exc, message=f"Failed to export FBX: {path}")
+from dcc_mcp_blender._interchange_ops import export_fbx
 
 
 @skill_entry

--- a/src/dcc_mcp_blender/skills/blender-geometry/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-geometry/tools.yaml
@@ -24,18 +24,63 @@ tools:
     destructive: false
     idempotent: true
   - name: export_fbx
-    description: "Export the current scene to FBX"
+    description: "Export the current scene or selected objects to FBX"
     source_file: scripts/export_fbx.py
     execution: sync
     affinity: main
+    timeout_hint_secs: 0
+    input_schema: &geometry_export_schema
+      type: object
+      additionalProperties: false
+      required: [path]
+      properties:
+        path:
+          type: string
+          minLength: 1
+          description: Output file path.
+        object_names:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            minLength: 1
+          description: Optional objects to export.
+        options:
+          type: object
+          additionalProperties: true
+          description: Blender export options.
+    output_schema: &geometry_result_schema
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
     read_only: false
     destructive: false
-    idempotent: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true
   - name: export_obj
-    description: "Export the current scene to OBJ"
+    description: "Export the current scene or selected objects to OBJ"
     source_file: scripts/export_obj.py
     execution: sync
     affinity: main
+    timeout_hint_secs: 0
+    input_schema: *geometry_export_schema
+    output_schema: *geometry_result_schema
     read_only: false
     destructive: false
-    idempotent: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true

--- a/src/dcc_mcp_blender/skills/blender-interchange/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-interchange/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: blender-interchange
+description: >-
+  Blender interchange skill for typed FBX/OBJ imports, GLTF/USD/Alembic exports,
+  and repeatable batch exports. Use for moving assets between DCC, game, and
+  pipeline tools before falling back to scripting.
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: blender
+    layer: domain
+    stage: interchange
+    version: "1.0.0"
+    tags: [blender, interchange, import, export, fbx, obj, gltf, usd, alembic, pipeline]
+    search-hint: >-
+      import file, import fbx, import obj, export gltf, export usd, export alembic,
+      batch export, interchange, pipeline, game export
+    tools: tools.yaml
+---
+
+# blender-interchange
+
+Typed import/export tools for Blender scene interchange. Load this skill when a
+workflow needs asset import, GLTF/USD/Alembic export, or batch export. Existing
+`blender-geometry` exposes FBX/OBJ export names and delegates to the same
+implementation.
+
+Prefer `blender-export-preset` for reusable export settings, `blender-shot-export`
+for camera/shot metadata, and `blender-scripting` only after checking typed
+interchange tools.

--- a/src/dcc_mcp_blender/skills/blender-interchange/scripts/batch_export.py
+++ b/src/dcc_mcp_blender/skills/blender-interchange/scripts/batch_export.py
@@ -1,16 +1,16 @@
-"""Export the current Blender scene or selected objects to OBJ."""
+"""Run a batch of Blender exports."""
 
 from __future__ import annotations
 
 from dcc_mcp_core.skill import skill_entry
 
-from dcc_mcp_blender._interchange_ops import export_obj
+from dcc_mcp_blender._interchange_ops import batch_export
 
 
 @skill_entry
 def main(**kwargs) -> dict:
-    """Entry point; delegates to :func:`export_obj`."""
-    return export_obj(**kwargs)
+    """Entry point; delegates to :func:`batch_export`."""
+    return batch_export(**kwargs)
 
 
 if __name__ == "__main__":

--- a/src/dcc_mcp_blender/skills/blender-interchange/scripts/export_alembic.py
+++ b/src/dcc_mcp_blender/skills/blender-interchange/scripts/export_alembic.py
@@ -1,16 +1,16 @@
-"""Export the current Blender scene or selected objects to OBJ."""
+"""Export Blender data to Alembic."""
 
 from __future__ import annotations
 
 from dcc_mcp_core.skill import skill_entry
 
-from dcc_mcp_blender._interchange_ops import export_obj
+from dcc_mcp_blender._interchange_ops import export_alembic
 
 
 @skill_entry
 def main(**kwargs) -> dict:
-    """Entry point; delegates to :func:`export_obj`."""
-    return export_obj(**kwargs)
+    """Entry point; delegates to :func:`export_alembic`."""
+    return export_alembic(**kwargs)
 
 
 if __name__ == "__main__":

--- a/src/dcc_mcp_blender/skills/blender-interchange/scripts/export_gltf.py
+++ b/src/dcc_mcp_blender/skills/blender-interchange/scripts/export_gltf.py
@@ -1,16 +1,16 @@
-"""Export the current Blender scene or selected objects to OBJ."""
+"""Export Blender data to GLTF or GLB."""
 
 from __future__ import annotations
 
 from dcc_mcp_core.skill import skill_entry
 
-from dcc_mcp_blender._interchange_ops import export_obj
+from dcc_mcp_blender._interchange_ops import export_gltf
 
 
 @skill_entry
 def main(**kwargs) -> dict:
-    """Entry point; delegates to :func:`export_obj`."""
-    return export_obj(**kwargs)
+    """Entry point; delegates to :func:`export_gltf`."""
+    return export_gltf(**kwargs)
 
 
 if __name__ == "__main__":

--- a/src/dcc_mcp_blender/skills/blender-interchange/scripts/export_usd.py
+++ b/src/dcc_mcp_blender/skills/blender-interchange/scripts/export_usd.py
@@ -1,16 +1,16 @@
-"""Export the current Blender scene or selected objects to OBJ."""
+"""Export Blender data to USD."""
 
 from __future__ import annotations
 
 from dcc_mcp_core.skill import skill_entry
 
-from dcc_mcp_blender._interchange_ops import export_obj
+from dcc_mcp_blender._interchange_ops import export_usd
 
 
 @skill_entry
 def main(**kwargs) -> dict:
-    """Entry point; delegates to :func:`export_obj`."""
-    return export_obj(**kwargs)
+    """Entry point; delegates to :func:`export_usd`."""
+    return export_usd(**kwargs)
 
 
 if __name__ == "__main__":

--- a/src/dcc_mcp_blender/skills/blender-interchange/scripts/import_fbx.py
+++ b/src/dcc_mcp_blender/skills/blender-interchange/scripts/import_fbx.py
@@ -1,16 +1,16 @@
-"""Export the current Blender scene or selected objects to OBJ."""
+"""Import an FBX file into Blender."""
 
 from __future__ import annotations
 
 from dcc_mcp_core.skill import skill_entry
 
-from dcc_mcp_blender._interchange_ops import export_obj
+from dcc_mcp_blender._interchange_ops import import_fbx
 
 
 @skill_entry
 def main(**kwargs) -> dict:
-    """Entry point; delegates to :func:`export_obj`."""
-    return export_obj(**kwargs)
+    """Entry point; delegates to :func:`import_fbx`."""
+    return import_fbx(**kwargs)
 
 
 if __name__ == "__main__":

--- a/src/dcc_mcp_blender/skills/blender-interchange/scripts/import_file.py
+++ b/src/dcc_mcp_blender/skills/blender-interchange/scripts/import_file.py
@@ -1,16 +1,16 @@
-"""Export the current Blender scene or selected objects to OBJ."""
+"""Import a Blender-supported interchange file."""
 
 from __future__ import annotations
 
 from dcc_mcp_core.skill import skill_entry
 
-from dcc_mcp_blender._interchange_ops import export_obj
+from dcc_mcp_blender._interchange_ops import import_file
 
 
 @skill_entry
 def main(**kwargs) -> dict:
-    """Entry point; delegates to :func:`export_obj`."""
-    return export_obj(**kwargs)
+    """Entry point; delegates to :func:`import_file`."""
+    return import_file(**kwargs)
 
 
 if __name__ == "__main__":

--- a/src/dcc_mcp_blender/skills/blender-interchange/scripts/import_obj.py
+++ b/src/dcc_mcp_blender/skills/blender-interchange/scripts/import_obj.py
@@ -1,16 +1,16 @@
-"""Export the current Blender scene or selected objects to OBJ."""
+"""Import an OBJ file into Blender."""
 
 from __future__ import annotations
 
 from dcc_mcp_core.skill import skill_entry
 
-from dcc_mcp_blender._interchange_ops import export_obj
+from dcc_mcp_blender._interchange_ops import import_obj
 
 
 @skill_entry
 def main(**kwargs) -> dict:
-    """Entry point; delegates to :func:`export_obj`."""
-    return export_obj(**kwargs)
+    """Entry point; delegates to :func:`import_obj`."""
+    return import_obj(**kwargs)
 
 
 if __name__ == "__main__":

--- a/src/dcc_mcp_blender/skills/blender-interchange/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-interchange/tools.yaml
@@ -1,0 +1,231 @@
+tools:
+  - name: import_file
+    description: "Import an FBX or OBJ file using Blender-native import operators."
+    source_file: scripts/import_file.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [path]
+      properties:
+        path:
+          type: string
+          minLength: 1
+          description: File path to import.
+        format:
+          type: string
+          enum: [fbx, obj]
+          description: Optional format override; inferred from extension when omitted.
+        collection_name:
+          type: string
+          minLength: 1
+          description: Optional collection for imported objects.
+        options:
+          type: object
+          additionalProperties: true
+          description: Blender operator options.
+    output_schema: &interchange_result_schema
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: true
+
+  - name: import_fbx
+    description: "Import an FBX file using Blender's FBX importer."
+    source_file: scripts/import_fbx.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [path]
+      properties:
+        path:
+          type: string
+          minLength: 1
+          description: FBX file path.
+        options:
+          type: object
+          additionalProperties: true
+          description: Blender FBX import options.
+    output_schema: *interchange_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: true
+
+  - name: import_obj
+    description: "Import an OBJ file using Blender's OBJ importer."
+    source_file: scripts/import_obj.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [path]
+      properties:
+        path:
+          type: string
+          minLength: 1
+          description: OBJ file path.
+        options:
+          type: object
+          additionalProperties: true
+          description: Blender OBJ import options.
+    output_schema: *interchange_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: true
+
+  - name: export_gltf
+    description: "Export scene or selected objects to GLTF or GLB."
+    source_file: scripts/export_gltf.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema: &export_schema
+      type: object
+      additionalProperties: false
+      required: [path]
+      properties:
+        path:
+          type: string
+          minLength: 1
+          description: Output file path.
+        object_names:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            minLength: 1
+          description: Optional objects to export.
+        options:
+          type: object
+          additionalProperties: true
+          description: Blender export operator options.
+    output_schema: *interchange_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true
+
+  - name: export_usd
+    description: "Export scene or selected objects to USD."
+    source_file: scripts/export_usd.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema: *export_schema
+    output_schema: *interchange_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true
+
+  - name: export_alembic
+    description: "Export scene or selected objects to Alembic with optional frame range."
+    source_file: scripts/export_alembic.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      <<: *export_schema
+      properties:
+        path:
+          type: string
+          minLength: 1
+          description: Output file path.
+        object_names:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            minLength: 1
+          description: Optional objects to export.
+        frame_range:
+          type: array
+          minItems: 2
+          maxItems: 2
+          items:
+            type: integer
+          description: Optional [start, end] frame range.
+        options:
+          type: object
+          additionalProperties: true
+          description: Blender Alembic export options.
+    output_schema: *interchange_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true
+
+  - name: batch_export
+    description: "Run multiple exports, optionally applying a scene-stored export preset."
+    source_file: scripts/batch_export.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [items]
+      properties:
+        items:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            additionalProperties: true
+          description: Export item objects with path, format, object_names, options, and frame_range.
+        preset_name:
+          type: string
+          minLength: 1
+          description: Optional export preset name.
+    output_schema: *interchange_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true

--- a/src/dcc_mcp_blender/skills/blender-shot-export/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-shot-export/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: blender-shot-export
+description: >-
+  Blender shot export skill for camera metadata and shot frame-range delivery.
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: blender
+    layer: domain
+    stage: interchange
+    version: "1.0.0"
+    tags: [blender, shot, camera, export, animation, interchange]
+    search-hint: >-
+      shot export, camera export, camera metadata, shot info, frame range,
+      animation delivery
+    tools: tools.yaml
+---
+
+# blender-shot-export
+
+Typed shot/camera metadata helpers for delivery workflows. Use with
+`blender-camera`, `blender-animation`, and `blender-interchange` when exporting
+shots or camera handoff data.

--- a/src/dcc_mcp_blender/skills/blender-shot-export/scripts/export_camera.py
+++ b/src/dcc_mcp_blender/skills/blender-shot-export/scripts/export_camera.py
@@ -1,16 +1,16 @@
-"""Export the current Blender scene or selected objects to OBJ."""
+"""Export Blender camera shot metadata."""
 
 from __future__ import annotations
 
 from dcc_mcp_core.skill import skill_entry
 
-from dcc_mcp_blender._interchange_ops import export_obj
+from dcc_mcp_blender._interchange_ops import export_camera
 
 
 @skill_entry
 def main(**kwargs) -> dict:
-    """Entry point; delegates to :func:`export_obj`."""
-    return export_obj(**kwargs)
+    """Entry point; delegates to :func:`export_camera`."""
+    return export_camera(**kwargs)
 
 
 if __name__ == "__main__":

--- a/src/dcc_mcp_blender/skills/blender-shot-export/scripts/get_shot_info.py
+++ b/src/dcc_mcp_blender/skills/blender-shot-export/scripts/get_shot_info.py
@@ -1,16 +1,16 @@
-"""Export the current Blender scene or selected objects to OBJ."""
+"""Get Blender shot metadata."""
 
 from __future__ import annotations
 
 from dcc_mcp_core.skill import skill_entry
 
-from dcc_mcp_blender._interchange_ops import export_obj
+from dcc_mcp_blender._interchange_ops import get_shot_info
 
 
 @skill_entry
 def main(**kwargs) -> dict:
-    """Entry point; delegates to :func:`export_obj`."""
-    return export_obj(**kwargs)
+    """Entry point; delegates to :func:`get_shot_info`."""
+    return get_shot_info(**kwargs)
 
 
 if __name__ == "__main__":

--- a/src/dcc_mcp_blender/skills/blender-shot-export/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-shot-export/tools.yaml
@@ -1,0 +1,82 @@
+tools:
+  - name: get_shot_info
+    description: "Return active or named camera metadata, frame range, FPS, and resolution."
+    source_file: scripts/get_shot_info.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        camera_name:
+          type: string
+          minLength: 1
+          description: Optional camera object name; defaults to active scene camera.
+        frame_range:
+          type: array
+          minItems: 2
+          maxItems: 2
+          items:
+            type: integer
+          description: Optional [start, end] override.
+    output_schema: &shot_result_schema
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: export_camera
+    description: "Write camera and shot metadata to a JSON file."
+    source_file: scripts/export_camera.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [camera_name, path]
+      properties:
+        camera_name:
+          type: string
+          minLength: 1
+          description: Camera object name.
+        path:
+          type: string
+          minLength: 1
+          description: Output JSON file path.
+        format:
+          type: string
+          enum: [json]
+          default: json
+          description: Camera export format.
+        frame_range:
+          type: array
+          minItems: 2
+          maxItems: 2
+          items:
+            type: integer
+          description: Optional [start, end] frame range.
+    output_schema: *shot_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true

--- a/tests/e2e/test_interchange_export_e2e.py
+++ b/tests/e2e/test_interchange_export_e2e.py
@@ -1,0 +1,58 @@
+"""E2E tests for Blender interchange and export tools.
+
+Requires a real Blender Python interpreter.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+bpy = pytest.importorskip("bpy", reason="bpy not available - run inside Blender Python interpreter")
+
+pytestmark = pytest.mark.e2e
+
+from tests.e2e.conftest import load_skill  # noqa: E402
+
+
+def _new_scene():
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+
+
+class TestInterchangeExportE2E:
+    def setup_method(self):
+        _new_scene()
+
+    def test_import_obj_export_obj_and_camera_metadata(self, tmp_path):
+        obj_path = tmp_path / "input.obj"
+        obj_path.write_text(
+            "o ImportedTriangle\nv 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n",
+            encoding="utf-8",
+        )
+
+        import_mod = load_skill("blender-interchange", "import_obj")
+        imported = import_mod.import_obj(path=str(obj_path))
+        assert imported["success"] is True
+        assert imported["context"]["imported_count"] >= 1
+
+        export_mod = load_skill("blender-geometry", "export_obj")
+        exported_path = tmp_path / "output.obj"
+        exported = export_mod.export_obj(path=str(exported_path))
+        assert exported["success"] is True
+        assert exported_path.is_file()
+        assert exported_path.stat().st_size > 0
+
+        bpy.ops.object.camera_add(location=(0, -5, 3), rotation=(1.0, 0.0, 0.0))
+        camera = bpy.context.active_object
+        camera.name = "ShotCam"
+        bpy.context.scene.camera = camera
+
+        shot_mod = load_skill("blender-shot-export", "get_shot_info")
+        shot = shot_mod.get_shot_info(camera_name="ShotCam", frame_range=[1, 12])
+        assert shot["success"] is True
+        assert shot["context"]["frame_range"] == [1, 12]
+
+        camera_mod = load_skill("blender-shot-export", "export_camera")
+        camera_json = tmp_path / "camera.json"
+        camera_export = camera_mod.export_camera(camera_name="ShotCam", path=str(camera_json))
+        assert camera_export["success"] is True
+        assert camera_json.is_file()

--- a/tests/test_skills_geometry.py
+++ b/tests/test_skills_geometry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -69,18 +70,23 @@ def test_export_fbx_calls_export_scene():
     result = load_and_call("blender-geometry/scripts/export_fbx.py", mock_bpy, path="/tmp/out.fbx")
 
     assert result["success"] is True
-    mock_bpy.ops.export_scene.fbx.assert_called_once_with(filepath="/tmp/out.fbx")
+    mock_bpy.ops.export_scene.fbx.assert_called_once()
+    _, kwargs = mock_bpy.ops.export_scene.fbx.call_args
+    assert Path(kwargs["filepath"]).name == "out.fbx"
+    assert kwargs["use_selection"] is False
 
 
 def test_export_obj_prefers_blender_3_plus_operator(tmp_path):
     mock_bpy = make_mock_bpy()
-    mock_bpy.ops.wm.obj_export.side_effect = lambda filepath: open(filepath, "w", encoding="utf-8").write("obj")
+    mock_bpy.ops.wm.obj_export.side_effect = lambda filepath, **_kwargs: open(filepath, "w", encoding="utf-8").write(
+        "obj"
+    )
     out_path = tmp_path / "out.obj"
 
     result = load_and_call("blender-geometry/scripts/export_obj.py", mock_bpy, path=str(out_path))
 
     assert result["success"] is True
-    mock_bpy.ops.wm.obj_export.assert_called_once_with(filepath=str(out_path))
+    mock_bpy.ops.wm.obj_export.assert_called_once_with(filepath=str(out_path), export_selected_objects=False)
 
 
 def test_export_obj_writes_basic_obj_when_operator_context_fails(tmp_path):

--- a/tests/test_skills_interchange_export.py
+++ b/tests/test_skills_interchange_export.py
@@ -1,0 +1,241 @@
+"""Unit tests for Blender interchange, export preset, and shot export skills."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import yaml
+
+from tests.conftest import load_and_call, make_mock_bpy
+
+SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_blender" / "skills"
+INTERCHANGE_DIR = SKILLS_ROOT / "blender-interchange"
+PRESET_DIR = SKILLS_ROOT / "blender-export-preset"
+SHOT_DIR = SKILLS_ROOT / "blender-shot-export"
+GEOMETRY_DIR = SKILLS_ROOT / "blender-geometry"
+
+INTERCHANGE_TOOLS = {
+    "import_file",
+    "import_fbx",
+    "import_obj",
+    "export_gltf",
+    "export_usd",
+    "export_alembic",
+    "batch_export",
+}
+PRESET_TOOLS = {"list_export_presets", "save_export_preset", "load_export_preset", "delete_export_preset"}
+SHOT_TOOLS = {"get_shot_info", "export_camera"}
+
+
+class FakeObjects(list):
+    def get(self, name):
+        return next((obj for obj in self if obj.name == name), None)
+
+
+class FakeScene(dict):
+    def __init__(self):
+        super().__init__()
+        self.frame_start = 1
+        self.frame_end = 24
+        self.frame_current = 1
+        self.camera = None
+        self.collection = MagicMock()
+        self.render = MagicMock()
+        self.render.fps = 24
+        self.render.resolution_x = 1920
+        self.render.resolution_y = 1080
+
+
+class FakeVertex:
+    def __init__(self, co):
+        self.co = co
+
+
+class FakePolygon:
+    def __init__(self, vertices):
+        self.vertices = vertices
+
+
+class FakeMesh:
+    def __init__(self):
+        self.vertices = [
+            FakeVertex((0.0, 0.0, 0.0)),
+            FakeVertex((1.0, 0.0, 0.0)),
+            FakeVertex((0.0, 1.0, 0.0)),
+        ]
+        self.polygons = [FakePolygon([0, 1, 2])]
+
+
+class FakeObject:
+    def __init__(self, name, obj_type="MESH"):
+        self.name = name
+        self.type = obj_type
+        self.data = FakeMesh() if obj_type == "MESH" else MagicMock()
+        self.location = [0.0, 0.0, 0.0]
+        self.rotation_euler = [0.0, 0.0, 0.0]
+        self.matrix_world = None
+        self._selected = False
+
+    def select_set(self, state):
+        self._selected = bool(state)
+
+
+def _bpy_with_scene(objects):
+    bpy = make_mock_bpy()
+    bpy.data.objects = FakeObjects(objects)
+    bpy.context.scene = FakeScene()
+    bpy.context.view_layer.objects.active = None
+    return bpy
+
+
+def _write_file_operator(text):
+    def _operator(filepath, **_kwargs):
+        Path(filepath).write_text(text, encoding="utf-8")
+        return {"FINISHED"}
+
+    return _operator
+
+
+def test_interchange_preset_shot_tools_yaml_declares_modern_contracts():
+    for skill_dir, expected in (
+        (INTERCHANGE_DIR, INTERCHANGE_TOOLS),
+        (PRESET_DIR, PRESET_TOOLS),
+        (SHOT_DIR, SHOT_TOOLS),
+    ):
+        doc = yaml.safe_load((skill_dir / "tools.yaml").read_text(encoding="utf-8"))
+        tools = {tool["name"]: tool for tool in doc["tools"]}
+        assert set(tools) == expected
+        for name, tool in tools.items():
+            assert (skill_dir / tool["source_file"]).exists(), name
+            assert tool["execution"] == "sync"
+            assert tool["affinity"] == "main"
+            assert isinstance(tool["timeout_hint_secs"], int)
+            assert tool["input_schema"]["type"] == "object"
+            assert tool["output_schema"]["properties"]["success"]["type"] == "boolean"
+            assert "annotations" in tool
+
+    geometry = yaml.safe_load((GEOMETRY_DIR / "tools.yaml").read_text(encoding="utf-8"))
+    geometry_tools = {tool["name"]: tool for tool in geometry["tools"]}
+    for name in ("export_fbx", "export_obj"):
+        assert geometry_tools[name]["input_schema"]["type"] == "object"
+        assert geometry_tools[name]["annotations"]["open_world_hint"] is True
+
+
+def test_import_obj_reports_imported_objects_and_missing_file(tmp_path):
+    source = tmp_path / "asset.obj"
+    source.write_text("o Imported\nv 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n", encoding="utf-8")
+    bpy = _bpy_with_scene([])
+
+    def import_obj(filepath, **_kwargs):
+        assert filepath == str(source)
+        bpy.data.objects.append(FakeObject("Imported"))
+        return {"FINISHED"}
+
+    bpy.ops.wm.obj_import.side_effect = import_obj
+
+    result = load_and_call("blender-interchange/scripts/import_obj.py", bpy, path=str(source))
+
+    assert result["success"] is True
+    assert result["context"]["imported_object_names"] == ["Imported"]
+    assert result["context"]["format"] == "obj"
+
+    missing = load_and_call("blender-interchange/scripts/import_file.py", bpy, path=str(tmp_path / "missing.fbx"))
+    assert missing["success"] is False
+
+
+def test_export_obj_fallback_and_gltf_batch_export(tmp_path):
+    cube = FakeObject("Cube")
+    bpy = _bpy_with_scene([cube])
+    bpy.ops.wm.obj_export.side_effect = RuntimeError("operator unavailable")
+    bpy.ops.export_scene.gltf.side_effect = _write_file_operator("gltf")
+
+    obj_path = tmp_path / "mesh.obj"
+    result = load_and_call("blender-geometry/scripts/export_obj.py", bpy, path=str(obj_path), object_names=["Cube"])
+    assert result["success"] is True
+    assert obj_path.read_text(encoding="utf-8").startswith("# Exported by dcc-mcp-blender")
+    assert result["context"]["written_files"] == [str(obj_path)]
+
+    preset = load_and_call(
+        "blender-export-preset/scripts/save_export_preset.py",
+        bpy,
+        name="GameGLTF",
+        format="gltf",
+        options={"export_format": "GLTF_SEPARATE"},
+    )
+    assert preset["success"] is True
+
+    gltf_path = tmp_path / "mesh.gltf"
+    batch = load_and_call(
+        "blender-interchange/scripts/batch_export.py",
+        bpy,
+        preset_name="GameGLTF",
+        items=[{"path": str(gltf_path), "object_names": ["Cube"]}],
+    )
+    assert batch["success"] is True
+    assert batch["context"]["written_files"] == [str(gltf_path)]
+    assert gltf_path.read_text(encoding="utf-8") == "gltf"
+
+    invalid = load_and_call(
+        "blender-interchange/scripts/export_alembic.py",
+        bpy,
+        path=str(tmp_path / "bad.abc"),
+        frame_range=[10, 1],
+    )
+    assert invalid["success"] is False
+
+
+def test_export_preset_lifecycle():
+    bpy = _bpy_with_scene([])
+
+    saved = load_and_call(
+        "blender-export-preset/scripts/save_export_preset.py",
+        bpy,
+        name="UsdShot",
+        format="usd",
+        options={"visible_objects_only": True},
+    )
+    assert saved["success"] is True
+
+    listed = load_and_call("blender-export-preset/scripts/list_export_presets.py", bpy)
+    assert listed["context"]["presets"] == [{"format": "usd", "name": "UsdShot", "option_count": 1}]
+
+    loaded = load_and_call("blender-export-preset/scripts/load_export_preset.py", bpy, name="UsdShot")
+    assert loaded["success"] is True
+    assert loaded["context"]["normalized_options"] == {"visible_objects_only": True}
+
+    deleted = load_and_call("blender-export-preset/scripts/delete_export_preset.py", bpy, name="UsdShot")
+    assert deleted["success"] is True
+
+    missing = load_and_call("blender-export-preset/scripts/load_export_preset.py", bpy, name="UsdShot")
+    assert missing["success"] is False
+
+
+def test_shot_info_and_camera_export(tmp_path):
+    camera = FakeObject("Camera", "CAMERA")
+    camera.data.name = "CameraData"
+    camera.data.lens = 35.0
+    camera.data.sensor_width = 32.0
+    bpy = _bpy_with_scene([camera])
+    bpy.context.scene.camera = camera
+
+    shot = load_and_call("blender-shot-export/scripts/get_shot_info.py", bpy)
+    assert shot["success"] is True
+    assert shot["context"]["camera"]["camera_name"] == "Camera"
+    assert shot["context"]["frame_range"] == [1, 24]
+
+    output = tmp_path / "camera.json"
+    exported = load_and_call(
+        "blender-shot-export/scripts/export_camera.py",
+        bpy,
+        camera_name="Camera",
+        path=str(output),
+        frame_range=[5, 12],
+    )
+    assert exported["success"] is True
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["frame_range"] == [5, 12]
+
+    invalid = load_and_call("blender-shot-export/scripts/get_shot_info.py", bpy, camera_name="Cube")
+    assert invalid["success"] is False

--- a/tools/show_versions.py
+++ b/tools/show_versions.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python
 """Show Python and dependency versions for dcc-mcp-blender."""
+
 import sys
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 print("📦 Environment Information:")
 print(f"Python version: {sys.version.split()[0]}")
 print("")
 
 print("Key Packages:")
-packages = ['dcc-mcp-blender', 'dcc-mcp-core', 'pytest', 'ruff']
+packages = ["dcc-mcp-blender", "dcc-mcp-core", "pytest", "ruff"]
 for pkg in packages:
     try:
         print(f"  {pkg}: {version(pkg)}")
     except PackageNotFoundError:
-        if pkg == 'dcc-mcp-blender':
+        if pkg == "dcc-mcp-blender":
             print(f"  {pkg}: not installed (run: pip install -e .)")
         else:
             print(f"  {pkg}: not installed")


### PR DESCRIPTION
## Summary
- Add Blender interchange tools for FBX/OBJ import and GLTF/USD/Alembic/batch export
- Add export preset and shot camera metadata skills
- Modernize existing OBJ/FBX export tools through a shared implementation

Closes #32

## Validation
- `python -m ruff check src tests tools packaging`
- `python -m ruff format --check src tests tools packaging`
- `python tools/lint_skills.py --warnings-as-errors`
- `python -m pytest tests/ -q`
- Real Blender E2E for interchange export tools
- HTTP/MCP smoke covering import, export, presets, batch export, and camera metadata
- `python -m build`
- addon ZIP assembly