### PR TITLE
feat: expand blender node graph tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 ├─────────────────────────────────┤
 │  dcc_mcp_blender                │
 │  ├─ BlenderMcpServer            │
-│  ├─ SkillCatalog (110+ tools)   │
+│  ├─ SkillCatalog (150+ tools)   │
 │  ├─ ActionRegistry              │
 │  └─ HTTP Handlers               │
 ├─────────────────────────────────┤
@@ -49,7 +49,7 @@
 ## Features
 
 - **Embedded MCP server** — no external gateway needed; the server runs inside Blender's Python interpreter
-- **110+ pre-built tools** — scene management, object manipulation, mesh/UV editing, rigging, pose libraries, interchange, materials, rendering, nodes, physics, scripting and more
+- **150+ pre-built tools** — scene management, object manipulation, mesh/UV editing, rigging, pose libraries, interchange, materials, node graphs, rendering, physics, scripting and more
 - **Extensible skill system** — drop new skill folders alongside built-ins or point to them via env vars
 - **Main-thread host adapter** — `BlenderHost` drives dispatcher ticks through `bpy.app.timers` or a background loop
 - **Streamable HTTP transport** — compatible with any MCP 2025-03-26 client
@@ -72,7 +72,7 @@
 | **blender-export-preset** | `list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset` |
 | **blender-shot-export** | `get_shot_info`, `export_camera` |
 | **blender-materials** | `create_material`, `assign_material`, `set_material_color`, `list_materials`, `delete_material` |
-| **blender-shader-nodes** | `list_material_nodes`, `set_principled_input` |
+| **blender-shader-nodes** | `list_material_nodes`, `set_principled_input`, `list_node_trees`, `list_nodes`, `create_node`, `delete_node`, `list_node_sockets`, `connect_nodes`, `disconnect_nodes`, `list_node_links`, `set_node_input`, `get_node_value`, `create_material_with_nodes`, `assign_texture_node`, `set_principled_inputs` |
 | **blender-render** | `render_scene`, `set_render_settings`, `get_render_info`, `capture_viewport` |
 | **blender-scripting** | `execute_python`, `execute_script_file`, `get_blender_info` |
 | **blender-animation** | `set_keyframe`, `set_frame_range`, `get_frame_range`, `set_current_frame`, `get_keyframes`, `delete_keyframes`, `bake_animation` |
@@ -80,7 +80,7 @@
 | **blender-camera** | `create_camera`, `set_active_camera`, `set_camera_properties`, `list_cameras` |
 | **blender-collection** | `create_collection`, `link_to_collection`, `list_collections` |
 | **blender-geometry** | `create_sphere`, `save_blend`, `file_exists`, `export_fbx`, `export_obj` |
-| **blender-geometry-nodes** | `add_geometry_nodes_modifier`, `list_geometry_nodes_modifiers` |
+| **blender-geometry-nodes** | `add_geometry_nodes_modifier`, `list_geometry_nodes_modifiers`, `create_geometry_node_group`, `assign_geometry_node_group`, `set_geometry_node_modifier_input`, `evaluate_geometry_nodes_info` |
 | **blender-physics** | `add_rigid_body`, `set_rigid_body_properties`, `remove_rigid_body` |
 
 See [`src/dcc_mcp_blender/skills/SKILLS_INDEX.md`](src/dcc_mcp_blender/skills/SKILLS_INDEX.md) for staged loading guidance, task-to-skill chains, and side-effect profiles for all bundled skills.

