### PR TITLE
feat: add blender dev diagnostic tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 | **blender-shader-nodes** | `list_material_nodes`, `set_principled_input`, `list_node_trees`, `list_nodes`, `create_node`, `delete_node`, `list_node_sockets`, `connect_nodes`, `disconnect_nodes`, `list_node_links`, `set_node_input`, `get_node_value`, `create_material_with_nodes`, `assign_texture_node`, `set_principled_inputs` |
 | **blender-render** | `render_scene`, `set_render_settings`, `get_render_info`, `capture_viewport` |
 | **blender-scripting** | `execute_python`, `execute_script_file`, `get_blender_info` |
+| **blender-dev** | `attach_project`, `reload_modules`, `run_check`, `run_entrypoint`, `run_script`, `list_addons`, `get_addon_status`, `enable_addon`, `disable_addon`, `capture_ui_snapshot`, `find_ui_elements`, `start_debug_server`, `get_python_environment` |
 | **blender-animation** | `set_keyframe`, `set_frame_range`, `get_frame_range`, `set_current_frame`, `get_keyframes`, `delete_keyframes`, `bake_animation` |
 | **blender-lighting** | `create_light`, `set_light_properties`, `list_lights`, `set_world_background` |
 | **blender-camera** | `create_camera`, `set_active_camera`, `set_camera_properties`, `list_cameras` |