--- a/src/dcc_mcp_blender/_node_graph_ops.py
+++ b/src/dcc_mcp_blender/_node_graph_ops.py
@@ -1,0 +1,979 @@
+"""Shared Blender shader and geometry node graph operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
+
+_SHADER_KINDS = {"shader", "material"}
+_GEOMETRY_KINDS = {"geometry", "geometry_nodes", "node_group"}
+_MODIFIER_KINDS = {"geometry_modifier", "modifier"}
+
+
+def _iter_collection(collection: Any) -> list[Any]:
+    try:
+        return list(collection)
+    except TypeError:
+        return []
+
+
+def _collection_get(collection: Any, name: str) -> Any | None:
+    getter = getattr(collection, "get", None)
+    if callable(getter):
+        return getter(name)
+    for item in _iter_collection(collection):
+        if getattr(item, "name", None) == name:
+            return item
+    return None
+
+
+def _node_type(node: Any) -> str | None:
+    return getattr(node, "bl_idname", None) or getattr(node, "type", None)
+
+
+def _socket_name(socket: Any) -> str:
+    return str(getattr(socket, "name", socket))
+
+
+def _socket_identifier(socket: Any) -> str:
+    return str(getattr(socket, "identifier", None) or _socket_name(socket))
+
+
+def _socket_value(socket: Any) -> Any:
+    if not hasattr(socket, "default_value"):
+        return None
+    value = socket.default_value
+    if isinstance(value, tuple):
+        return list(value)
+    try:
+        if not isinstance(value, (str, bytes, int, float, bool, dict, list, type(None))):
+            return list(value)
+    except TypeError:
+        pass
+    return value
+
+
+def _socket_info(socket: Any) -> dict[str, Any]:
+    return {
+        "name": _socket_name(socket),
+        "identifier": _socket_identifier(socket),
+        "type": getattr(socket, "type", None),
+        "value": _socket_value(socket),
+        "is_linked": bool(getattr(socket, "is_linked", False)),
+    }
+
+
+def _socket_items(sockets: Any) -> list[Any]:
+    if hasattr(sockets, "values"):
+        try:
+            return list(sockets.values())
+        except Exception:
+            pass
+    return _iter_collection(sockets)
+
+
+def _socket_names(sockets: Any) -> list[str]:
+    if hasattr(sockets, "keys"):
+        try:
+            return [str(name) for name in sockets.keys()]
+        except Exception:
+            pass
+    return [_socket_name(socket) for socket in _socket_items(sockets)]
+
+
+def _get_socket(sockets: Any, name: str) -> Any | None:
+    getter = getattr(sockets, "get", None)
+    if callable(getter):
+        socket = getter(name)
+        if socket is not None:
+            return socket
+    for socket in _socket_items(sockets):
+        if _socket_name(socket) == name or _socket_identifier(socket) == name:
+            return socket
+    return None
+
+
+def _node_info(node: Any, include_sockets: bool = True) -> dict[str, Any]:
+    info = {
+        "name": getattr(node, "name", None),
+        "type": getattr(node, "type", None),
+        "bl_idname": getattr(node, "bl_idname", None),
+        "label": getattr(node, "label", ""),
+        "location": list(getattr(node, "location", []) or []),
+    }
+    if include_sockets:
+        info["inputs"] = [_socket_info(socket) for socket in _socket_items(getattr(node, "inputs", []))]
+        info["outputs"] = [_socket_info(socket) for socket in _socket_items(getattr(node, "outputs", []))]
+    return info
+
+
+def _normalise_value(default_value: Any, value: Any) -> Any:
+    if isinstance(value, tuple):
+        value = list(value)
+    if not isinstance(value, list):
+        return value
+    try:
+        target_len = len(default_value)
+    except TypeError:
+        return value
+    if target_len == 4 and len(value) == 3:
+        return [*value, 1.0]
+    return value
+
+
+def _set_socket_value(socket: Any, value: Any) -> Any:
+    if not hasattr(socket, "default_value"):
+        raise ValueError(f"Socket {_socket_name(socket)} does not expose a default value")
+    socket.default_value = _normalise_value(socket.default_value, value)
+    return _socket_value(socket)
+
+
+def _link_id(link: Any) -> str:
+    from_node = getattr(getattr(link, "from_node", None), "name", "")
+    from_socket = _socket_identifier(getattr(link, "from_socket", ""))
+    to_node = getattr(getattr(link, "to_node", None), "name", "")
+    to_socket = _socket_identifier(getattr(link, "to_socket", ""))
+    return f"{from_node}:{from_socket}->{to_node}:{to_socket}"
+
+
+def _link_info(link: Any) -> dict[str, Any]:
+    return {
+        "id": _link_id(link),
+        "from_node": getattr(getattr(link, "from_node", None), "name", None),
+        "from_socket": _socket_name(getattr(link, "from_socket", "")),
+        "from_socket_identifier": _socket_identifier(getattr(link, "from_socket", "")),
+        "to_node": getattr(getattr(link, "to_node", None), "name", None),
+        "to_socket": _socket_name(getattr(link, "to_socket", "")),
+        "to_socket_identifier": _socket_identifier(getattr(link, "to_socket", "")),
+    }
+
+
+def _ensure_mapping(value: Mapping[str, Any] | None, label: str) -> tuple[dict[str, Any] | None, dict | None]:
+    if value is None:
+        return {}, None
+    if not isinstance(value, Mapping):
+        return None, skill_error(f"Invalid {label}", f"{label} must be an object.")
+    return dict(value), None
+
+
+def _get_material(bpy: Any, material_name: str, *, create: bool = False) -> Any | None:
+    material = _collection_get(bpy.data.materials, material_name)
+    if material is None and create:
+        material = bpy.data.materials.new(material_name)
+    return material
+
+
+def _ensure_material_nodes(material: Any) -> Any:
+    material.use_nodes = True
+    return material.node_tree
+
+
+def _get_geometry_modifier(obj: Any, modifier_name: str | None = None) -> Any | None:
+    for modifier in _iter_collection(getattr(obj, "modifiers", [])):
+        if getattr(modifier, "type", None) != "NODES":
+            continue
+        if modifier_name is None or getattr(modifier, "name", None) == modifier_name:
+            return modifier
+    return None
+
+
+def _new_modifier(obj: Any, name: str = "Geometry Nodes") -> Any:
+    return obj.modifiers.new(name=name, type="NODES")
+
+
+def _resolve_node_tree(bpy: Any, node_tree_ref: Mapping[str, Any]) -> tuple[Any | None, dict[str, Any], dict | None]:
+    if not isinstance(node_tree_ref, Mapping):
+        return None, {}, skill_error("Invalid node_tree_ref", "node_tree_ref must be an object.")
+    kind = str(node_tree_ref.get("kind") or node_tree_ref.get("type") or "").lower()
+    if not kind:
+        return None, {}, skill_error("Invalid node_tree_ref", "node_tree_ref.kind is required.")
+
+    if kind in _SHADER_KINDS:
+        material_name = (
+            node_tree_ref.get("material_name") or node_tree_ref.get("owner_name") or node_tree_ref.get("name")
+        )
+        if not material_name:
+            return None, {}, skill_error("Invalid node_tree_ref", "material_name is required for shader node trees.")
+        material = _get_material(bpy, str(material_name))
+        if material is None:
+            return (
+                None,
+                {},
+                skill_error(f"Material not found: {material_name}", f"No material named '{material_name}'."),
+            )
+        if not getattr(material, "use_nodes", False) or getattr(material, "node_tree", None) is None:
+            return (
+                None,
+                {},
+                skill_error(
+                    f"Material {material_name} does not use nodes",
+                    "Enable material nodes or use create_material_with_nodes first.",
+                ),
+            )
+        return material.node_tree, {"kind": "shader", "material_name": str(material_name)}, None
+
+    if kind in _GEOMETRY_KINDS:
+        group_name = node_tree_ref.get("group_name") or node_tree_ref.get("owner_name") or node_tree_ref.get("name")
+        if not group_name:
+            return None, {}, skill_error("Invalid node_tree_ref", "group_name is required for geometry node groups.")
+        group = _collection_get(bpy.data.node_groups, str(group_name))
+        if group is None:
+            return None, {}, skill_error(f"Node group not found: {group_name}", f"No node group named '{group_name}'.")
+        return group, {"kind": "geometry", "group_name": str(group_name)}, None
+
+    if kind in _MODIFIER_KINDS:
+        object_name = node_tree_ref.get("object_name") or node_tree_ref.get("owner_name")
+        if not object_name:
+            return None, {}, skill_error("Invalid node_tree_ref", "object_name is required for modifier node trees.")
+        obj = _collection_get(bpy.data.objects, str(object_name))
+        if obj is None:
+            return None, {}, skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+        modifier = _get_geometry_modifier(obj, node_tree_ref.get("modifier_name"))
+        if modifier is None:
+            return (
+                None,
+                {},
+                skill_error(
+                    f"Geometry Nodes modifier not found on {object_name}",
+                    "Add or assign a Geometry Nodes modifier first.",
+                ),
+            )
+        group = getattr(modifier, "node_group", None)
+        if group is None:
+            return (
+                None,
+                {},
+                skill_error(
+                    f"Modifier {modifier.name} has no node group",
+                    "Assign a Geometry Nodes node group before editing its graph.",
+                ),
+            )
+        return (
+            group,
+            {
+                "kind": "geometry_modifier",
+                "object_name": str(object_name),
+                "modifier_name": modifier.name,
+                "group_name": getattr(group, "name", None),
+            },
+            None,
+        )
+
+    return None, {}, skill_error("Unsupported node tree kind", f"Unsupported node_tree_ref.kind: {kind}")
+
+
+def _create_node_in_tree(node_tree: Any, node_type: str) -> Any:
+    try:
+        return node_tree.nodes.new(type=node_type)
+    except TypeError:
+        return node_tree.nodes.new(node_type)
+
+
+def _remove_node(node_tree: Any, node: Any) -> None:
+    remover = getattr(node_tree.nodes, "remove", None)
+    if callable(remover):
+        remover(node)
+
+
+def _remove_link(node_tree: Any, link: Any) -> None:
+    remover = getattr(node_tree.links, "remove", None)
+    if callable(remover):
+        remover(link)
+
+
+def _find_principled_node(nodes: Any, node_name: str = "Principled BSDF") -> Any | None:
+    node = _collection_get(nodes, node_name)
+    if node is not None:
+        return node
+    for candidate in _iter_collection(nodes):
+        if (
+            getattr(candidate, "type", None) == "BSDF_PRINCIPLED"
+            or getattr(candidate, "bl_idname", None) == "ShaderNodeBsdfPrincipled"
+        ):
+            return candidate
+    return None
+
+
+def _node_group_type(group: Any) -> str | None:
+    return getattr(group, "bl_idname", None) or getattr(group, "type", None)
+
+
+def _interface_sockets(group: Any) -> list[Any]:
+    interface = getattr(group, "interface", None)
+    items_tree = getattr(interface, "items_tree", None)
+    if items_tree is not None:
+        return [item for item in _iter_collection(items_tree) if hasattr(item, "name")]
+    inputs = _iter_collection(getattr(group, "inputs", []))
+    outputs = _iter_collection(getattr(group, "outputs", []))
+    return inputs + outputs
+
+
+def _modifier_get(modifier: Any, key: str) -> Any:
+    getter = getattr(modifier, "get", None)
+    if callable(getter):
+        return getter(key)
+    try:
+        return modifier[key]
+    except Exception:
+        return None
+
+
+def _modifier_set(modifier: Any, key: str, value: Any) -> None:
+    try:
+        modifier[key] = value
+    except TypeError:
+        setattr(modifier, key, value)
+
+
+def _modifier_input_identifier(group: Any, input_name: str) -> str:
+    for socket in _interface_sockets(group):
+        if getattr(socket, "in_out", "INPUT") not in {"INPUT", None}:
+            continue
+        if getattr(socket, "name", None) == input_name or getattr(socket, "identifier", None) == input_name:
+            return _socket_identifier(socket)
+    return input_name
+
+
+def _add_group_socket(group: Any, name: str, socket_type: str, in_out: str) -> None:
+    for socket in _interface_sockets(group):
+        if getattr(socket, "name", None) == name and getattr(socket, "in_out", in_out) == in_out:
+            return
+    interface = getattr(group, "interface", None)
+    if interface is not None and callable(getattr(interface, "new_socket", None)):
+        try:
+            interface.new_socket(name=name, in_out=in_out, socket_type=socket_type)
+            return
+        except Exception:
+            pass
+    items_tree = getattr(interface, "items_tree", None)
+    if items_tree is not None and callable(getattr(items_tree, "new_socket", None)):
+        try:
+            items_tree.new_socket(name=name, in_out=in_out, socket_type=socket_type)
+            return
+        except Exception:
+            pass
+    collection = getattr(group, "inputs" if in_out == "INPUT" else "outputs", None)
+    if collection is not None and callable(getattr(collection, "new", None)):
+        try:
+            collection.new(socket_type, name)
+        except Exception:
+            pass
+
+
+def _ensure_group_node(group: Any, node_type: str, names: set[str]) -> None:
+    for node in _iter_collection(getattr(group, "nodes", [])):
+        if getattr(node, "bl_idname", None) == node_type or getattr(node, "type", None) == node_type:
+            return
+        if getattr(node, "name", None) in names:
+            return
+    try:
+        group.nodes.new(type=node_type)
+    except Exception:
+        pass
+
+
+def _create_passthrough_geometry_group(group: Any) -> None:
+    _add_group_socket(group, "Geometry", "NodeSocketGeometry", "INPUT")
+    _add_group_socket(group, "Geometry", "NodeSocketGeometry", "OUTPUT")
+    _ensure_group_node(group, "NodeGroupInput", {"Group Input"})
+    _ensure_group_node(group, "NodeGroupOutput", {"Group Output"})
+
+
+def list_node_trees(kind: str, owner_name: str | None = None) -> dict:
+    """List material or geometry node trees."""
+    try:
+        import bpy
+
+        key = kind.lower()
+        trees = []
+        if key in _SHADER_KINDS or key == "all":
+            for material in _iter_collection(bpy.data.materials):
+                if owner_name and material.name != owner_name:
+                    continue
+                if getattr(material, "use_nodes", False) and getattr(material, "node_tree", None) is not None:
+                    trees.append(
+                        {
+                            "kind": "shader",
+                            "owner_name": material.name,
+                            "node_tree_name": getattr(material.node_tree, "name", None),
+                            "node_count": len(_iter_collection(material.node_tree.nodes)),
+                        }
+                    )
+        if key in _GEOMETRY_KINDS or key == "all":
+            for group in _iter_collection(bpy.data.node_groups):
+                if owner_name and group.name != owner_name:
+                    continue
+                if _node_group_type(group) in {"GeometryNodeTree", "GEOMETRY"}:
+                    trees.append(
+                        {
+                            "kind": "geometry",
+                            "owner_name": group.name,
+                            "node_tree_name": group.name,
+                            "node_count": len(_iter_collection(group.nodes)),
+                        }
+                    )
+        return skill_success(
+            f"Found {len(trees)} node tree(s)",
+            kind=kind,
+            owner_name=owner_name,
+            node_trees=trees,
+            count=len(trees),
+            prompt="Use list_nodes with a node_tree_ref to inspect a specific graph.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list node trees")
+
+
+def list_nodes(node_tree_ref: Mapping[str, Any], type_filter: str | None = None) -> dict:
+    """List nodes in a resolved node tree."""
+    try:
+        import bpy
+
+        node_tree, resolved, error = _resolve_node_tree(bpy, node_tree_ref)
+        if error:
+            return error
+        nodes = []
+        for node in _iter_collection(node_tree.nodes):
+            if type_filter and type_filter not in {str(getattr(node, "type", "")), str(getattr(node, "bl_idname", ""))}:
+                continue
+            nodes.append(_node_info(node))
+        return skill_success(
+            f"Found {len(nodes)} node(s)",
+            node_tree_ref=resolved,
+            type_filter=type_filter,
+            nodes=nodes,
+            count=len(nodes),
+            prompt="Use list_node_sockets before connecting or setting node values.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list nodes")
+
+
+def create_node(
+    node_tree_ref: Mapping[str, Any],
+    node_type: str,
+    name: str | None = None,
+    location: Sequence[float] | None = None,
+) -> dict:
+    """Create a node in a material or geometry node tree."""
+    try:
+        import bpy
+
+        node_tree, resolved, error = _resolve_node_tree(bpy, node_tree_ref)
+        if error:
+            return error
+        if name and _collection_get(node_tree.nodes, name) is not None:
+            return skill_error(f"Node already exists: {name}", "Choose a unique node name.")
+        node = _create_node_in_tree(node_tree, node_type)
+        if name:
+            node.name = name
+            node.label = name
+        if location is not None:
+            if isinstance(location, (str, bytes)) or len(location) != 2:
+                return skill_error("Invalid location", "location must be [x, y].")
+            node.location = (float(location[0]), float(location[1]))
+        return skill_success(
+            f"Created node {getattr(node, 'name', node_type)}",
+            node_tree_ref=resolved,
+            node=_node_info(node),
+            prompt="Use connect_nodes or set_node_input to wire the node into the graph.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to create node {node_type}")
+
+
+def delete_node(node_tree_ref: Mapping[str, Any], node_name: str) -> dict:
+    """Delete a node from a node tree."""
+    try:
+        import bpy
+
+        node_tree, resolved, error = _resolve_node_tree(bpy, node_tree_ref)
+        if error:
+            return error
+        node = _collection_get(node_tree.nodes, node_name)
+        if node is None:
+            return skill_error(f"Node not found: {node_name}", f"No node named '{node_name}'.")
+        _remove_node(node_tree, node)
+        return skill_success(
+            f"Deleted node {node_name}",
+            node_tree_ref=resolved,
+            node_name=node_name,
+            prompt="Use list_nodes or list_node_links to inspect the remaining graph.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to delete node {node_name}")
+
+
+def list_node_sockets(node_tree_ref: Mapping[str, Any], node_name: str) -> dict:
+    """List sockets on a node."""
+    try:
+        import bpy
+
+        node_tree, resolved, error = _resolve_node_tree(bpy, node_tree_ref)
+        if error:
+            return error
+        node = _collection_get(node_tree.nodes, node_name)
+        if node is None:
+            return skill_error(f"Node not found: {node_name}", f"No node named '{node_name}'.")
+        return skill_success(
+            f"Listed sockets for {node_name}",
+            node_tree_ref=resolved,
+            node_name=node_name,
+            inputs=[_socket_info(socket) for socket in _socket_items(node.inputs)],
+            outputs=[_socket_info(socket) for socket in _socket_items(node.outputs)],
+            prompt="Use connect_nodes with socket names or identifiers.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to list sockets for {node_name}")
+
+
+def list_node_links(node_tree_ref: Mapping[str, Any]) -> dict:
+    """List node links in a graph."""
+    try:
+        import bpy
+
+        node_tree, resolved, error = _resolve_node_tree(bpy, node_tree_ref)
+        if error:
+            return error
+        links = [_link_info(link) for link in _iter_collection(node_tree.links)]
+        return skill_success(
+            f"Found {len(links)} node link(s)",
+            node_tree_ref=resolved,
+            links=links,
+            count=len(links),
+            prompt="Use disconnect_nodes with a link id or endpoints to remove a link.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list node links")
+
+
+def connect_nodes(
+    node_tree_ref: Mapping[str, Any],
+    from_node: str,
+    from_socket: str,
+    to_node: str,
+    to_socket: str,
+) -> dict:
+    """Connect two node sockets."""
+    try:
+        import bpy
+
+        node_tree, resolved, error = _resolve_node_tree(bpy, node_tree_ref)
+        if error:
+            return error
+        source = _collection_get(node_tree.nodes, from_node)
+        target = _collection_get(node_tree.nodes, to_node)
+        if source is None:
+            return skill_error(f"Node not found: {from_node}", f"No source node named '{from_node}'.")
+        if target is None:
+            return skill_error(f"Node not found: {to_node}", f"No target node named '{to_node}'.")
+        source_socket = _get_socket(source.outputs, from_socket)
+        target_socket = _get_socket(target.inputs, to_socket)
+        if source_socket is None:
+            return skill_error(
+                f"Output socket not found: {from_socket}",
+                f"Available outputs: {', '.join(_socket_names(source.outputs))}",
+            )
+        if target_socket is None:
+            return skill_error(
+                f"Input socket not found: {to_socket}", f"Available inputs: {', '.join(_socket_names(target.inputs))}"
+            )
+        link = node_tree.links.new(source_socket, target_socket)
+        return skill_success(
+            f"Connected {from_node}.{from_socket} to {to_node}.{to_socket}",
+            node_tree_ref=resolved,
+            link=_link_info(link),
+            prompt="Use list_node_links to inspect graph connectivity.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to connect node sockets")
+
+
+def disconnect_nodes(
+    node_tree_ref: Mapping[str, Any],
+    link_id: str | None = None,
+    from_node: str | None = None,
+    from_socket: str | None = None,
+    to_node: str | None = None,
+    to_socket: str | None = None,
+) -> dict:
+    """Disconnect node links by id or endpoint tuple."""
+    try:
+        import bpy
+
+        node_tree, resolved, error = _resolve_node_tree(bpy, node_tree_ref)
+        if error:
+            return error
+        removed = []
+        for link in list(_iter_collection(node_tree.links)):
+            info = _link_info(link)
+            matches_id = link_id and info["id"] == link_id
+            matches_endpoints = all(
+                [
+                    from_node is None or info["from_node"] == from_node,
+                    from_socket is None or from_socket in {info["from_socket"], info["from_socket_identifier"]},
+                    to_node is None or info["to_node"] == to_node,
+                    to_socket is None or to_socket in {info["to_socket"], info["to_socket_identifier"]},
+                ]
+            )
+            if matches_id or (not link_id and matches_endpoints):
+                _remove_link(node_tree, link)
+                removed.append(info)
+        if not removed:
+            return skill_error("No matching node links", "No link matched the provided id or endpoints.")
+        return skill_success(
+            f"Disconnected {len(removed)} node link(s)",
+            node_tree_ref=resolved,
+            removed_links=removed,
+            count=len(removed),
+            prompt="Use list_node_links to verify the graph.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to disconnect node links")
+
+
+def set_node_input(node_tree_ref: Mapping[str, Any], node_name: str, socket: str, value: Any) -> dict:
+    """Set a node input socket value."""
+    try:
+        import bpy
+
+        node_tree, resolved, error = _resolve_node_tree(bpy, node_tree_ref)
+        if error:
+            return error
+        node = _collection_get(node_tree.nodes, node_name)
+        if node is None:
+            return skill_error(f"Node not found: {node_name}", f"No node named '{node_name}'.")
+        target = _get_socket(node.inputs, socket)
+        if target is None:
+            return skill_error(
+                f"Input socket not found: {socket}", f"Available inputs: {', '.join(_socket_names(node.inputs))}"
+            )
+        normalized = _set_socket_value(target, value)
+        return skill_success(
+            f"Set {socket} on {node_name}",
+            node_tree_ref=resolved,
+            node_name=node_name,
+            socket=socket,
+            value=normalized,
+            prompt="Use get_node_value or render/capture tools to validate the result.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to set {socket} on {node_name}")
+
+
+def get_node_value(node_tree_ref: Mapping[str, Any], node_name: str, socket: str | None = None) -> dict:
+    """Get one input socket value or all socket values for a node."""
+    try:
+        import bpy
+
+        node_tree, resolved, error = _resolve_node_tree(bpy, node_tree_ref)
+        if error:
+            return error
+        node = _collection_get(node_tree.nodes, node_name)
+        if node is None:
+            return skill_error(f"Node not found: {node_name}", f"No node named '{node_name}'.")
+        if socket:
+            target = _get_socket(node.inputs, socket) or _get_socket(node.outputs, socket)
+            if target is None:
+                return skill_error(f"Socket not found: {socket}", "The node has no matching input or output socket.")
+            return skill_success(
+                f"Read {socket} on {node_name}",
+                node_tree_ref=resolved,
+                node_name=node_name,
+                socket=_socket_info(target),
+                value=_socket_value(target),
+                prompt="Use set_node_input for mutable input sockets.",
+            )
+        return skill_success(
+            f"Read node values for {node_name}",
+            node_tree_ref=resolved,
+            node_name=node_name,
+            inputs=[_socket_info(item) for item in _socket_items(node.inputs)],
+            outputs=[_socket_info(item) for item in _socket_items(node.outputs)],
+            prompt="Use list_node_sockets to inspect socket identifiers.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to read node values for {node_name}")
+
+
+def create_material_with_nodes(material_name: str, template: str = "principled") -> dict:
+    """Create or initialize a node-based material."""
+    try:
+        import bpy
+
+        material = _get_material(bpy, material_name, create=True)
+        if material is None:
+            return skill_error(f"Material not found: {material_name}", "Material could not be created.")
+        node_tree = _ensure_material_nodes(material)
+        if template == "emission":
+            output = _collection_get(node_tree.nodes, "Material Output")
+            emission = _collection_get(node_tree.nodes, "Emission") or _create_node_in_tree(
+                node_tree, "ShaderNodeEmission"
+            )
+            emission.name = "Emission"
+            if output is not None:
+                out_socket = _get_socket(emission.outputs, "Emission")
+                surface = _get_socket(output.inputs, "Surface")
+                if out_socket is not None and surface is not None:
+                    node_tree.links.new(out_socket, surface)
+        elif template not in {"principled", "default", ""}:
+            return skill_error("Unsupported material template", f"Unsupported template: {template}")
+        return skill_success(
+            f"Created material node graph for {material_name}",
+            material_name=material.name,
+            template=template,
+            node_count=len(_iter_collection(node_tree.nodes)),
+            prompt="Use create_node, connect_nodes, or set_principled_inputs for graph edits.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to create material {material_name}")
+
+
+def assign_texture_node(material_name: str, image_path: str, target_socket: str = "Base Color") -> dict:
+    """Create an image texture node and connect it to a Principled input."""
+    path = Path(image_path).expanduser()
+    if not path.is_file():
+        return skill_error(f"Image not found: {path}", f"No image exists at '{path}'.")
+    try:
+        import bpy
+
+        material = _get_material(bpy, material_name)
+        if material is None:
+            return skill_error(f"Material not found: {material_name}", f"No material named '{material_name}'.")
+        node_tree = _ensure_material_nodes(material)
+        image = bpy.data.images.load(str(path), check_existing=True)
+        node = _create_node_in_tree(node_tree, "ShaderNodeTexImage")
+        node.name = f"{path.stem} Texture"
+        node.image = image
+        principled = _find_principled_node(node_tree.nodes)
+        if principled is None:
+            return skill_error(
+                f"No Principled BSDF node in {material_name}", "Create or restore a Principled node first."
+            )
+        color = _get_socket(node.outputs, "Color")
+        target = _get_socket(principled.inputs, target_socket)
+        if color is None or target is None:
+            return skill_error(
+                "Texture connection sockets not found",
+                f"Could not connect Color to {target_socket}.",
+            )
+        link = node_tree.links.new(color, target)
+        return skill_success(
+            f"Assigned texture to {material_name}",
+            material_name=material_name,
+            image_path=str(path),
+            image_name=getattr(image, "name", None),
+            node=_node_info(node),
+            link=_link_info(link),
+            target_socket=target_socket,
+            prompt="Use list_node_links or render/capture tools to validate the material.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to assign texture to {material_name}")
+
+
+def set_principled_inputs(material_name: str, inputs: Mapping[str, Any], node_name: str = "Principled BSDF") -> dict:
+    """Set multiple Principled BSDF inputs."""
+    opts, error = _ensure_mapping(inputs, "inputs")
+    if error:
+        return error
+    try:
+        import bpy
+
+        material = _get_material(bpy, material_name)
+        if material is None:
+            return skill_error(f"Material not found: {material_name}", f"No material named '{material_name}'.")
+        if not getattr(material, "use_nodes", False) or getattr(material, "node_tree", None) is None:
+            return skill_error(f"Material {material_name} does not use nodes", "Enable material nodes first.")
+        node = _find_principled_node(material.node_tree.nodes, node_name)
+        if node is None:
+            return skill_error(
+                f"No Principled BSDF node in {material_name}", "This tool edits Principled BSDF nodes only."
+            )
+        changed = {}
+        missing = []
+        for input_name, value in opts.items():
+            socket = _get_socket(node.inputs, input_name)
+            if socket is None:
+                missing.append(input_name)
+                continue
+            changed[input_name] = _set_socket_value(socket, value)
+        if missing:
+            return skill_error(
+                "Input not found on Principled BSDF",
+                f"Missing inputs: {', '.join(missing)}. Available inputs: {', '.join(_socket_names(node.inputs))}",
+            )
+        return skill_success(
+            f"Set {len(changed)} Principled input(s) on {material_name}",
+            material_name=material_name,
+            node_name=getattr(node, "name", node_name),
+            values=changed,
+            prompt="Use get_node_value or render/capture tools to validate the material.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to set Principled inputs on {material_name}")
+
+
+def create_geometry_node_group(name: str, template: str = "empty") -> dict:
+    """Create or return a Geometry Nodes node group."""
+    try:
+        import bpy
+
+        group = _collection_get(bpy.data.node_groups, name)
+        created = False
+        if group is None:
+            group = bpy.data.node_groups.new(name, "GeometryNodeTree")
+            created = True
+        if template == "pass_through":
+            _create_passthrough_geometry_group(group)
+        elif template not in {"empty", "default", ""}:
+            return skill_error("Unsupported geometry node template", f"Unsupported template: {template}")
+        return skill_success(
+            f"{'Created' if created else 'Loaded'} Geometry Nodes group {name}",
+            group_name=getattr(group, "name", name),
+            template=template,
+            created=created,
+            node_count=len(_iter_collection(group.nodes)),
+            prompt="Use assign_geometry_node_group to attach this group to an object.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to create Geometry Nodes group {name}")
+
+
+def assign_geometry_node_group(object_name: str, group_name: str, modifier_name: str = "Geometry Nodes") -> dict:
+    """Assign a Geometry Nodes group to an object's modifier."""
+    try:
+        import bpy
+
+        obj = _collection_get(bpy.data.objects, object_name)
+        if obj is None:
+            return skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+        if getattr(obj, "type", None) != "MESH":
+            return skill_error(f"{object_name} is not a mesh", "Geometry Nodes modifiers require a mesh object.")
+        group = _collection_get(bpy.data.node_groups, group_name)
+        if group is None:
+            return skill_error(f"Node group not found: {group_name}", f"No node group named '{group_name}'.")
+        modifier = _get_geometry_modifier(obj, modifier_name) or _new_modifier(obj, modifier_name)
+        modifier.node_group = group
+        return skill_success(
+            f"Assigned Geometry Nodes group {group_name} to {object_name}",
+            object_name=object_name,
+            modifier_name=modifier.name,
+            group_name=getattr(group, "name", group_name),
+            prompt="Use set_geometry_node_modifier_input or evaluate_geometry_nodes_info next.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to assign Geometry Nodes group {group_name}")
+
+
+def set_geometry_node_modifier_input(object_name: str, modifier_name: str, input_name: str, value: Any) -> dict:
+    """Set an exposed Geometry Nodes modifier input."""
+    try:
+        import bpy
+
+        obj = _collection_get(bpy.data.objects, object_name)
+        if obj is None:
+            return skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+        modifier = _get_geometry_modifier(obj, modifier_name)
+        if modifier is None:
+            return skill_error(
+                f"Modifier not found: {modifier_name}", f"No Geometry Nodes modifier named '{modifier_name}'."
+            )
+        group = getattr(modifier, "node_group", None)
+        if group is None:
+            return skill_error(f"Modifier {modifier_name} has no node group", "Assign a node group first.")
+        identifier = _modifier_input_identifier(group, input_name)
+        _modifier_set(modifier, identifier, value)
+        try:
+            obj.update_tag()
+        except Exception:
+            pass
+        return skill_success(
+            f"Set Geometry Nodes modifier input {input_name}",
+            object_name=object_name,
+            modifier_name=modifier.name,
+            input_name=input_name,
+            identifier=identifier,
+            value=_modifier_get(modifier, identifier),
+            prompt="Use evaluate_geometry_nodes_info to inspect exposed inputs.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to set Geometry Nodes modifier input {input_name}")
+
+
+def evaluate_geometry_nodes_info(object_name: str, modifier_name: str) -> dict:
+    """Return structured information for a Geometry Nodes modifier and group."""
+    try:
+        import bpy
+
+        obj = _collection_get(bpy.data.objects, object_name)
+        if obj is None:
+            return skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+        modifier = _get_geometry_modifier(obj, modifier_name)
+        if modifier is None:
+            return skill_error(
+                f"Modifier not found: {modifier_name}", f"No Geometry Nodes modifier named '{modifier_name}'."
+            )
+        group = getattr(modifier, "node_group", None)
+        if group is None:
+            return skill_error(f"Modifier {modifier_name} has no node group", "Assign a node group first.")
+        inputs = []
+        for socket in _interface_sockets(group):
+            identifier = _socket_identifier(socket)
+            inputs.append(
+                {
+                    "name": _socket_name(socket),
+                    "identifier": identifier,
+                    "value": _modifier_get(modifier, identifier),
+                    "in_out": getattr(socket, "in_out", None),
+                    "type": getattr(socket, "socket_type", None) or getattr(socket, "type", None),
+                }
+            )
+        return skill_success(
+            f"Evaluated Geometry Nodes info for {object_name}",
+            object_name=object_name,
+            modifier_name=modifier.name,
+            group_name=getattr(group, "name", None),
+            node_count=len(_iter_collection(group.nodes)),
+            link_count=len(_iter_collection(group.links)),
+            inputs=inputs,
+            prompt="Use list_nodes or set_geometry_node_modifier_input for further edits.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to evaluate Geometry Nodes info for {object_name}")