--- a/src/dcc_mcp_blender/_dev_ops.py
+++ b/src/dcc_mcp_blender/_dev_ops.py
@@ -1,0 +1,574 @@
+"""Development and diagnostics helpers for Blender MCP workflows."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import io
+import platform
+import runpy
+import sys
+import time
+import traceback
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
+
+_DEBUG_SERVER: Dict[str, Any] = {}
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_jsonable(item) for item in value]
+    return repr(value)
+
+
+def _module_version(package_name: str) -> Optional[str]:
+    try:
+        return importlib.metadata.version(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _iterable(value: Any) -> Iterable[Any]:
+    if value is None:
+        return []
+    try:
+        return list(value)
+    except TypeError:
+        return []
+
+
+def _package_versions() -> Dict[str, Optional[str]]:
+    return {
+        "dcc-mcp-blender": _module_version("dcc-mcp-blender"),
+        "dcc-mcp-core": _module_version("dcc-mcp-core"),
+        "debugpy": _module_version("debugpy"),
+        "pytest": _module_version("pytest"),
+    }
+
+
+def attach_project(project_root: str, extra_paths: Optional[List[str]] = None) -> dict:
+    """Attach a project checkout to ``sys.path`` for live add-on debugging."""
+    try:
+        root_path = Path(project_root).expanduser().resolve()
+        paths = [root_path]
+        if extra_paths:
+            for extra_path in extra_paths:
+                candidate = Path(extra_path).expanduser()
+                paths.append(candidate if candidate.is_absolute() else root_path / candidate)
+
+        added = []
+        existing = []
+        missing = []
+        for raw_path in paths:
+            resolved = str(raw_path.resolve())
+            if not Path(resolved).exists():
+                missing.append(resolved)
+                continue
+            if resolved in sys.path:
+                existing.append(resolved)
+                continue
+            sys.path.insert(0, resolved)
+            added.append(resolved)
+
+        return skill_success(
+            "Attached project paths",
+            project_root=str(root_path),
+            added=added,
+            existing=existing,
+            missing=missing,
+            sys_path_head=sys.path[:10],
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to attach project")
+
+
+def reload_modules(
+    module_names: Optional[List[str]] = None,
+    package_prefix: Optional[str] = None,
+) -> dict:
+    """Reload explicit modules or loaded modules matching a package prefix."""
+    try:
+        targets: List[str] = []
+        if module_names:
+            targets.extend(module_names)
+        if package_prefix:
+            prefix = package_prefix.rstrip(".")
+            targets.extend(name for name in sys.modules if name == prefix or name.startswith(f"{prefix}."))
+        targets = sorted(set(targets), key=lambda name: name.count("."), reverse=True)
+        if not targets:
+            return skill_error(
+                "No modules selected",
+                "Pass module_names or package_prefix to reload development modules.",
+            )
+
+        reloaded = []
+        imported = []
+        errors = []
+        for name in targets:
+            try:
+                module = sys.modules.get(name)
+                if module is None:
+                    importlib.import_module(name)
+                    imported.append(name)
+                else:
+                    importlib.reload(module)
+                    reloaded.append(name)
+            except Exception as exc:
+                errors.append({"module": name, "error": repr(exc), "traceback": traceback.format_exc()})
+
+        if errors:
+            return skill_error(
+                "Some modules failed to reload",
+                "One or more modules raised during import or reload.",
+                reloaded=reloaded,
+                imported=imported,
+                errors=errors,
+            )
+        return skill_success(
+            "Modules reloaded",
+            reloaded=reloaded,
+            imported=imported,
+            count=len(reloaded) + len(imported),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to reload modules")
+
+
+def _check_import_module(args: Dict[str, Any]) -> dict:
+    module_name = args.get("module") or args.get("module_name")
+    if not module_name:
+        return skill_error("Missing module", "Pass args.module for import_module.")
+    module = importlib.import_module(str(module_name))
+    return skill_success(
+        f"Imported {module_name}",
+        module=str(module_name),
+        file=getattr(module, "__file__", None),
+        package=getattr(module, "__package__", None),
+    )
+
+
+def _check_python_environment(args: Dict[str, Any]) -> dict:
+    return get_python_environment(include_sys_path=bool(args.get("include_sys_path", False)))
+
+
+def _check_addon_status(args: Dict[str, Any]) -> dict:
+    addon_module = args.get("addon_module") or args.get("module")
+    if not addon_module:
+        return skill_error("Missing add-on module", "Pass args.addon_module for addon_status.")
+    return get_addon_status(str(addon_module))
+
+
+def _check_sleep(args: Dict[str, Any]) -> dict:
+    seconds = float(args.get("seconds", 0))
+    time.sleep(seconds)
+    return skill_success("Sleep check completed", seconds=seconds)
+
+
+_CHECKS = {
+    "import_module": _check_import_module,
+    "python_environment": _check_python_environment,
+    "addon_status": _check_addon_status,
+    "sleep": _check_sleep,
+}
+
+
+def run_check(command_name: str, args: Optional[Dict[str, Any]] = None, timeout_secs: Optional[float] = 30.0) -> dict:
+    """Run a named in-process development check with a timeout envelope."""
+    check = _CHECKS.get(command_name)
+    if check is None:
+        return skill_error(
+            f"Unknown check: {command_name}",
+            f"Expected one of {sorted(_CHECKS)}.",
+            available=sorted(_CHECKS),
+        )
+
+    executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="blender-dev-check")
+    future = executor.submit(check, args or {})
+    timed_out = False
+    try:
+        timeout = 30.0 if timeout_secs is None else max(float(timeout_secs), 0.001)
+        return future.result(timeout=timeout)
+    except TimeoutError:
+        timed_out = True
+        future.cancel()
+        return skill_error(
+            f"Check timed out: {command_name}",
+            f"The check exceeded {timeout_secs} seconds.",
+            timeout_secs=timeout_secs,
+            command_name=command_name,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message=f"Check failed: {command_name}")
+    finally:
+        executor.shutdown(wait=not timed_out, cancel_futures=True)
+
+
+def _call_with_args(function: Any, args: Any) -> Any:
+    if args is None:
+        return function()
+    if isinstance(args, dict):
+        return function(**args)
+    if isinstance(args, list):
+        return function(*args)
+    return function(args)
+
+
+def run_entrypoint(module: str, function: str, args: Any = None) -> dict:
+    """Import a module and run a named function for reproducible add-on checks."""
+    try:
+        imported = importlib.import_module(module)
+        entrypoint = getattr(imported, function, None)
+        if not callable(entrypoint):
+            return skill_error(
+                f"Entrypoint not callable: {module}.{function}", "The named attribute is missing or not callable."
+            )
+
+        stdout_buf = io.StringIO()
+        stderr_buf = io.StringIO()
+        with redirect_stdout(stdout_buf), redirect_stderr(stderr_buf):
+            result = _call_with_args(entrypoint, args)
+        return skill_success(
+            f"Ran {module}.{function}",
+            module=module,
+            function=function,
+            stdout=stdout_buf.getvalue(),
+            stderr=stderr_buf.getvalue(),
+            result=_jsonable(result),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to run {module}.{function}")
+
+
+def run_script(path: str, args: Any = None) -> dict:
+    """Execute a Python script file inside the Blender process."""
+    try:
+        script_path = Path(path).expanduser().resolve()
+        if not script_path.exists():
+            return skill_error(f"Script not found: {path}", f"No file exists at {script_path}.")
+        if script_path.suffix != ".py":
+            return skill_error(f"Unsupported script file: {path}", "Only Python .py scripts can be run by this tool.")
+
+        stdout_buf = io.StringIO()
+        stderr_buf = io.StringIO()
+        old_argv = sys.argv[:]
+        argv = args if isinstance(args, list) else []
+        sys.argv = [str(script_path), *[str(item) for item in argv]]
+        try:
+            with redirect_stdout(stdout_buf), redirect_stderr(stderr_buf):
+                globals_after = runpy.run_path(str(script_path), init_globals={"ARGS": args}, run_name="__main__")
+        finally:
+            sys.argv = old_argv
+
+        interesting_globals = {
+            key: _jsonable(value)
+            for key, value in globals_after.items()
+            if not key.startswith("__") and not isinstance(value, ModuleType)
+        }
+        return skill_success(
+            f"Ran script {script_path.name}",
+            path=str(script_path),
+            stdout=stdout_buf.getvalue(),
+            stderr=stderr_buf.getvalue(),
+            globals=interesting_globals,
+            result=interesting_globals.get("result"),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to run script {path}")
+
+
+def _addon_bl_info(module: Any) -> Dict[str, Any]:
+    try:
+        import addon_utils
+
+        info = addon_utils.module_bl_info(module)
+    except Exception:
+        info = getattr(module, "bl_info", {}) or {}
+    return _jsonable(info) if isinstance(info, dict) else {}
+
+
+def _addon_modules() -> List[Any]:
+    import addon_utils
+
+    return list(addon_utils.modules(refresh=False))
+
+
+def _addon_status_data(addon_module: str) -> Dict[str, Any]:
+    import addon_utils
+
+    loaded, enabled = addon_utils.check(addon_module)
+    module = next(
+        (candidate for candidate in _addon_modules() if getattr(candidate, "__name__", None) == addon_module), None
+    )
+    info = _addon_bl_info(module) if module is not None else {}
+    return {
+        "addon_module": addon_module,
+        "installed": module is not None,
+        "loaded": bool(loaded),
+        "enabled": bool(enabled),
+        "name": info.get("name") or addon_module,
+        "version": info.get("version"),
+        "category": info.get("category"),
+        "description": info.get("description"),
+        "file": getattr(module, "__file__", None) if module is not None else None,
+    }
+
+
+def list_addons(filter: Optional[str] = None) -> dict:
+    """List available Blender add-ons with enabled/loaded state."""
+    try:
+        query = (filter or "").lower()
+        addons = []
+        for module in _addon_modules():
+            module_name = getattr(module, "__name__", "")
+            info = _addon_bl_info(module)
+            display_name = str(info.get("name") or module_name)
+            if query and query not in module_name.lower() and query not in display_name.lower():
+                continue
+            addons.append(_addon_status_data(module_name))
+
+        return skill_success(
+            f"Found {len(addons)} add-ons",
+            count=len(addons),
+            addons=addons,
+            filter=filter,
+        )
+    except ImportError:
+        return skill_error("Blender add-on utilities unavailable", "addon_utils could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list add-ons")
+
+
+def get_addon_status(addon_module: str) -> dict:
+    """Return structured status for a Blender add-on module."""
+    try:
+        status = _addon_status_data(addon_module)
+        return skill_success(
+            f"Add-on status retrieved for {addon_module}",
+            **status,
+        )
+    except ImportError:
+        return skill_error("Blender add-on utilities unavailable", "addon_utils could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to get add-on status for {addon_module}")
+
+
+def enable_addon(addon_module: str) -> dict:
+    """Enable a Blender add-on and report before/after state."""
+    try:
+        import bpy
+
+        before = _addon_status_data(addon_module)
+        try:
+            bpy.ops.preferences.addon_enable(module=addon_module)
+        except Exception as exc:
+            if not before.get("enabled"):
+                try:
+                    bpy.ops.preferences.addon_disable(module=addon_module)
+                except Exception:
+                    pass
+            after = _addon_status_data(addon_module)
+            return skill_exception(exc, message=f"Failed to enable add-on {addon_module}", before=before, after=after)
+
+        after = _addon_status_data(addon_module)
+        if not after.get("enabled"):
+            return skill_error(
+                f"Add-on was not enabled: {addon_module}",
+                "Blender completed the enable operation but the add-on is still disabled.",
+                before=before,
+                after=after,
+            )
+        return skill_success(f"Enabled add-on {addon_module}", before=before, after=after)
+    except ImportError:
+        return skill_error("Blender not available", "bpy or addon_utils could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to enable add-on {addon_module}")
+
+
+def disable_addon(addon_module: str) -> dict:
+    """Disable a Blender add-on and report before/after state."""
+    try:
+        import bpy
+
+        before = _addon_status_data(addon_module)
+        try:
+            bpy.ops.preferences.addon_disable(module=addon_module)
+        except Exception as exc:
+            after = _addon_status_data(addon_module)
+            return skill_exception(exc, message=f"Failed to disable add-on {addon_module}", before=before, after=after)
+
+        after = _addon_status_data(addon_module)
+        if after.get("enabled"):
+            return skill_error(
+                f"Add-on was not disabled: {addon_module}",
+                "Blender completed the disable operation but the add-on is still enabled.",
+                before=before,
+                after=after,
+            )
+        return skill_success(f"Disabled add-on {addon_module}", before=before, after=after)
+    except ImportError:
+        return skill_error("Blender not available", "bpy or addon_utils could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to disable add-on {addon_module}")
+
+
+def _area_context(screen_name: str, area: Any) -> Dict[str, Any]:
+    spaces = _iterable(getattr(area, "spaces", []))
+    active_space = getattr(getattr(area, "spaces", None), "active", None)
+    if active_space is None and spaces:
+        active_space = spaces[0]
+    regions = _iterable(getattr(area, "regions", []))
+    return {
+        "screen": screen_name,
+        "area_type": getattr(area, "type", None),
+        "region_types": [getattr(region, "type", None) for region in regions],
+        "space_types": [getattr(space, "type", None) for space in spaces],
+        "active_space_type": getattr(active_space, "type", None) if active_space is not None else None,
+    }
+
+
+def capture_ui_snapshot(area_filter: Optional[str] = None) -> dict:
+    """Return structured Blender UI/window/screen metadata."""
+    try:
+        import bpy
+
+        query = (area_filter or "").lower()
+        screens = []
+        for screen in _iterable(getattr(bpy.data, "screens", [])):
+            screen_name = getattr(screen, "name", "")
+            areas = []
+            for area in _iterable(getattr(screen, "areas", [])):
+                area_type = str(getattr(area, "type", ""))
+                if query and query not in area_type.lower() and query not in screen_name.lower():
+                    continue
+                areas.append(_area_context(screen_name, area))
+            if areas or not query:
+                screens.append({"name": screen_name, "areas": areas, "area_count": len(areas)})
+
+        windows = []
+        window_manager = getattr(bpy.context, "window_manager", None)
+        for window in _iterable(getattr(window_manager, "windows", [])):
+            screen = getattr(window, "screen", None)
+            windows.append({"screen": getattr(screen, "name", None)})
+
+        return skill_success(
+            "Captured Blender UI snapshot",
+            is_background=bool(getattr(bpy.app, "background", False)),
+            window_count=len(windows),
+            windows=windows,
+            screens=screens,
+            screen_count=len(screens),
+            area_filter=area_filter,
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to capture UI snapshot")
+
+
+def find_ui_elements(query: str, area_filter: Optional[str] = None) -> dict:
+    """Find structured UI metadata entries matching a query."""
+    try:
+        if not query:
+            return skill_error("Missing UI query", "Pass a non-empty query string.")
+        snapshot = capture_ui_snapshot(area_filter=area_filter)
+        if not snapshot.get("success"):
+            return snapshot
+
+        needle = query.lower()
+        matches = []
+        for screen in snapshot.get("context", {}).get("screens", []):
+            screen_name = str(screen.get("name") or "")
+            if needle in screen_name.lower():
+                matches.append({"kind": "screen", "screen": screen_name})
+            for area in screen.get("areas", []):
+                area_type = str(area.get("area_type") or "")
+                if needle in area_type.lower():
+                    matches.append({"kind": "area", "screen": screen_name, "area_type": area_type})
+                for region_type in area.get("region_types", []):
+                    if needle in str(region_type).lower():
+                        matches.append(
+                            {
+                                "kind": "region",
+                                "screen": screen_name,
+                                "area_type": area_type,
+                                "region_type": region_type,
+                            }
+                        )
+                for space_type in area.get("space_types", []):
+                    if needle in str(space_type).lower():
+                        matches.append(
+                            {
+                                "kind": "space",
+                                "screen": screen_name,
+                                "area_type": area_type,
+                                "space_type": space_type,
+                            }
+                        )
+
+        return skill_success(
+            f"Found {len(matches)} UI metadata matches",
+            query=query,
+            area_filter=area_filter,
+            count=len(matches),
+            matches=matches,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to find UI elements")
+
+
+def start_debug_server(host: str = "127.0.0.1", port: int = 5678) -> dict:
+    """Start a debugpy listener if debugpy is available."""
+    try:
+        import debugpy
+
+        if _DEBUG_SERVER.get("listening"):
+            return skill_success("Debug server already listening", **_DEBUG_SERVER)
+
+        address: Tuple[str, int] = (host, int(port))
+        debugpy.listen(address)
+        _DEBUG_SERVER.update({"listening": True, "host": host, "port": int(port), "backend": "debugpy"})
+        return skill_success("Debug server listening", **_DEBUG_SERVER)
+    except ImportError:
+        return skill_error(
+            "debugpy unavailable", "Install debugpy in Blender's Python environment to start a debug server."
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to start debug server")
+
+
+def get_python_environment(include_sys_path: bool = True) -> dict:
+    """Return Blender Python and package environment diagnostics."""
+    try:
+        import bpy
+
+        blender = {
+            "version": getattr(bpy.app, "version_string", None),
+            "version_tuple": list(getattr(bpy.app, "version", ())),
+            "binary_path": getattr(bpy.app, "binary_path", None),
+            "background": bool(getattr(bpy.app, "background", False)),
+        }
+    except ImportError:
+        blender = {"available": False}
+
+    context = {
+        "python_version": sys.version,
+        "python_executable": sys.executable,
+        "prefix": sys.prefix,
+        "base_prefix": getattr(sys, "base_prefix", None),
+        "platform": platform.platform(),
+        "packages": _package_versions(),
+        "blender": blender,
+    }
+    if include_sys_path:
+        context["sys_path"] = list(sys.path)
+    return skill_success("Python environment retrieved", **context)

--- a/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
@@ -26,6 +26,7 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | `blender-camera` | shot, layout, render | Create cameras, set the active camera, edit camera properties, and list cameras. | Load when view, shot, or render framing is requested. | Mutating except camera listing. | camera, lens, active camera, shot, framing |
 | `blender-lighting` | lookdev, render | Create lights, edit light properties, list lights, and set world background. | Load when visibility or render quality depends on lighting. | Mutating except light listing. | light, world background, sun, area light, exposure |
 | `blender-render` | render, diagnostics, delivery | Configure renders, render scenes, inspect render settings, and capture viewport images. | Load after scene/camera/lighting setup when output is needed. | Disk/output producing; read-only for render info. | render, viewport capture, image output, resolution |
+| `blender-dev` | diagnostics, development | Inspect add-ons, Python environment, structured UI metadata, module reloads, debug listeners, and development entrypoints. | Load for adapter/add-on debugging before falling back to arbitrary scripting; avoid for normal scene authoring. | Mixed: read-only diagnostics plus explicit development code execution, path mutation, module reload, and add-on enable/disable. | addon diagnostics, reload modules, run check, debug server, UI snapshot, Python environment |
 | `blender-scripting` | diagnostics, escape hatch | Execute Python snippets or script files and inspect Blender runtime info. | Load last, after checking typed skills and only when custom logic is required. | Potentially arbitrary; use with explicit user intent. | python, script, custom, escape hatch, blender info |
 
 ## Common Task Chains
@@ -45,6 +46,7 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | Shot and render delivery | `blender-camera` -> `blender-lighting` -> `blender-render` |
 | File interchange | `blender-scene` -> `blender-interchange` -> `blender-export-preset` when settings repeat |
 | Shot delivery | `blender-camera` -> `blender-animation` -> `blender-shot-export` -> `blender-interchange` |
+| Add-on diagnostics | `blender-dev` -> `blender-scripting` only when no diagnostic helper fits |
 | Custom fallback | Typed domain skill -> `blender-scripting` only for the missing operation |
 
 ## Loading Guidance
@@ -54,5 +56,6 @@ This index helps agents choose typed Blender skills before falling back to raw P
 - Load authoring skills only when the requested task enters that domain; prefer `blender-mesh-ops` for topology, `blender-mesh` for modifiers, and `blender-rigging`/`blender-pose-library` for character setup.
 - Use `blender-shader-nodes` for graph-level socket/link edits; use `blender-materials` when material slots or simple colors are enough, and `blender-geometry-nodes` when the workflow is about modifier assignment or exposed procedural inputs.
 - Use `blender-interchange` and `blender-shot-export` for import/export and delivery before writing custom Python exporters.
+- Use `blender-dev` for add-on/runtime diagnostics, structured UI metadata, module reloads, and reproducible development entrypoints before reaching for arbitrary Python.
 - Keep `blender-scripting` as the final escape hatch; mention which typed skills were checked first.
 - Treat disk-writing, render, and scripting tools as higher-risk operations and ask for explicit paths or intent when needed.

--- a/src/dcc_mcp_blender/skills/blender-dev/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-dev/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: blender-dev
+description: "Blender add-on development diagnostics, reloads, UI metadata, and environment checks"
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, development, diagnostics, addon, reload, ui, debug]
+    search-hint: "addon diagnostics, reload modules, run check, development, debug server, UI snapshot, Python environment"
+    tools: tools.yaml
+---
+
+# blender-dev
+
+Development-only diagnostics for Blender add-ons and adapter debugging.
+
+Prefer typed domain skills for scene authoring. Use this skill when you need to
+inspect add-on state, attach a checkout to `sys.path`, reload development
+modules, run a named diagnostic check, inspect structured UI metadata, or start
+an optional `debugpy` listener. Code execution helpers can run arbitrary Python
+inside Blender and should be used only for explicit development or test flows.

--- a/src/dcc_mcp_blender/skills/blender-dev/scripts/attach_project.py
+++ b/src/dcc_mcp_blender/skills/blender-dev/scripts/attach_project.py
@@ -1,0 +1,17 @@
+"""Attach a project checkout to Blender's Python path."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._dev_ops import attach_project
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`attach_project`."""
+    return attach_project(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-dev/scripts/capture_ui_snapshot.py
+++ b/src/dcc_mcp_blender/skills/blender-dev/scripts/capture_ui_snapshot.py
@@ -1,0 +1,17 @@
+"""Capture structured Blender UI metadata."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._dev_ops import capture_ui_snapshot
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`capture_ui_snapshot`."""
+    return capture_ui_snapshot(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-dev/scripts/disable_addon.py
+++ b/src/dcc_mcp_blender/skills/blender-dev/scripts/disable_addon.py
@@ -1,0 +1,17 @@
+"""Disable a Blender add-on for development checks."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._dev_ops import disable_addon
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`disable_addon`."""
+    return disable_addon(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-dev/scripts/enable_addon.py
+++ b/src/dcc_mcp_blender/skills/blender-dev/scripts/enable_addon.py
@@ -1,0 +1,17 @@
+"""Enable a Blender add-on for development checks."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._dev_ops import enable_addon
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`enable_addon`."""
+    return enable_addon(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-dev/scripts/find_ui_elements.py
+++ b/src/dcc_mcp_blender/skills/blender-dev/scripts/find_ui_elements.py
@@ -1,0 +1,17 @@
+"""Find structured Blender UI metadata entries."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._dev_ops import find_ui_elements
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`find_ui_elements`."""
+    return find_ui_elements(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-dev/scripts/get_addon_status.py
+++ b/src/dcc_mcp_blender/skills/blender-dev/scripts/get_addon_status.py
@@ -1,0 +1,17 @@
+"""Get structured Blender add-on status."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._dev_ops import get_addon_status
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_addon_status`."""
+    return get_addon_status(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-dev/scripts/get_python_environment.py
+++ b/src/dcc_mcp_blender/skills/blender-dev/scripts/get_python_environment.py
@@ -1,0 +1,17 @@
+"""Get Blender Python environment diagnostics."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._dev_ops import get_python_environment
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_python_environment`."""
+    return get_python_environment(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-dev/scripts/list_addons.py
+++ b/src/dcc_mcp_blender/skills/blender-dev/scripts/list_addons.py
@@ -1,0 +1,17 @@
+"""List Blender add-ons and development status."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._dev_ops import list_addons
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_addons`."""
+    return list_addons(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-dev/scripts/reload_modules.py
+++ b/src/dcc_mcp_blender/skills/blender-dev/scripts/reload_modules.py
@@ -1,0 +1,17 @@
+"""Reload Python modules during Blender add-on development."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._dev_ops import reload_modules
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`reload_modules`."""
+    return reload_modules(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-dev/scripts/run_check.py
+++ b/src/dcc_mcp_blender/skills/blender-dev/scripts/run_check.py
@@ -1,0 +1,17 @@
+"""Run a named Blender development diagnostic check."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._dev_ops import run_check
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`run_check`."""
+    return run_check(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-dev/scripts/run_entrypoint.py
+++ b/src/dcc_mcp_blender/skills/blender-dev/scripts/run_entrypoint.py
@@ -1,0 +1,17 @@
+"""Run a Python module entrypoint for Blender add-on diagnostics."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._dev_ops import run_entrypoint
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`run_entrypoint`."""
+    return run_entrypoint(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-dev/scripts/run_script.py
+++ b/src/dcc_mcp_blender/skills/blender-dev/scripts/run_script.py
@@ -1,0 +1,17 @@
+"""Run a Python script file for Blender add-on diagnostics."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._dev_ops import run_script
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`run_script`."""
+    return run_script(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-dev/scripts/start_debug_server.py
+++ b/src/dcc_mcp_blender/skills/blender-dev/scripts/start_debug_server.py
@@ -1,0 +1,17 @@
+"""Start an optional debugpy server for Blender development."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._dev_ops import start_debug_server
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`start_debug_server`."""
+    return start_debug_server(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-dev/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-dev/tools.yaml
@@ -1,0 +1,460 @@
+tools:
+  - name: attach_project
+    description: "Attach a project checkout and optional extra paths to Blender's sys.path."
+    source_file: scripts/attach_project.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [project_root]
+      properties:
+        project_root:
+          type: string
+          minLength: 1
+        extra_paths:
+          type: array
+          items:
+            type: string
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true
+
+  - name: reload_modules
+    description: "Reload explicit Python modules or loaded modules matching a package prefix."
+    source_file: scripts/reload_modules.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 30
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        module_names:
+          type: array
+          items:
+            type: string
+        package_prefix:
+          type: string
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: true
+
+  - name: run_check
+    description: "Run a named in-process development diagnostic check with a timeout."
+    source_file: scripts/run_check.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 30
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [command_name]
+      properties:
+        command_name:
+          type: string
+          enum: [import_module, python_environment, addon_status, sleep]
+        args:
+          type: object
+          additionalProperties: true
+        timeout_secs:
+          type: number
+          default: 30
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: true
+
+  - name: run_entrypoint
+    description: "Import a module and call a named function for reproducible development checks."
+    source_file: scripts/run_entrypoint.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 30
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [module, function]
+      properties:
+        module:
+          type: string
+          minLength: 1
+        function:
+          type: string
+          minLength: 1
+        args:
+          description: JSON value passed as kwargs for objects, positional args for arrays, or one argument otherwise.
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: true
+
+  - name: run_script
+    description: "Run a Python script file inside Blender for explicit development/test entrypoints."
+    source_file: scripts/run_script.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 30
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [path]
+      properties:
+        path:
+          type: string
+          minLength: 1
+        args:
+          description: JSON value exposed to the script as ARGS; arrays also populate sys.argv.
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: true
+
+  - name: list_addons
+    description: "List Blender add-ons with installed, loaded, enabled, and metadata state."
+    source_file: scripts/list_addons.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        filter:
+          type: string
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: get_addon_status
+    description: "Return structured status for one Blender add-on module."
+    source_file: scripts/get_addon_status.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [addon_module]
+      properties:
+        addon_module:
+          type: string
+          minLength: 1
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: enable_addon
+    description: "Enable a Blender add-on and return before/after state."
+    source_file: scripts/enable_addon.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 30
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [addon_module]
+      properties:
+        addon_module:
+          type: string
+          minLength: 1
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: disable_addon
+    description: "Disable a Blender add-on and return before/after state."
+    source_file: scripts/disable_addon.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 30
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [addon_module]
+      properties:
+        addon_module:
+          type: string
+          minLength: 1
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: capture_ui_snapshot
+    description: "Capture structured Blender UI/window/screen metadata without screenshots."
+    source_file: scripts/capture_ui_snapshot.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        area_filter:
+          type: string
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: find_ui_elements
+    description: "Find screen, area, region, and space metadata matching a UI query."
+    source_file: scripts/find_ui_elements.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [query]
+      properties:
+        query:
+          type: string
+          minLength: 1
+        area_filter:
+          type: string
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: start_debug_server
+    description: "Start an optional debugpy listener for Blender development debugging."
+    source_file: scripts/start_debug_server.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 30
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        host:
+          type: string
+          default: "127.0.0.1"
+        port:
+          type: integer
+          default: 5678
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true
+
+  - name: get_python_environment
+    description: "Return Blender Python, sys.path, platform, and package environment diagnostics."
+    source_file: scripts/get_python_environment.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        include_sys_path:
+          type: boolean
+          default: true
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false

--- a/tests/e2e/test_dev_diagnostics_e2e.py
+++ b/tests/e2e/test_dev_diagnostics_e2e.py
@@ -1,0 +1,29 @@
+"""E2E tests for Blender development diagnostics."""
+
+from __future__ import annotations
+
+import pytest
+
+bpy = pytest.importorskip("bpy", reason="bpy not available - run inside Blender Python interpreter")
+
+pytestmark = pytest.mark.e2e
+
+from tests.e2e.conftest import load_skill  # noqa: E402
+
+
+class TestDevDiagnosticsE2E:
+    def test_environment_addon_status_and_ui_snapshot(self):
+        env_mod = load_skill("blender-dev", "get_python_environment")
+        env_result = env_mod.get_python_environment(include_sys_path=False)
+        assert env_result["success"] is True
+        assert env_result["context"]["blender"]["version"]
+
+        status_mod = load_skill("blender-dev", "get_addon_status")
+        status_result = status_mod.get_addon_status(addon_module="io_scene_fbx")
+        assert status_result["success"] is True
+        assert status_result["context"]["addon_module"] == "io_scene_fbx"
+
+        snapshot_mod = load_skill("blender-dev", "capture_ui_snapshot")
+        snapshot_result = snapshot_mod.capture_ui_snapshot()
+        assert snapshot_result["success"] is True
+        assert "screens" in snapshot_result["context"]

--- a/tests/test_skills_dev.py
+++ b/tests/test_skills_dev.py
@@ -1,0 +1,235 @@
+"""Unit tests for blender-dev skill scripts."""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+
+from tests.conftest import load_and_call, make_mock_bpy
+
+
+class _Spaces(list):
+    pass
+
+
+def _install_fake_addon_utils(monkeypatch, enabled=False):
+    addon = types.ModuleType("fake_addon")
+    addon.__file__ = "/addons/fake_addon.py"
+    addon.bl_info = {
+        "name": "Fake Addon",
+        "version": (1, 2, 3),
+        "category": "Development",
+        "description": "Fake diagnostics add-on",
+    }
+    state = {"enabled": enabled, "loaded": enabled}
+    addon_utils = types.ModuleType("addon_utils")
+    addon_utils.modules = lambda refresh=False: [addon]
+    addon_utils.check = lambda name: (state["loaded"], state["enabled"]) if name == "fake_addon" else (False, False)
+    addon_utils.module_bl_info = lambda module: getattr(module, "bl_info", {})
+    monkeypatch.setitem(sys.modules, "addon_utils", addon_utils)
+    return state
+
+
+class TestDevPathAndReload:
+    def test_attach_project_adds_existing_path(self, tmp_path, monkeypatch):
+        original_path = list(sys.path)
+        monkeypatch.setattr(sys, "path", list(original_path))
+
+        result = load_and_call(
+            "blender-dev/scripts/attach_project.py",
+            make_mock_bpy(),
+            project_root=str(tmp_path),
+        )
+
+        assert result["success"] is True
+        assert str(tmp_path.resolve()) in result["context"]["added"]
+        assert sys.path[0] == str(tmp_path.resolve())
+
+    def test_reload_modules_reloads_loaded_module(self):
+        result = load_and_call(
+            "blender-dev/scripts/reload_modules.py",
+            make_mock_bpy(),
+            module_names=["json"],
+        )
+
+        assert result["success"] is True
+        assert "json" in result["context"]["reloaded"] or "json" in result["context"]["imported"]
+
+
+class TestDevChecks:
+    def test_run_check_reports_unknown_command(self):
+        result = load_and_call(
+            "blender-dev/scripts/run_check.py",
+            make_mock_bpy(),
+            command_name="missing",
+        )
+
+        assert result["success"] is False
+        assert "available" in result["context"]
+
+    def test_run_check_timeout_returns_failure_envelope(self):
+        result = load_and_call(
+            "blender-dev/scripts/run_check.py",
+            make_mock_bpy(),
+            command_name="sleep",
+            args={"seconds": 0.2},
+            timeout_secs=0.01,
+        )
+
+        assert result["success"] is False
+        assert result["context"]["command_name"] == "sleep"
+        assert "timed out" in result["message"].lower()
+
+    def test_run_check_import_module_succeeds(self):
+        result = load_and_call(
+            "blender-dev/scripts/run_check.py",
+            make_mock_bpy(),
+            command_name="import_module",
+            args={"module": "json"},
+        )
+
+        assert result["success"] is True
+        assert result["context"]["module"] == "json"
+
+
+class TestDevEntrypoints:
+    def test_run_entrypoint_calls_function_with_args(self):
+        result = load_and_call(
+            "blender-dev/scripts/run_entrypoint.py",
+            make_mock_bpy(),
+            module="math",
+            function="pow",
+            args=[2, 3],
+        )
+
+        assert result["success"] is True
+        assert result["context"]["result"] == 8.0
+
+    def test_run_script_returns_stdout_and_result(self, tmp_path):
+        script = tmp_path / "check.py"
+        script.write_text("print('dev check')\nresult = {'ok': True, 'args': ARGS}\n", encoding="utf-8")
+
+        result = load_and_call(
+            "blender-dev/scripts/run_script.py",
+            make_mock_bpy(),
+            path=str(script),
+            args=["--quick"],
+        )
+
+        assert result["success"] is True
+        assert "dev check" in result["context"]["stdout"]
+        assert result["context"]["result"]["ok"] is True
+
+
+class TestAddonDiagnostics:
+    def test_get_addon_status_returns_structured_state(self, monkeypatch):
+        _install_fake_addon_utils(monkeypatch, enabled=True)
+
+        result = load_and_call(
+            "blender-dev/scripts/get_addon_status.py",
+            make_mock_bpy(),
+            addon_module="fake_addon",
+        )
+
+        assert result["success"] is True
+        assert result["context"]["installed"] is True
+        assert result["context"]["enabled"] is True
+        assert result["context"]["name"] == "Fake Addon"
+
+    def test_enable_addon_returns_before_after_state(self, monkeypatch):
+        state = _install_fake_addon_utils(monkeypatch, enabled=False)
+        bpy = make_mock_bpy()
+
+        def _enable(module):
+            assert module == "fake_addon"
+            state.update({"enabled": True, "loaded": True})
+
+        bpy.ops.preferences.addon_enable.side_effect = _enable
+
+        result = load_and_call(
+            "blender-dev/scripts/enable_addon.py",
+            bpy,
+            addon_module="fake_addon",
+        )
+
+        assert result["success"] is True
+        assert result["context"]["before"]["enabled"] is False
+        assert result["context"]["after"]["enabled"] is True
+
+    def test_disable_addon_returns_before_after_state(self, monkeypatch):
+        state = _install_fake_addon_utils(monkeypatch, enabled=True)
+        bpy = make_mock_bpy()
+
+        def _disable(module):
+            assert module == "fake_addon"
+            state.update({"enabled": False, "loaded": False})
+
+        bpy.ops.preferences.addon_disable.side_effect = _disable
+
+        result = load_and_call(
+            "blender-dev/scripts/disable_addon.py",
+            bpy,
+            addon_module="fake_addon",
+        )
+
+        assert result["success"] is True
+        assert result["context"]["before"]["enabled"] is True
+        assert result["context"]["after"]["enabled"] is False
+
+    def test_list_addons_filters_by_name(self, monkeypatch):
+        _install_fake_addon_utils(monkeypatch, enabled=True)
+
+        result = load_and_call(
+            "blender-dev/scripts/list_addons.py",
+            make_mock_bpy(),
+            filter="fake",
+        )
+
+        assert result["success"] is True
+        assert result["context"]["count"] == 1
+        assert result["context"]["addons"][0]["addon_module"] == "fake_addon"
+
+
+class TestUiDiagnostics:
+    def test_capture_ui_snapshot_returns_structured_metadata(self):
+        bpy = make_mock_bpy(app_attrs={"background": False})
+        spaces = _Spaces([SimpleNamespace(type="VIEW_3D")])
+        spaces.active = spaces[0]
+        area = SimpleNamespace(type="VIEW_3D", regions=[SimpleNamespace(type="WINDOW")], spaces=spaces)
+        screen = SimpleNamespace(name="Layout", areas=[area])
+        bpy.data.screens = [screen]
+        bpy.context.window_manager.windows = [SimpleNamespace(screen=screen)]
+
+        result = load_and_call("blender-dev/scripts/capture_ui_snapshot.py", bpy)
+
+        assert result["success"] is True
+        assert result["context"]["window_count"] == 1
+        assert result["context"]["screens"][0]["areas"][0]["area_type"] == "VIEW_3D"
+
+    def test_find_ui_elements_searches_structured_metadata(self):
+        bpy = make_mock_bpy(app_attrs={"background": False})
+        spaces = _Spaces([SimpleNamespace(type="NODE_EDITOR")])
+        spaces.active = spaces[0]
+        area = SimpleNamespace(type="NODE_EDITOR", regions=[SimpleNamespace(type="WINDOW")], spaces=spaces)
+        bpy.data.screens = [SimpleNamespace(name="Compositing", areas=[area])]
+
+        result = load_and_call("blender-dev/scripts/find_ui_elements.py", bpy, query="node")
+
+        assert result["success"] is True
+        assert result["context"]["count"] >= 1
+
+
+class TestEnvironmentDiagnostics:
+    def test_get_python_environment_reports_blender_context(self):
+        bpy = make_mock_bpy(app_attrs={"version_string": "4.4.3", "background": True})
+
+        result = load_and_call(
+            "blender-dev/scripts/get_python_environment.py",
+            bpy,
+            include_sys_path=False,
+        )
+
+        assert result["success"] is True
+        assert result["context"]["blender"]["version"] == "4.4.3"
+        assert "sys_path" not in result["context"]


### PR DESCRIPTION
## Summary
- Add a `blender-dev` bundled skill for add-on diagnostics, module reloads, named checks, development entrypoints, structured UI metadata, optional debug server startup, and Python environment inspection
- Add shared dev helpers with structured success/error envelopes for add-on state, command failures, and timeout handling
- Document when to use `blender-dev` versus domain skills or raw scripting, with unit and Blender E2E coverage

## Validation
- python -m ruff check src tests packaging
- python -m ruff format --check src tests packaging
- python tools/lint_skills.py --warnings-as-errors
- python -m pytest tests\ -q
- Blender 4.4 background E2E suite
- HTTP MCP smoke: 190 tools discovered; get_python_environment, get_addon_status, and capture_ui_snapshot succeeded
- python -m build
- python packaging/assemble_zip.py --platform win64 --output-dir dist_addon

Closes #41