--- a/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
@@ -17,8 +17,8 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | `blender-export-preset` | interchange, pipeline | Save, list, load, and delete reusable scene-stored export option presets. | Load when export settings need repeatable named presets. | Mutating except preset listing/loading. | export preset, batch export, reusable export options |
 | `blender-shot-export` | interchange, shot | Inspect shot metadata and export camera metadata JSON. | Load for camera, shot, and animation delivery metadata. | Disk-writing except shot info. | shot export, camera metadata, frame range, camera json |
 | `blender-materials` | authoring, lookdev | Create, assign, edit, list, and delete materials. | Load before shader nodes when material slots or colors are enough. | Mutating except material listing. | material, assign, color, shader base, delete material |
-| `blender-shader-nodes` | authoring, node graph, lookdev | Inspect material nodes and edit Principled BSDF inputs. | Load after materials when node-level shader edits are requested. | Mixed: read-only node listing plus shader mutations. | shader nodes, principled, metallic, roughness, sockets |
-| `blender-geometry-nodes` | authoring, node graph, procedural | Add and list Geometry Nodes modifiers and node groups. | Load for procedural geometry setup or node modifier inspection. | Mixed: modifier creation plus read-only listing. | geometry nodes, procedural, node group, modifier input |
+| `blender-shader-nodes` | authoring, node graph, lookdev | Inspect and edit shader/material node graphs plus shared node tree sockets, links, and values. | Load after materials when node-level shader edits or generic node graph operations are requested. | Mixed: read-only graph inspection plus node/link/socket mutations. | shader nodes, node graph, sockets, links, principled, texture node |
+| `blender-geometry-nodes` | authoring, node graph, procedural | Create Geometry Nodes groups, assign them to modifiers, set exposed inputs, and inspect procedural graph state. | Load for procedural geometry setup, modifier input updates, or geometry node group assignment. | Mixed: modifier/group creation plus read-only graph summaries. | geometry nodes, procedural, node group, modifier input, exposed socket |
 | `blender-physics` | simulation, authoring | Add, edit, and remove rigid-body physics settings. | Load for rigid-body setup after objects or mesh creation. | Mutating. | rigid body, collision, mass, friction, physics |
 | `blender-rigging` | authoring, animation | Create armatures and bones, add constraints, bind meshes, create shape keys, set drivers, and retarget compatible rigs. | Load for character setup, deformation rigs, constraints, drivers, shape keys, or retargeting. | Mutating. | rigging, armature, bones, constraints, drivers, shape keys, retargeting |
 | `blender-pose-library` | authoring, animation | List, save, load, and mirror reusable armature poses stored on armature objects. | Load after rigging when pose capture or animation handoff needs reusable poses. | Mutating except pose listing. | pose library, save pose, load pose, mirror pose, armature pose |
@@ -39,7 +39,8 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | Character rig setup | `blender-objects` -> `blender-rigging` -> `blender-pose-library` -> `blender-animation` |
 | Animation handoff | `blender-rigging` -> `blender-pose-library` -> `blender-animation` |
 | Material setup | `blender-materials` -> `blender-shader-nodes` -> `blender-render` |
-| Procedural node setup | `blender-objects` -> `blender-geometry-nodes` -> `blender-render` |
+| Shader node graph edit | `blender-materials` -> `blender-shader-nodes` (`list_node_sockets` before `connect_nodes`/`set_node_input`) |
+| Procedural node setup | `blender-objects` -> `blender-geometry-nodes` -> `blender-shader-nodes` for low-level graph edits -> `blender-render` |
 | Physics setup | `blender-objects` -> `blender-mesh` -> `blender-physics` |
 | Shot and render delivery | `blender-camera` -> `blender-lighting` -> `blender-render` |
 | File interchange | `blender-scene` -> `blender-interchange` -> `blender-export-preset` when settings repeat |
@@ -51,6 +52,7 @@ This index helps agents choose typed Blender skills before falling back to raw P
 - Prefer typed skills for repeatable operations, structured errors, and MCP annotations.
 - Use `blender-scene` for initial session and scene discovery.
 - Load authoring skills only when the requested task enters that domain; prefer `blender-mesh-ops` for topology, `blender-mesh` for modifiers, and `blender-rigging`/`blender-pose-library` for character setup.
+- Use `blender-shader-nodes` for graph-level socket/link edits; use `blender-materials` when material slots or simple colors are enough, and `blender-geometry-nodes` when the workflow is about modifier assignment or exposed procedural inputs.
 - Use `blender-interchange` and `blender-shot-export` for import/export and delivery before writing custom Python exporters.
 - Keep `blender-scripting` as the final escape hatch; mention which typed skills were checked first.
 - Treat disk-writing, render, and scripting tools as higher-risk operations and ask for explicit paths or intent when needed.

--- a/src/dcc_mcp_blender/skills/blender-geometry-nodes/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-geometry-nodes/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: blender-geometry-nodes
-description: "Blender geometry nodes modifier tools for procedural object workflows"
+description: "Blender Geometry Nodes group, modifier, and exposed input tools"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
 metadata:
   dcc-mcp:
     dcc: blender
     version: "1.0.0"
-    tags: [blender, geometry-nodes, procedural, modifiers]
-    search-hint: "geometry nodes modifier, procedural nodes, node group, list geometry nodes"
+    tags: [blender, geometry-nodes, node-graph, sockets, links, procedural, modifiers]
+    search-hint: "geometry nodes modifier, procedural nodes, node group, modifier input, assign geometry node group"
     tools: tools.yaml
 ---
 
 # blender-geometry-nodes
 
-Tools for adding and inspecting Geometry Nodes modifiers on scene objects.
+Typed tools for creating Geometry Nodes groups, assigning them to mesh
+modifiers, setting exposed modifier inputs, and inspecting procedural graph
+state. Use `blender-shader-nodes` for low-level shared node graph operations
+such as `list_nodes`, `connect_nodes`, and `set_node_input`.

--- a/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/add_geometry_nodes_modifier.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/add_geometry_nodes_modifier.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Optional
 
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import assign_geometry_node_group, create_geometry_node_group
 
 
 def add_geometry_nodes_modifier(
@@ -14,40 +16,12 @@ def add_geometry_nodes_modifier(
     create_node_group: bool = True,
 ) -> dict:
     """Add a Geometry Nodes modifier and optionally attach a node group."""
-    try:
-        import bpy
-
-        obj = bpy.data.objects.get(object_name)
-        if obj is None:
-            return skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
-        if obj.type != "MESH":
-            return skill_error(
-                f"{object_name} is not a mesh",
-                f"Geometry Nodes modifiers are currently supported for MESH objects, got {obj.type}.",
-            )
-
-        bpy.context.view_layer.objects.active = obj
-        modifier = obj.modifiers.new(name=name, type="NODES")
-
-        node_group = None
-        if create_node_group or group_name:
-            wanted_group_name = group_name or f"{object_name} Geometry Nodes"
-            node_group = bpy.data.node_groups.get(wanted_group_name)
-            if node_group is None:
-                node_group = bpy.data.node_groups.new(wanted_group_name, "GeometryNodeTree")
-            modifier.node_group = node_group
-
-        return skill_success(
-            f"Added Geometry Nodes modifier to {object_name}",
-            object_name=object_name,
-            modifier_name=modifier.name,
-            node_group=getattr(node_group, "name", None),
-            prompt="Use list_geometry_nodes_modifiers to inspect procedural modifiers on this object.",
-        )
-    except ImportError:
-        return skill_error("Blender not available", "bpy could not be imported")
-    except Exception as exc:
-        return skill_exception(exc, message=f"Failed to add Geometry Nodes modifier to {object_name}")
+    wanted_group_name = group_name or f"{object_name} Geometry Nodes"
+    if create_node_group or group_name:
+        created = create_geometry_node_group(wanted_group_name)
+        if not created.get("success"):
+            return created
+    return assign_geometry_node_group(object_name=object_name, group_name=wanted_group_name, modifier_name=name)
 
 
 @skill_entry

--- a/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/assign_geometry_node_group.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/assign_geometry_node_group.py
@@ -1,0 +1,19 @@
+"""Assign a Geometry Nodes group to an object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import assign_geometry_node_group
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`assign_geometry_node_group`."""
+    return assign_geometry_node_group(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/create_geometry_node_group.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/create_geometry_node_group.py
@@ -1,0 +1,19 @@
+"""Create a Blender Geometry Nodes group."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import create_geometry_node_group
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_geometry_node_group`."""
+    return create_geometry_node_group(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/evaluate_geometry_nodes_info.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/evaluate_geometry_nodes_info.py
@@ -1,0 +1,19 @@
+"""Evaluate a Geometry Nodes modifier graph summary."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import evaluate_geometry_nodes_info
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`evaluate_geometry_nodes_info`."""
+    return evaluate_geometry_nodes_info(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/list_geometry_nodes_modifiers.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/list_geometry_nodes_modifiers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+from dcc_mcp_blender._node_graph_ops import evaluate_geometry_nodes_info
+
 
 def list_geometry_nodes_modifiers(object_name: str) -> dict:
     """Return Geometry Nodes modifiers attached to an object."""
@@ -18,14 +20,19 @@ def list_geometry_nodes_modifiers(object_name: str) -> dict:
         for modifier in obj.modifiers:
             if modifier.type != "NODES":
                 continue
-            node_group = getattr(modifier, "node_group", None)
+            info = evaluate_geometry_nodes_info(object_name=object_name, modifier_name=modifier.name)
+            context = info.get("context", {}) if info.get("success") else {}
             modifiers.append(
                 {
                     "name": modifier.name,
                     "type": modifier.type,
-                    "node_group": getattr(node_group, "name", None),
+                    "node_group": context.get("group_name")
+                    or getattr(getattr(modifier, "node_group", None), "name", None),
                     "show_viewport": modifier.show_viewport,
                     "show_render": modifier.show_render,
+                    "node_count": context.get("node_count"),
+                    "link_count": context.get("link_count"),
+                    "inputs": context.get("inputs", []),
                 }
             )
 

--- a/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/set_geometry_node_modifier_input.py
+++ b/src/dcc_mcp_blender/skills/blender-geometry-nodes/scripts/set_geometry_node_modifier_input.py
@@ -1,0 +1,19 @@
+"""Set an exposed Geometry Nodes modifier input."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import set_geometry_node_modifier_input
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_geometry_node_modifier_input`."""
+    return set_geometry_node_modifier_input(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-geometry-nodes/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-geometry-nodes/tools.yaml
@@ -1,17 +1,172 @@
 tools:
   - name: add_geometry_nodes_modifier
-    description: "Add a Geometry Nodes modifier to a mesh object"
+    description: "Add a Geometry Nodes modifier to a mesh object."
     source_file: scripts/add_geometry_nodes_modifier.py
     execution: sync
     affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+        name:
+          type: string
+          default: "Geometry Nodes"
+        group_name:
+          type: string
+          minLength: 1
+        create_node_group:
+          type: boolean
+          default: true
+    output_schema: &geometry_nodes_result_schema
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
     read_only: false
     destructive: false
     idempotent: false
+    annotations: &mutating_annotations
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
   - name: list_geometry_nodes_modifiers
-    description: "List Geometry Nodes modifiers on an object"
+    description: "List Geometry Nodes modifiers on an object."
     source_file: scripts/list_geometry_nodes_modifiers.py
     execution: sync
     affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+    output_schema: *geometry_nodes_result_schema
     read_only: true
     destructive: false
     idempotent: true
+    annotations: &read_only_annotations
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: create_geometry_node_group
+    description: "Create or return a Geometry Nodes node group."
+    source_file: scripts/create_geometry_node_group.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+        template:
+          type: string
+          enum: [empty, default, pass_through]
+          default: empty
+    output_schema: *geometry_nodes_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations: &mutating_idempotent_annotations
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: assign_geometry_node_group
+    description: "Assign a Geometry Nodes group to a mesh object's modifier."
+    source_file: scripts/assign_geometry_node_group.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name, group_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+        group_name:
+          type: string
+          minLength: 1
+        modifier_name:
+          type: string
+          default: "Geometry Nodes"
+    output_schema: *geometry_nodes_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations: *mutating_idempotent_annotations
+
+  - name: set_geometry_node_modifier_input
+    description: "Set an exposed Geometry Nodes modifier input."
+    source_file: scripts/set_geometry_node_modifier_input.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name, modifier_name, input_name, value]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+        modifier_name:
+          type: string
+          minLength: 1
+        input_name:
+          type: string
+          minLength: 1
+        value:
+          description: JSON value to assign to the exposed modifier input.
+    output_schema: *geometry_nodes_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations: *mutating_idempotent_annotations
+
+  - name: evaluate_geometry_nodes_info
+    description: "Return node, link, and exposed input info for a Geometry Nodes modifier."
+    source_file: scripts/evaluate_geometry_nodes_info.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name, modifier_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+        modifier_name:
+          type: string
+          minLength: 1
+    output_schema: *geometry_nodes_result_schema
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations: *read_only_annotations

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: blender-shader-nodes
-description: "Blender shader node inspection and Principled BSDF editing tools"
+description: "Blender shader and shared node graph editing tools"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
 metadata:
   dcc-mcp:
     dcc: blender
     version: "1.0.0"
-    tags: [blender, shader, nodes, materials]
-    search-hint: "shader nodes, material nodes, principled bsdf, metallic roughness base color"
+    tags: [blender, shader-nodes, geometry-nodes, node-graph, sockets, links, materials, procedural]
+    search-hint: "shader nodes, material nodes, node graph, sockets, links, principled bsdf, texture node, geometry node tree"
     tools: tools.yaml
 ---
 
 # blender-shader-nodes
 
-Focused tools for inspecting material node graphs and editing common Principled BSDF inputs.
+Typed tools for inspecting and editing Blender node graphs. Use the material
+helpers for common shader workflows, and the shared `node_tree_ref` tools for
+node creation, sockets, links, and socket values before falling back to custom
+Python.

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/assign_texture_node.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/assign_texture_node.py
@@ -1,0 +1,19 @@
+"""Assign an image texture node to a material graph."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import assign_texture_node
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`assign_texture_node`."""
+    return assign_texture_node(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/connect_nodes.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/connect_nodes.py
@@ -1,0 +1,19 @@
+"""Connect two Blender node sockets."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import connect_nodes
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`connect_nodes`."""
+    return connect_nodes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/create_material_with_nodes.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/create_material_with_nodes.py
@@ -1,0 +1,19 @@
+"""Create a node-based Blender material."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import create_material_with_nodes
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_material_with_nodes`."""
+    return create_material_with_nodes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/create_node.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/create_node.py
@@ -1,0 +1,19 @@
+"""Create a node in a Blender node tree."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import create_node
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_node`."""
+    return create_node(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/delete_node.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/delete_node.py
@@ -1,0 +1,19 @@
+"""Delete a node from a Blender node tree."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import delete_node
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`delete_node`."""
+    return delete_node(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/disconnect_nodes.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/disconnect_nodes.py
@@ -1,0 +1,19 @@
+"""Disconnect Blender node links."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import disconnect_nodes
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`disconnect_nodes`."""
+    return disconnect_nodes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/get_node_value.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/get_node_value.py
@@ -1,0 +1,19 @@
+"""Read Blender node socket values."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import get_node_value
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_node_value`."""
+    return get_node_value(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/list_material_nodes.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/list_material_nodes.py
@@ -2,59 +2,21 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable, List
+from dcc_mcp_core.skill import skill_entry
 
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
-
-
-def _socket_names(sockets: Any) -> List[str]:
-    if hasattr(sockets, "keys"):
-        try:
-            return [str(name) for name in sockets.keys()]
-        except Exception:
-            pass
-
-    try:
-        items: Iterable[Any] = sockets
-    except TypeError:
-        return []
-    return [str(getattr(socket, "name", socket)) for socket in items]
+from dcc_mcp_blender._node_graph_ops import list_nodes
 
 
 def list_material_nodes(material_name: str, include_sockets: bool = True) -> dict:
     """List nodes in a material's shader graph."""
-    try:
-        import bpy
-
-        mat = bpy.data.materials.get(material_name)
-        if mat is None:
-            return skill_error(f"Material not found: {material_name}", f"No material named '{material_name}'.")
-        if not mat.use_nodes or mat.node_tree is None:
-            return skill_error(f"Material {material_name} does not use nodes", "Enable material nodes first.")
-
-        nodes = []
-        for node in mat.node_tree.nodes:
-            info = {
-                "name": node.name,
-                "type": node.type,
-                "label": getattr(node, "label", ""),
-            }
-            if include_sockets:
-                info["inputs"] = _socket_names(node.inputs)
-                info["outputs"] = _socket_names(node.outputs)
-            nodes.append(info)
-
-        return skill_success(
-            f"Found {len(nodes)} shader nodes on {material_name}",
-            material_name=material_name,
-            nodes=nodes,
-            count=len(nodes),
-            prompt="Use set_principled_input to tune common Principled BSDF inputs.",
-        )
-    except ImportError:
-        return skill_error("Blender not available", "bpy could not be imported")
-    except Exception as exc:
-        return skill_exception(exc, message=f"Failed to list shader nodes for {material_name}")
+    result = list_nodes({"kind": "shader", "material_name": material_name})
+    if result.get("success"):
+        result["context"]["material_name"] = material_name
+        if not include_sockets:
+            for node in result["context"].get("nodes", []):
+                node.pop("inputs", None)
+                node.pop("outputs", None)
+    return result
 
 
 @skill_entry

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/list_node_links.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/list_node_links.py
@@ -1,0 +1,19 @@
+"""List Blender node links."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import list_node_links
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_node_links`."""
+    return list_node_links(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/list_node_sockets.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/list_node_sockets.py
@@ -1,0 +1,19 @@
+"""List sockets on a Blender node."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import list_node_sockets
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_node_sockets`."""
+    return list_node_sockets(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/list_node_trees.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/list_node_trees.py
@@ -1,0 +1,19 @@
+"""List available Blender node trees."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import list_node_trees
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_node_trees`."""
+    return list_node_trees(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/list_nodes.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/list_nodes.py
@@ -1,0 +1,19 @@
+"""List nodes in a Blender node tree."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import list_nodes
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_nodes`."""
+    return list_nodes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/set_node_input.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/set_node_input.py
@@ -1,0 +1,19 @@
+"""Set a Blender node input socket value."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import set_node_input
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_node_input`."""
+    return set_node_input(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/set_principled_input.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/set_principled_input.py
@@ -2,36 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry
 
-
-def _find_principled_node(nodes: Any, node_name: str):
-    node = nodes.get(node_name) if hasattr(nodes, "get") else None
-    if node is not None:
-        return node
-
-    for candidate in nodes:
-        if getattr(candidate, "type", "") == "BSDF_PRINCIPLED":
-            return candidate
-    return None
-
-
-def _normalise_value(default_value: Any, value: Any) -> Any:
-    if isinstance(value, tuple):
-        value = list(value)
-    if not isinstance(value, list):
-        return value
-
-    try:
-        target_len = len(default_value)
-    except TypeError:
-        return value
-
-    if target_len == 4 and len(value) == 3:
-        return value + [1.0]
-    return value
+from dcc_mcp_blender._node_graph_ops import set_principled_inputs
 
 
 def set_principled_input(
@@ -41,42 +16,11 @@ def set_principled_input(
     node_name: str = "Principled BSDF",
 ) -> dict:
     """Set a Principled BSDF input value."""
-    try:
-        import bpy
-
-        mat = bpy.data.materials.get(material_name)
-        if mat is None:
-            return skill_error(f"Material not found: {material_name}", f"No material named '{material_name}'.")
-        if not mat.use_nodes or mat.node_tree is None:
-            return skill_error(f"Material {material_name} does not use nodes", "Enable material nodes first.")
-
-        node = _find_principled_node(mat.node_tree.nodes, node_name)
-        if node is None:
-            return skill_error(
-                f"No Principled BSDF node in {material_name}",
-                "This tool edits the material's Principled BSDF shader.",
-            )
-
-        socket: Optional[Any] = node.inputs.get(input_name) if hasattr(node.inputs, "get") else None
-        if socket is None:
-            return skill_error(
-                f"Input not found on Principled BSDF: {input_name}",
-                f"Available inputs: {', '.join(str(name) for name in node.inputs.keys())}",
-            )
-
-        socket.default_value = _normalise_value(socket.default_value, value)
-        return skill_success(
-            f"Set {input_name} on {material_name}",
-            material_name=material_name,
-            node_name=getattr(node, "name", node_name),
-            input_name=input_name,
-            value=socket.default_value,
-            prompt="Use render_scene or capture_viewport to inspect the material result.",
-        )
-    except ImportError:
-        return skill_error("Blender not available", "bpy could not be imported")
-    except Exception as exc:
-        return skill_exception(exc, message=f"Failed to set {input_name} on {material_name}")
+    result = set_principled_inputs(material_name=material_name, inputs={input_name: value}, node_name=node_name)
+    if result.get("success"):
+        result["context"]["input_name"] = input_name
+        result["context"]["value"] = result["context"].get("values", {}).get(input_name)
+    return result
 
 
 @skill_entry

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/set_principled_inputs.py
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/scripts/set_principled_inputs.py
@@ -1,0 +1,19 @@
+"""Set multiple Principled BSDF inputs on a material."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._node_graph_ops import set_principled_inputs
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_principled_inputs`."""
+    return set_principled_inputs(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/tools.yaml
@@ -1,17 +1,421 @@
 tools:
   - name: list_material_nodes
-    description: "List shader nodes and sockets for a material"
+    description: "List shader nodes and sockets for a material."
     source_file: scripts/list_material_nodes.py
     execution: sync
     affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [material_name]
+      properties:
+        material_name:
+          type: string
+          minLength: 1
+        include_sockets:
+          type: boolean
+          default: true
+    output_schema: &node_result_schema
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
     read_only: true
     destructive: false
     idempotent: true
+    annotations: &read_only_annotations
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
   - name: set_principled_input
-    description: "Set a value on a material's Principled BSDF shader"
+    description: "Set a value on a material's Principled BSDF shader."
     source_file: scripts/set_principled_input.py
     execution: sync
     affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [material_name, input_name, value]
+      properties:
+        material_name:
+          type: string
+          minLength: 1
+        input_name:
+          type: string
+          minLength: 1
+        value:
+          description: JSON value to assign to the socket.
+        node_name:
+          type: string
+          default: "Principled BSDF"
+    output_schema: *node_result_schema
     read_only: false
     destructive: false
     idempotent: true
+    annotations: &mutating_idempotent_annotations
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: list_node_trees
+    description: "List material and Geometry Nodes node trees."
+    source_file: scripts/list_node_trees.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [kind]
+      properties:
+        kind:
+          type: string
+          enum: [all, shader, material, geometry, geometry_nodes, node_group]
+        owner_name:
+          type: string
+          minLength: 1
+    output_schema: *node_result_schema
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations: *read_only_annotations
+
+  - name: list_nodes
+    description: "List nodes in a material, node group, or Geometry Nodes modifier tree."
+    source_file: scripts/list_nodes.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema: &node_tree_schema
+      type: object
+      additionalProperties: false
+      required: [node_tree_ref]
+      properties:
+        node_tree_ref:
+          type: object
+          additionalProperties: true
+          description: "Reference such as {kind: shader, material_name: Mat} or {kind: geometry, group_name: Group}."
+        type_filter:
+          type: string
+          minLength: 1
+    output_schema: *node_result_schema
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations: *read_only_annotations
+
+  - name: create_node
+    description: "Create a node in a material or Geometry Nodes graph."
+    source_file: scripts/create_node.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [node_tree_ref, node_type]
+      properties:
+        node_tree_ref:
+          type: object
+          additionalProperties: true
+        node_type:
+          type: string
+          minLength: 1
+          description: Blender node type id, for example ShaderNodeTexImage.
+        name:
+          type: string
+          minLength: 1
+        location:
+          type: array
+          minItems: 2
+          maxItems: 2
+          items:
+            type: number
+    output_schema: *node_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations: &mutating_annotations
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: delete_node
+    description: "Delete a node from a material or Geometry Nodes graph."
+    source_file: scripts/delete_node.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [node_tree_ref, node_name]
+      properties:
+        node_tree_ref:
+          type: object
+          additionalProperties: true
+        node_name:
+          type: string
+          minLength: 1
+    output_schema: *node_result_schema
+    read_only: false
+    destructive: true
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: list_node_sockets
+    description: "List input and output sockets for a node."
+    source_file: scripts/list_node_sockets.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [node_tree_ref, node_name]
+      properties:
+        node_tree_ref:
+          type: object
+          additionalProperties: true
+        node_name:
+          type: string
+          minLength: 1
+    output_schema: *node_result_schema
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations: *read_only_annotations
+
+  - name: connect_nodes
+    description: "Connect an output socket to an input socket."
+    source_file: scripts/connect_nodes.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [node_tree_ref, from_node, from_socket, to_node, to_socket]
+      properties:
+        node_tree_ref:
+          type: object
+          additionalProperties: true
+        from_node:
+          type: string
+          minLength: 1
+        from_socket:
+          type: string
+          minLength: 1
+        to_node:
+          type: string
+          minLength: 1
+        to_socket:
+          type: string
+          minLength: 1
+    output_schema: *node_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations: *mutating_annotations
+
+  - name: disconnect_nodes
+    description: "Disconnect node links by id or endpoint fields."
+    source_file: scripts/disconnect_nodes.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [node_tree_ref]
+      properties:
+        node_tree_ref:
+          type: object
+          additionalProperties: true
+        link_id:
+          type: string
+          minLength: 1
+        from_node:
+          type: string
+          minLength: 1
+        from_socket:
+          type: string
+          minLength: 1
+        to_node:
+          type: string
+          minLength: 1
+        to_socket:
+          type: string
+          minLength: 1
+    output_schema: *node_result_schema
+    read_only: false
+    destructive: true
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: list_node_links
+    description: "List links in a material or Geometry Nodes graph."
+    source_file: scripts/list_node_links.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema: *node_tree_schema
+    output_schema: *node_result_schema
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations: *read_only_annotations
+
+  - name: set_node_input
+    description: "Set an input socket value on a node."
+    source_file: scripts/set_node_input.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [node_tree_ref, node_name, socket, value]
+      properties:
+        node_tree_ref:
+          type: object
+          additionalProperties: true
+        node_name:
+          type: string
+          minLength: 1
+        socket:
+          type: string
+          minLength: 1
+        value:
+          description: JSON value to assign to the socket.
+    output_schema: *node_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations: *mutating_idempotent_annotations
+
+  - name: get_node_value
+    description: "Read one socket value or all socket values for a node."
+    source_file: scripts/get_node_value.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [node_tree_ref, node_name]
+      properties:
+        node_tree_ref:
+          type: object
+          additionalProperties: true
+        node_name:
+          type: string
+          minLength: 1
+        socket:
+          type: string
+          minLength: 1
+    output_schema: *node_result_schema
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations: *read_only_annotations
+
+  - name: create_material_with_nodes
+    description: "Create or initialize a material with a node graph."
+    source_file: scripts/create_material_with_nodes.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [material_name]
+      properties:
+        material_name:
+          type: string
+          minLength: 1
+        template:
+          type: string
+          enum: [principled, default, emission]
+          default: principled
+    output_schema: *node_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations: *mutating_idempotent_annotations
+
+  - name: assign_texture_node
+    description: "Create an image texture node and connect it to a material socket."
+    source_file: scripts/assign_texture_node.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [material_name, image_path]
+      properties:
+        material_name:
+          type: string
+          minLength: 1
+        image_path:
+          type: string
+          minLength: 1
+        target_socket:
+          type: string
+          default: "Base Color"
+    output_schema: *node_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: true
+
+  - name: set_principled_inputs
+    description: "Set multiple values on a material's Principled BSDF shader."
+    source_file: scripts/set_principled_inputs.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [material_name, inputs]
+      properties:
+        material_name:
+          type: string
+          minLength: 1
+        inputs:
+          type: object
+          additionalProperties: true
+        node_name:
+          type: string
+          default: "Principled BSDF"
+    output_schema: *node_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations: *mutating_idempotent_annotations

--- a/tests/e2e/test_node_graph_e2e.py
+++ b/tests/e2e/test_node_graph_e2e.py
@@ -1,0 +1,144 @@
+"""E2E tests for editable shader and geometry node graphs."""
+
+from __future__ import annotations
+
+import pytest
+
+bpy = pytest.importorskip("bpy", reason="bpy not available - run inside Blender Python interpreter")
+
+pytestmark = pytest.mark.e2e
+
+from tests.e2e.conftest import load_skill  # noqa: E402
+
+
+def _new_scene():
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+
+
+def _add_float_group_input(group, name: str) -> str:
+    interface = getattr(group, "interface", None)
+    if interface is not None and hasattr(interface, "new_socket"):
+        socket = interface.new_socket(name=name, in_out="INPUT", socket_type="NodeSocketFloat")
+        return socket.identifier
+
+    socket = group.inputs.new("NodeSocketFloat", name)
+    return socket.identifier
+
+
+class TestNodeGraphE2E:
+    def setup_method(self):
+        _new_scene()
+
+    def test_shader_node_graph_edit_chain(self):
+        create_material = load_skill("blender-shader-nodes", "create_material_with_nodes")
+        created = create_material.main(material_name="E2E Node Material")
+        assert created["success"] is True
+
+        ref = {"kind": "shader", "material_name": "E2E Node Material"}
+
+        set_inputs = load_skill("blender-shader-nodes", "set_principled_inputs")
+        updated = set_inputs.main(
+            material_name="E2E Node Material",
+            inputs={"Metallic": 0.35, "Roughness": 0.62},
+        )
+        assert updated["success"] is True
+
+        create_node = load_skill("blender-shader-nodes", "create_node")
+        node = create_node.main(
+            node_tree_ref=ref,
+            node_type="ShaderNodeValue",
+            name="E2E Metallic Driver",
+            location=[-450.0, 160.0],
+        )
+        assert node["success"] is True
+
+        connect = load_skill("blender-shader-nodes", "connect_nodes")
+        linked = connect.main(
+            node_tree_ref=ref,
+            from_node="E2E Metallic Driver",
+            from_socket="Value",
+            to_node="Principled BSDF",
+            to_socket="Metallic",
+        )
+        assert linked["success"] is True
+
+        list_links = load_skill("blender-shader-nodes", "list_node_links")
+        links = list_links.main(node_tree_ref=ref)
+        assert links["success"] is True
+        assert any(link["to_socket"] == "Metallic" for link in links["context"]["links"])
+
+        get_value = load_skill("blender-shader-nodes", "get_node_value")
+        value = get_value.main(node_tree_ref=ref, node_name="Principled BSDF", socket="Roughness")
+        assert value["success"] is True
+        assert value["context"]["value"] == pytest.approx(0.62)
+
+        disconnect = load_skill("blender-shader-nodes", "disconnect_nodes")
+        removed = disconnect.main(
+            node_tree_ref=ref,
+            from_node="E2E Metallic Driver",
+            to_node="Principled BSDF",
+            to_socket="Metallic",
+        )
+        assert removed["success"] is True
+
+        delete = load_skill("blender-shader-nodes", "delete_node")
+        deleted = delete.main(node_tree_ref=ref, node_name="E2E Metallic Driver")
+        assert deleted["success"] is True
+        material = bpy.data.materials["E2E Node Material"]
+        assert material.node_tree.nodes.get("E2E Metallic Driver") is None
+
+    def test_geometry_node_group_modifier_chain(self):
+        bpy.ops.mesh.primitive_cube_add()
+        cube_name = bpy.context.active_object.name
+
+        create_group = load_skill("blender-geometry-nodes", "create_geometry_node_group")
+        created = create_group.main(name="E2E Geometry Graph", template="pass_through")
+        assert created["success"] is True
+
+        group = bpy.data.node_groups["E2E Geometry Graph"]
+        scale_identifier = None
+        if bpy.app.version >= (4, 0, 0):
+            scale_identifier = _add_float_group_input(group, "Scale")
+
+        assign_group = load_skill("blender-geometry-nodes", "assign_geometry_node_group")
+        assigned = assign_group.main(
+            object_name=cube_name,
+            group_name="E2E Geometry Graph",
+            modifier_name="E2E Geometry Nodes",
+        )
+        assert assigned["success"] is True
+
+        evaluate = load_skill("blender-geometry-nodes", "evaluate_geometry_nodes_info")
+        if scale_identifier is None:
+            info = evaluate.main(object_name=cube_name, modifier_name="E2E Geometry Nodes")
+            assert info["success"] is True
+            assert info["context"]["node_count"] >= 2
+            pytest.skip("Blender 3.6 uses legacy Geometry Nodes sockets; full graph edit coverage runs on 4.x")
+
+        ref = {"kind": "geometry", "group_name": "E2E Geometry Graph"}
+        connect = load_skill("blender-shader-nodes", "connect_nodes")
+        linked = connect.main(
+            node_tree_ref=ref,
+            from_node="Group Input",
+            from_socket="Geometry",
+            to_node="Group Output",
+            to_socket="Geometry",
+        )
+        assert linked["success"] is True
+
+        set_input = load_skill("blender-geometry-nodes", "set_geometry_node_modifier_input")
+        updated = set_input.main(
+            object_name=cube_name,
+            modifier_name="E2E Geometry Nodes",
+            input_name="Scale",
+            value=1.75,
+        )
+        assert updated["success"] is True
+        assert updated["context"]["identifier"] == scale_identifier
+
+        info = evaluate.main(object_name=cube_name, modifier_name="E2E Geometry Nodes")
+        assert info["success"] is True
+        assert info["context"]["node_count"] >= 2
+        assert info["context"]["link_count"] >= 1
+        scale_input = next(item for item in info["context"]["inputs"] if item["name"] == "Scale")
+        assert scale_input["value"] == pytest.approx(1.75)

--- a/tests/test_skills_geometry_nodes.py
+++ b/tests/test_skills_geometry_nodes.py
@@ -2,18 +2,100 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import yaml
+
 from tests.conftest import load_and_call, make_mock_bpy
+
+GEOMETRY_NODES_DIR = "blender-geometry-nodes"
+GEOMETRY_NODES_PATH = "src/dcc_mcp_blender/skills/blender-geometry-nodes/tools.yaml"
+
+
+class FakeNodes(list):
+    def new(self, type):  # noqa: A002
+        node = SimpleNamespace(
+            name=type, type=type, bl_idname=type, inputs={}, outputs={}, label="", location=[0.0, 0.0]
+        )
+        self.append(node)
+        return node
+
+
+class FakeLinks(list):
+    pass
+
+
+class FakeInterface(list):
+    def new_socket(self, name, in_out, socket_type):
+        socket = SimpleNamespace(name=name, identifier=name, in_out=in_out, socket_type=socket_type)
+        self.append(socket)
+        return socket
+
+
+class FakeNodeGroup:
+    def __init__(self, name="GeoGroup"):
+        self.name = name
+        self.type = "GeometryNodeTree"
+        self.bl_idname = "GeometryNodeTree"
+        self.nodes = FakeNodes()
+        self.links = FakeLinks()
+        self.interface = SimpleNamespace(items_tree=FakeInterface())
+
+
+class FakeNodeGroups(list):
+    def get(self, name):
+        return next((group for group in self if group.name == name), None)
+
+    def new(self, name, tree_type):
+        group = FakeNodeGroup(name)
+        group.type = tree_type
+        self.append(group)
+        return group
+
+
+class FakeModifier(dict):
+    def __init__(self, name="Geometry Nodes", node_group=None):
+        super().__init__()
+        self.name = name
+        self.type = "NODES"
+        self.node_group = node_group
+        self.show_viewport = True
+        self.show_render = True
+
+
+class FakeModifiers(list):
+    def new(self, name, type):  # noqa: A002
+        modifier = FakeModifier(name)
+        modifier.type = type
+        self.append(modifier)
+        return modifier
 
 
 def _make_mesh_obj(name="Cube"):
     obj = MagicMock()
     obj.name = name
     obj.type = "MESH"
-    obj.modifiers = MagicMock()
-    obj.modifiers.__iter__ = MagicMock(return_value=iter([]))
+    obj.modifiers = FakeModifiers()
     return obj
+
+
+def test_geometry_nodes_tools_yaml_declares_modern_contracts():
+    doc = yaml.safe_load(Path(GEOMETRY_NODES_PATH).read_text(encoding="utf-8"))
+    tools = {tool["name"]: tool for tool in doc["tools"]}
+    assert {
+        "create_geometry_node_group",
+        "assign_geometry_node_group",
+        "set_geometry_node_modifier_input",
+        "evaluate_geometry_nodes_info",
+    }.issubset(tools)
+    for tool in tools.values():
+        assert tool["execution"] == "sync"
+        assert tool["affinity"] == "main"
+        assert tool["input_schema"]["type"] == "object"
+        assert tool["output_schema"]["properties"]["success"]["type"] == "boolean"
+        assert "annotations" in tool
 
 
 class TestAddGeometryNodesModifier:
@@ -22,15 +104,8 @@ class TestAddGeometryNodesModifier:
         obj = _make_mesh_obj()
         bpy.data.objects.get.return_value = obj
 
-        modifier = MagicMock()
-        modifier.name = "Geometry Nodes"
-        modifier.type = "NODES"
-        obj.modifiers.new.return_value = modifier
-
-        group = MagicMock()
-        group.name = "Procedural Group"
-        bpy.data.node_groups.get.return_value = None
-        bpy.data.node_groups.new.return_value = group
+        groups = FakeNodeGroups()
+        bpy.data.node_groups = groups
 
         result = load_and_call(
             "blender-geometry-nodes/scripts/add_geometry_nodes_modifier.py",
@@ -40,9 +115,8 @@ class TestAddGeometryNodesModifier:
         )
 
         assert result["success"] is True
-        obj.modifiers.new.assert_called_once_with(name="Geometry Nodes", type="NODES")
-        bpy.data.node_groups.new.assert_called_once_with("Procedural Group", "GeometryNodeTree")
-        assert modifier.node_group is group
+        assert obj.modifiers[0].name == "Geometry Nodes"
+        assert obj.modifiers[0].node_group is groups[0]
 
     def test_non_mesh_returns_error(self):
         bpy = make_mock_bpy()
@@ -63,21 +137,15 @@ class TestListGeometryNodesModifiers:
     def test_lists_only_geometry_nodes_modifiers(self):
         bpy = make_mock_bpy()
         obj = _make_mesh_obj()
-        group = MagicMock()
-        group.name = "GeoGroup"
+        group = FakeNodeGroup("GeoGroup")
 
-        geo = MagicMock()
-        geo.name = "Geometry Nodes"
-        geo.type = "NODES"
-        geo.node_group = group
-        geo.show_viewport = True
-        geo.show_render = True
+        geo = FakeModifier("Geometry Nodes", group)
 
         bevel = MagicMock()
         bevel.name = "Bevel"
         bevel.type = "BEVEL"
 
-        obj.modifiers.__iter__ = MagicMock(return_value=iter([geo, bevel]))
+        obj.modifiers.extend([geo, bevel])
         bpy.data.objects.get.return_value = obj
 
         result = load_and_call(
@@ -101,3 +169,85 @@ class TestListGeometryNodesModifiers:
         )
 
         assert result["success"] is False
+
+
+class TestGeometryNodeGraphTools:
+    def test_create_assign_set_and_evaluate_modifier_input(self):
+        bpy = make_mock_bpy()
+        obj = _make_mesh_obj()
+        bpy.data.objects.get.return_value = obj
+        bpy.data.node_groups = FakeNodeGroups()
+
+        created = load_and_call(
+            f"{GEOMETRY_NODES_DIR}/scripts/create_geometry_node_group.py",
+            bpy,
+            name="ScatterGroup",
+            template="pass_through",
+        )
+        assert created["success"] is True
+        group = bpy.data.node_groups.get("ScatterGroup")
+        group.interface.items_tree.new_socket("Scale", "INPUT", "NodeSocketFloat")
+
+        second_create = load_and_call(
+            f"{GEOMETRY_NODES_DIR}/scripts/create_geometry_node_group.py",
+            bpy,
+            name="ScatterGroup",
+            template="pass_through",
+        )
+        assert second_create["success"] is True
+        assert len(group.nodes) == 2
+        assert [(socket.name, socket.in_out) for socket in group.interface.items_tree].count(("Geometry", "INPUT")) == 1
+        assert [(socket.name, socket.in_out) for socket in group.interface.items_tree].count(
+            ("Geometry", "OUTPUT")
+        ) == 1
+
+        assigned = load_and_call(
+            f"{GEOMETRY_NODES_DIR}/scripts/assign_geometry_node_group.py",
+            bpy,
+            object_name="Cube",
+            group_name="ScatterGroup",
+            modifier_name="Scatter",
+        )
+        assert assigned["success"] is True
+        assert obj.modifiers[0].node_group is group
+
+        updated = load_and_call(
+            f"{GEOMETRY_NODES_DIR}/scripts/set_geometry_node_modifier_input.py",
+            bpy,
+            object_name="Cube",
+            modifier_name="Scatter",
+            input_name="Scale",
+            value=2.5,
+        )
+        assert updated["success"] is True
+        assert obj.modifiers[0]["Scale"] == 2.5
+
+        info = load_and_call(
+            f"{GEOMETRY_NODES_DIR}/scripts/evaluate_geometry_nodes_info.py",
+            bpy,
+            object_name="Cube",
+            modifier_name="Scatter",
+        )
+        assert info["success"] is True
+        assert {
+            "name": "Scale",
+            "identifier": "Scale",
+            "value": 2.5,
+            "in_out": "INPUT",
+            "type": "NodeSocketFloat",
+        } in info["context"]["inputs"]
+
+    def test_missing_group_and_non_mesh_return_errors(self):
+        bpy = make_mock_bpy()
+        obj = _make_mesh_obj("Light")
+        obj.type = "LIGHT"
+        bpy.data.objects.get.return_value = obj
+        bpy.data.node_groups = FakeNodeGroups()
+
+        assigned = load_and_call(
+            f"{GEOMETRY_NODES_DIR}/scripts/assign_geometry_node_group.py",
+            bpy,
+            object_name="Light",
+            group_name="Missing",
+        )
+        assert assigned["success"] is False

--- a/tests/test_skills_shader_nodes.py
+++ b/tests/test_skills_shader_nodes.py
@@ -2,17 +2,87 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import yaml
 
 from tests.conftest import load_and_call, make_mock_bpy
 
+SHADER_NODES_DIR = "blender-shader-nodes"
+SHADER_NODES_PATH = "src/dcc_mcp_blender/skills/blender-shader-nodes/tools.yaml"
+
+
+class FakeSocket(SimpleNamespace):
+    def __init__(self, name, default_value=None, socket_type="VALUE"):
+        super().__init__(
+            name=name,
+            identifier=name,
+            default_value=default_value,
+            type=socket_type,
+            is_linked=False,
+            node=None,
+        )
+
+
+class FakeNode:
+    def __init__(self, name, node_type, inputs=None, outputs=None):
+        self.name = name
+        self.type = node_type
+        self.bl_idname = node_type
+        self.label = ""
+        self.location = [0.0, 0.0]
+        self.inputs = inputs or {}
+        self.outputs = outputs or {}
+        for socket in [*self.inputs.values(), *self.outputs.values()]:
+            socket.node = self
+
+
+class FakeNodes(list):
+    def get(self, name):
+        return next((node for node in self if node.name == name), None)
+
+    def new(self, type):  # noqa: A002
+        if type == "ShaderNodeValue":
+            node = FakeNode("Value", type, outputs={"Value": FakeSocket("Value", 0.0)})
+        elif type == "ShaderNodeTexImage":
+            node = FakeNode("Image Texture", type, outputs={"Color": FakeSocket("Color", [1.0, 1.0, 1.0, 1.0])})
+        elif type == "ShaderNodeEmission":
+            node = FakeNode(
+                "Emission",
+                type,
+                inputs={"Color": FakeSocket("Color", [1.0, 1.0, 1.0, 1.0])},
+                outputs={"Emission": FakeSocket("Emission")},
+            )
+        else:
+            node = FakeNode(type, type)
+        self.append(node)
+        return node
+
+    def remove(self, node):
+        self[:] = [item for item in self if item is not node]
+
+
+class FakeLinks(list):
+    def new(self, from_socket, to_socket):
+        from_socket.is_linked = True
+        to_socket.is_linked = True
+        link = SimpleNamespace(
+            from_node=from_socket.node,
+            from_socket=from_socket,
+            to_node=to_socket.node,
+            to_socket=to_socket,
+        )
+        self.append(link)
+        return link
+
+    def remove(self, link):
+        self[:] = [item for item in self if item is not link]
+
 
 def _nodes_collection(nodes):
-    collection = MagicMock()
-    collection.__iter__ = MagicMock(return_value=iter(nodes))
-    by_name = {node.name: node for node in nodes}
-    collection.get = MagicMock(side_effect=lambda name: by_name.get(name))
-    return collection
+    return FakeNodes(nodes)
 
 
 def _make_material(name="ShaderMat", use_nodes=True):
@@ -20,26 +90,49 @@ def _make_material(name="ShaderMat", use_nodes=True):
     mat.name = name
     mat.use_nodes = use_nodes
 
-    bsdf = MagicMock()
-    bsdf.name = "Principled BSDF"
-    bsdf.type = "BSDF_PRINCIPLED"
-    bsdf.label = ""
+    bsdf = FakeNode("Principled BSDF", "BSDF_PRINCIPLED")
     bsdf.inputs = {
-        "Base Color": MagicMock(default_value=[1.0, 1.0, 1.0, 1.0]),
-        "Metallic": MagicMock(default_value=0.0),
-        "Roughness": MagicMock(default_value=0.5),
+        "Base Color": FakeSocket("Base Color", [1.0, 1.0, 1.0, 1.0], "RGBA"),
+        "Metallic": FakeSocket("Metallic", 0.0),
+        "Roughness": FakeSocket("Roughness", 0.5),
     }
-    bsdf.outputs = {"BSDF": MagicMock(name="BSDF")}
+    bsdf.outputs = {"BSDF": FakeSocket("BSDF")}
 
-    output = MagicMock()
-    output.name = "Material Output"
-    output.type = "OUTPUT_MATERIAL"
-    output.label = ""
-    output.inputs = {"Surface": MagicMock(name="Surface")}
-    output.outputs = {}
+    output = FakeNode("Material Output", "OUTPUT_MATERIAL", inputs={"Surface": FakeSocket("Surface")})
+    for socket in [*bsdf.inputs.values(), *bsdf.outputs.values(), *output.inputs.values()]:
+        socket.node = bsdf if socket in [*bsdf.inputs.values(), *bsdf.outputs.values()] else output
 
     mat.node_tree.nodes = _nodes_collection([bsdf, output])
+    mat.node_tree.links = FakeLinks()
     return mat, bsdf
+
+
+def test_shader_nodes_tools_yaml_declares_modern_contracts():
+    raw_tools = Path(SHADER_NODES_PATH).read_text(encoding="utf-8")
+    assert "<<:" not in raw_tools
+    doc = yaml.safe_load(raw_tools)
+    tools = {tool["name"]: tool for tool in doc["tools"]}
+    assert {
+        "list_node_trees",
+        "list_nodes",
+        "create_node",
+        "delete_node",
+        "list_node_sockets",
+        "connect_nodes",
+        "disconnect_nodes",
+        "list_node_links",
+        "set_node_input",
+        "get_node_value",
+        "create_material_with_nodes",
+        "assign_texture_node",
+        "set_principled_inputs",
+    }.issubset(tools)
+    for tool in tools.values():
+        assert tool["execution"] == "sync"
+        assert tool["affinity"] == "main"
+        assert tool["input_schema"]["type"] == "object"
+        assert tool["output_schema"]["properties"]["success"]["type"] == "boolean"
+        assert "annotations" in tool
 
 
 class TestListMaterialNodes:
@@ -57,7 +150,7 @@ class TestListMaterialNodes:
         assert result["success"] is True
         assert result["context"]["count"] == 2
         assert result["context"]["nodes"][0]["name"] == "Principled BSDF"
-        assert "Base Color" in result["context"]["nodes"][0]["inputs"]
+        assert result["context"]["nodes"][0]["inputs"][0]["name"] == "Base Color"
 
     def test_material_not_found(self):
         bpy = make_mock_bpy()
@@ -70,6 +163,125 @@ class TestListMaterialNodes:
         )
 
         assert result["success"] is False
+
+
+class TestNodeGraphTools:
+    def test_create_set_connect_get_delete_shader_node(self):
+        bpy = make_mock_bpy()
+        mat, bsdf = _make_material("ShaderMat")
+        bpy.data.materials.get.return_value = mat
+        bpy.data.materials.__iter__ = MagicMock(return_value=iter([mat]))
+        ref = {"kind": "shader", "material_name": "ShaderMat"}
+
+        listed_trees = load_and_call(f"{SHADER_NODES_DIR}/scripts/list_node_trees.py", bpy, kind="shader")
+        assert listed_trees["success"] is True
+        assert listed_trees["context"]["count"] == 1
+
+        created = load_and_call(
+            f"{SHADER_NODES_DIR}/scripts/create_node.py",
+            bpy,
+            node_tree_ref=ref,
+            node_type="ShaderNodeValue",
+            name="Metallic Value",
+        )
+        assert created["success"] is True
+
+        set_value = load_and_call(
+            f"{SHADER_NODES_DIR}/scripts/set_node_input.py",
+            bpy,
+            node_tree_ref=ref,
+            node_name="Principled BSDF",
+            socket="Metallic",
+            value=0.42,
+        )
+        assert set_value["success"] is True
+        assert bsdf.inputs["Metallic"].default_value == 0.42
+
+        connected = load_and_call(
+            f"{SHADER_NODES_DIR}/scripts/connect_nodes.py",
+            bpy,
+            node_tree_ref=ref,
+            from_node="Metallic Value",
+            from_socket="Value",
+            to_node="Principled BSDF",
+            to_socket="Metallic",
+        )
+        assert connected["success"] is True
+        assert len(mat.node_tree.links) == 1
+
+        links = load_and_call(f"{SHADER_NODES_DIR}/scripts/list_node_links.py", bpy, node_tree_ref=ref)
+        assert links["context"]["count"] == 1
+
+        value = load_and_call(
+            f"{SHADER_NODES_DIR}/scripts/get_node_value.py",
+            bpy,
+            node_tree_ref=ref,
+            node_name="Principled BSDF",
+            socket="Metallic",
+        )
+        assert value["context"]["value"] == 0.42
+
+        disconnected = load_and_call(
+            f"{SHADER_NODES_DIR}/scripts/disconnect_nodes.py",
+            bpy,
+            node_tree_ref=ref,
+            from_node="Metallic Value",
+            to_node="Principled BSDF",
+        )
+        assert disconnected["success"] is True
+        assert len(mat.node_tree.links) == 0
+
+        deleted = load_and_call(
+            f"{SHADER_NODES_DIR}/scripts/delete_node.py",
+            bpy,
+            node_tree_ref=ref,
+            node_name="Metallic Value",
+        )
+        assert deleted["success"] is True
+
+    def test_bad_socket_returns_error(self):
+        bpy = make_mock_bpy()
+        mat, _bsdf = _make_material("ShaderMat")
+        bpy.data.materials.get.return_value = mat
+
+        result = load_and_call(
+            f"{SHADER_NODES_DIR}/scripts/connect_nodes.py",
+            bpy,
+            node_tree_ref={"kind": "shader", "material_name": "ShaderMat"},
+            from_node="Principled BSDF",
+            from_socket="Not Real",
+            to_node="Material Output",
+            to_socket="Surface",
+        )
+
+        assert result["success"] is False
+
+    def test_assign_texture_node_requires_existing_image(self, tmp_path):
+        bpy = make_mock_bpy()
+        mat, _bsdf = _make_material("ShaderMat")
+        bpy.data.materials.get.return_value = mat
+        image = SimpleNamespace(name="albedo.png")
+        bpy.data.images.load.return_value = image
+        texture = tmp_path / "albedo.png"
+        texture.write_bytes(b"png")
+
+        result = load_and_call(
+            f"{SHADER_NODES_DIR}/scripts/assign_texture_node.py",
+            bpy,
+            material_name="ShaderMat",
+            image_path=str(texture),
+        )
+
+        assert result["success"] is True
+        bpy.data.images.load.assert_called_once()
+
+        missing = load_and_call(
+            f"{SHADER_NODES_DIR}/scripts/assign_texture_node.py",
+            bpy,
+            material_name="ShaderMat",
+            image_path=str(tmp_path / "missing.png"),
+        )
+        assert missing["success"] is False
 
 
 class TestSetPrincipledInput:
@@ -119,3 +331,19 @@ class TestSetPrincipledInput:
         )
 
         assert result["success"] is False
+
+    def test_sets_multiple_principled_inputs(self):
+        bpy = make_mock_bpy()
+        mat, bsdf = _make_material("ShaderMat")
+        bpy.data.materials.get.return_value = mat
+
+        result = load_and_call(
+            f"{SHADER_NODES_DIR}/scripts/set_principled_inputs.py",
+            bpy,
+            material_name="ShaderMat",
+            inputs={"Metallic": 0.7, "Roughness": 0.2},
+        )
+
+        assert result["success"] is True
+        assert bsdf.inputs["Metallic"].default_value == 0.7
+        assert bsdf.inputs["Roughness"].default_value == 0.2


### PR DESCRIPTION
## Summary
- add shared shader and Geometry Nodes graph operations for node trees, sockets, links, values, materials, textures, and modifier inputs
- expand shader/geometry node skill manifests and docs to expose the new tools
- add unit coverage plus real Blender E2E coverage for editable node graph workflows

## Validation
- python -m ruff check src tests tools packaging
- python -m ruff format --check src tests tools packaging
- python tools\lint_skills.py --warnings-as-errors
- python -m pytest tests/ -q
- Blender 4.4.3 E2E: 104 passed, 1 skipped
- HTTP MCP smoke: tools/list pagination found 164 tools and node graph tool calls passed
- python -m build
- python packaging\assemble_zip.py --platform win64 --output-dir dist_addon

Closes #33