### PR TITLE
feat: add blender asset validation pipeline tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@
 | **blender-interchange** | `import_file`, `import_fbx`, `import_obj`, `export_gltf`, `export_usd`, `export_alembic`, `batch_export` |
 | **blender-export-preset** | `list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset` |
 | **blender-shot-export** | `get_shot_info`, `export_camera` |
+| **blender-validation** | `run_scene_checks`, `validate_mesh`, `validate_materials`, `validate_animation`, `validate_export_readiness`, `get_validation_report` |
+| **blender-pipeline** | `get_asset_metadata`, `tag_asset_metadata`, `clear_asset_metadata`, `set_project_context`, `create_publish_manifest`, `prepare_publish_package` |
 | **blender-materials** | `create_material`, `assign_material`, `set_material_color`, `list_materials`, `delete_material` |
 | **blender-shader-nodes** | `list_material_nodes`, `set_principled_input`, `list_node_trees`, `list_nodes`, `create_node`, `delete_node`, `list_node_sockets`, `connect_nodes`, `disconnect_nodes`, `list_node_links`, `set_node_input`, `get_node_value`, `create_material_with_nodes`, `assign_texture_node`, `set_principled_inputs` |
 | **blender-render** | `render_scene`, `set_render_settings`, `get_render_info`, `capture_viewport` |

--- a/src/dcc_mcp_blender/_asset_pipeline_ops.py
+++ b/src/dcc_mcp_blender/_asset_pipeline_ops.py
@@ -1,0 +1,675 @@
+"""Blender asset validation and local publish pipeline helpers."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
+
+ASSET_METADATA_KEY = "dcc_mcp_asset_metadata"
+PROJECT_CONTEXT_KEY = "dcc_mcp_project_context"
+SUPPORTED_EXPORT_FORMATS = {"fbx", "obj", "gltf", "glb", "usd", "usda", "usdc", "abc", "blend"}
+
+_REPORTS: Dict[str, Dict[str, Any]] = {}
+_LATEST_REPORT_ID: Optional[str] = None
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _issue(
+    code: str,
+    severity: str,
+    message: str,
+    object_name: Optional[str] = None,
+    details: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    item = {
+        "code": code,
+        "severity": severity,
+        "message": message,
+    }
+    if object_name is not None:
+        item["object_name"] = object_name
+    if details:
+        item["details"] = details
+    return item
+
+
+def _issue_counts(issues: List[Dict[str, Any]]) -> Dict[str, int]:
+    counts = {"info": 0, "warning": 0, "error": 0}
+    for issue in issues:
+        severity = issue.get("severity", "info")
+        counts[severity] = counts.get(severity, 0) + 1
+    return counts
+
+
+def _make_report(
+    report_type: str,
+    issues: List[Dict[str, Any]],
+    checked_objects: Optional[List[str]] = None,
+    context: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    global _LATEST_REPORT_ID
+
+    counts = _issue_counts(issues)
+    report = {
+        "report_id": str(uuid.uuid4()),
+        "report_type": report_type,
+        "created_at": _now(),
+        "passed": counts.get("error", 0) == 0,
+        "counts": counts,
+        "issues": issues,
+        "checked_objects": checked_objects or [],
+        "context": context or {},
+    }
+    _REPORTS[report["report_id"]] = report
+    _LATEST_REPORT_ID = report["report_id"]
+    return report
+
+
+def _len_or_zero(value: Any) -> int:
+    try:
+        return len(value)
+    except Exception:
+        return 0
+
+
+def _iter_or_empty(value: Any) -> Iterable[Any]:
+    if value is None:
+        return []
+    try:
+        return list(value)
+    except TypeError:
+        return []
+
+
+def _objects(bpy) -> List[Any]:
+    return list(_iter_or_empty(getattr(bpy.data, "objects", [])))
+
+
+def _object_named(bpy, object_name: str) -> Any:
+    return bpy.data.objects.get(object_name)
+
+
+def _object_name(obj: Any) -> str:
+    return str(getattr(obj, "name", ""))
+
+
+def _objects_for_names(bpy, object_names: Optional[List[str]]) -> Tuple[List[Any], List[Dict[str, Any]]]:
+    if not object_names:
+        return _objects(bpy), []
+
+    found = []
+    issues = []
+    for name in object_names:
+        obj = _object_named(bpy, name)
+        if obj is None:
+            issues.append(_issue("OBJECT_MISSING", "error", f"Object not found: {name}", object_name=name))
+            continue
+        found.append(obj)
+    return found, issues
+
+
+def _mesh_stats(obj: Any) -> Dict[str, int]:
+    data = getattr(obj, "data", None)
+    return {
+        "vertices": _len_or_zero(getattr(data, "vertices", [])),
+        "edges": _len_or_zero(getattr(data, "edges", [])),
+        "polygons": _len_or_zero(getattr(data, "polygons", [])),
+        "materials": _len_or_zero(getattr(data, "materials", [])),
+        "uv_layers": _len_or_zero(getattr(data, "uv_layers", [])),
+    }
+
+
+def _material_slots(obj: Any) -> List[Any]:
+    return list(_iter_or_empty(getattr(obj, "material_slots", [])))
+
+
+def _object_materials(obj: Any) -> List[Any]:
+    data = getattr(obj, "data", None)
+    materials = list(_iter_or_empty(getattr(data, "materials", [])))
+    if materials:
+        return materials
+    return [getattr(slot, "material", None) for slot in _material_slots(obj)]
+
+
+def _custom_get(target: Any, key: str, default: Any = None) -> Any:
+    getter = getattr(target, "get", None)
+    if callable(getter):
+        return getter(key, default)
+    try:
+        return target[key]
+    except Exception:
+        return default
+
+
+def _custom_set(target: Any, key: str, value: Any) -> None:
+    try:
+        target[key] = value
+    except Exception:
+        setattr(target, key, value)
+
+
+def _custom_delete(target: Any, key: str) -> None:
+    try:
+        del target[key]
+    except Exception:
+        if hasattr(target, key):
+            delattr(target, key)
+
+
+def _load_json_prop(target: Any, key: str) -> Dict[str, Any]:
+    raw = _custom_get(target, key, None)
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        return dict(raw)
+    try:
+        data = json.loads(str(raw))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _store_json_prop(target: Any, key: str, value: Dict[str, Any]) -> None:
+    _custom_set(target, key, json.dumps(value, sort_keys=True))
+
+
+def _visibility(obj: Any) -> Dict[str, Any]:
+    hidden = None
+    hide_get = getattr(obj, "hide_get", None)
+    if callable(hide_get):
+        try:
+            hidden = bool(hide_get())
+        except Exception:
+            hidden = None
+    if hidden is None:
+        hidden = bool(getattr(obj, "hide_viewport", False))
+    return {
+        "hidden": hidden,
+        "hide_viewport": bool(getattr(obj, "hide_viewport", False)),
+        "hide_render": bool(getattr(obj, "hide_render", False)),
+    }
+
+
+def _object_summary(obj: Any) -> Dict[str, Any]:
+    return {
+        "name": _object_name(obj),
+        "type": getattr(obj, "type", None),
+        "mesh": _mesh_stats(obj) if getattr(obj, "type", None) == "MESH" else {},
+        "visibility": _visibility(obj),
+        "metadata": _load_json_prop(obj, ASSET_METADATA_KEY),
+    }
+
+
+def _safe_json_path(output_path: str) -> Tuple[Optional[Path], Optional[dict]]:
+    raw = str(output_path or "").strip()
+    if not raw:
+        return None, skill_error("Missing output path", "Pass a local JSON output path.")
+    if "://" in raw or raw.startswith("\\\\"):
+        return None, skill_error("Unsafe output path", "Use a local filesystem path, not a URL or UNC path.")
+    path = Path(raw).expanduser()
+    if path.suffix.lower() != ".json":
+        path = path.with_suffix(".json")
+    return path.resolve(), None
+
+
+def _safe_output_dir(output_dir: str) -> Tuple[Optional[Path], Optional[dict]]:
+    raw = str(output_dir or "").strip()
+    if not raw:
+        return None, skill_error("Missing output directory", "Pass a local output directory.")
+    if "://" in raw or raw.startswith("\\\\"):
+        return None, skill_error("Unsafe output directory", "Use a local filesystem directory, not a URL or UNC path.")
+    return Path(raw).expanduser().resolve(), None
+
+
+def _project_context(scene: Any) -> Dict[str, Any]:
+    context = _load_json_prop(scene, PROJECT_CONTEXT_KEY)
+    render = getattr(scene, "render", None)
+    unit_settings = getattr(scene, "unit_settings", None)
+    return {
+        "name": context.get("name"),
+        "root": context.get("root"),
+        "unit_scale": context.get("unit_scale", getattr(unit_settings, "scale_length", None)),
+        "frame_rate": context.get("frame_rate", getattr(render, "fps", None)),
+        "metadata": context.get("metadata", {}),
+    }
+
+
+def validate_mesh(object_name: str, rules: Optional[Dict[str, Any]] = None) -> dict:
+    """Validate one mesh object and store a structured report."""
+    try:
+        import bpy
+
+        rules = rules or {}
+        obj = _object_named(bpy, object_name)
+        issues: List[Dict[str, Any]] = []
+        if obj is None:
+            issues.append(_issue("OBJECT_MISSING", "error", f"Object not found: {object_name}", object_name))
+            report = _make_report("mesh", issues, [object_name], {"rules": rules})
+            return skill_success("Mesh validation completed", report=report)
+        if getattr(obj, "type", None) != "MESH":
+            issues.append(_issue("OBJECT_NOT_MESH", "error", f"{object_name} is not a mesh object.", object_name))
+            report = _make_report("mesh", issues, [object_name], {"rules": rules})
+            return skill_success("Mesh validation completed", report=report)
+
+        stats = _mesh_stats(obj)
+        if stats["vertices"] == 0:
+            issues.append(_issue("MESH_NO_VERTICES", "error", "Mesh has no vertices.", object_name))
+        if stats["polygons"] == 0:
+            issues.append(_issue("MESH_NO_FACES", "warning", "Mesh has no polygons.", object_name))
+        max_polygons = rules.get("max_polygons")
+        if max_polygons is not None and stats["polygons"] > int(max_polygons):
+            issues.append(
+                _issue(
+                    "MESH_TOO_MANY_POLYGONS",
+                    "warning",
+                    f"Mesh has {stats['polygons']} polygons, above limit {max_polygons}.",
+                    object_name,
+                    {"polygons": stats["polygons"], "max_polygons": int(max_polygons)},
+                )
+            )
+        if rules.get("require_uvs") and stats["uv_layers"] == 0:
+            issues.append(_issue("MESH_MISSING_UVS", "warning", "Mesh has no UV layers.", object_name))
+        if rules.get("require_materials") and stats["materials"] == 0:
+            issues.append(_issue("MESH_MISSING_MATERIALS", "warning", "Mesh has no assigned materials.", object_name))
+
+        if not issues:
+            issues.append(_issue("MESH_VALID", "info", "Mesh validation passed.", object_name, stats))
+        report = _make_report("mesh", issues, [object_name], {"rules": rules, "mesh": stats})
+        return skill_success("Mesh validation completed", report=report)
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to validate mesh {object_name}")
+
+
+def validate_materials(object_names: Optional[List[str]] = None, rules: Optional[Dict[str, Any]] = None) -> dict:
+    """Validate material assignments for scene objects."""
+    try:
+        import bpy
+
+        rules = rules or {}
+        objects, issues = _objects_for_names(bpy, object_names)
+        for obj in objects:
+            name = _object_name(obj)
+            if getattr(obj, "type", None) != "MESH":
+                continue
+            materials = _object_materials(obj)
+            assigned = [material for material in materials if material is not None]
+            if rules.get("require_materials", True) and not assigned:
+                issues.append(_issue("MATERIALS_MISSING", "warning", "Mesh has no assigned materials.", name))
+            for index, material in enumerate(materials):
+                if material is None:
+                    issues.append(
+                        _issue(
+                            "MATERIAL_SLOT_EMPTY", "warning", f"Material slot {index} is empty.", name, {"slot": index}
+                        )
+                    )
+                    continue
+                if rules.get("require_nodes") and not bool(getattr(material, "use_nodes", False)):
+                    issues.append(
+                        _issue(
+                            "MATERIAL_NODES_DISABLED",
+                            "warning",
+                            f"Material {getattr(material, 'name', '<unnamed>')} does not use nodes.",
+                            name,
+                        )
+                    )
+        if not issues:
+            issues.append(_issue("MATERIALS_VALID", "info", "Material validation passed."))
+        report = _make_report("materials", issues, [_object_name(obj) for obj in objects], {"rules": rules})
+        return skill_success("Material validation completed", report=report)
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to validate materials")
+
+
+def validate_animation(
+    object_names: Optional[List[str]] = None,
+    frame_range: Optional[List[int]] = None,
+    rules: Optional[Dict[str, Any]] = None,
+) -> dict:
+    """Validate animation data and frame ranges."""
+    try:
+        import bpy
+
+        rules = rules or {}
+        objects, issues = _objects_for_names(bpy, object_names)
+        scene = bpy.context.scene
+        start = int(frame_range[0]) if frame_range else int(getattr(scene, "frame_start", 1))
+        end = int(frame_range[1]) if frame_range and len(frame_range) > 1 else int(getattr(scene, "frame_end", start))
+        if start > end:
+            issues.append(_issue("ANIMATION_FRAME_RANGE_INVALID", "error", "Frame range start is after end."))
+
+        require_keyframes = bool(rules.get("require_keyframes", False))
+        for obj in objects:
+            name = _object_name(obj)
+            action = getattr(getattr(obj, "animation_data", None), "action", None)
+            fcurves = list(_iter_or_empty(getattr(action, "fcurves", []))) if action is not None else []
+            keyframe_count = sum(_len_or_zero(getattr(fcurve, "keyframe_points", [])) for fcurve in fcurves)
+            if require_keyframes and keyframe_count == 0:
+                issues.append(_issue("ANIMATION_MISSING_KEYFRAMES", "warning", "Object has no keyframes.", name))
+            for fcurve in fcurves:
+                for point in _iter_or_empty(getattr(fcurve, "keyframe_points", [])):
+                    co = getattr(point, "co", [0])
+                    try:
+                        frame = float(co[0])
+                    except Exception:
+                        frame = 0.0
+                    if frame < start or frame > end:
+                        issues.append(
+                            _issue(
+                                "ANIMATION_KEYFRAME_OUT_OF_RANGE",
+                                "warning",
+                                f"Keyframe at frame {frame:g} is outside the validation range.",
+                                name,
+                                {"frame": frame, "frame_start": start, "frame_end": end},
+                            )
+                        )
+        if not issues:
+            issues.append(_issue("ANIMATION_VALID", "info", "Animation validation passed."))
+        report = _make_report(
+            "animation",
+            issues,
+            [_object_name(obj) for obj in objects],
+            {"frame_start": start, "frame_end": end, "rules": rules},
+        )
+        return skill_success("Animation validation completed", report=report)
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to validate animation")
+
+
+def validate_export_readiness(
+    object_names: List[str],
+    target_format: str,
+    preset_name: Optional[str] = None,
+    rules: Optional[Dict[str, Any]] = None,
+) -> dict:
+    """Validate selected objects for local export/publish readiness."""
+    try:
+        import bpy
+
+        rules = rules or {}
+        target = str(target_format).lower().lstrip(".")
+        objects, issues = _objects_for_names(bpy, object_names)
+        if target not in SUPPORTED_EXPORT_FORMATS:
+            issues.append(
+                _issue(
+                    "EXPORT_FORMAT_UNSUPPORTED",
+                    "error",
+                    f"Unsupported export format: {target_format}",
+                    details={"supported_formats": sorted(SUPPORTED_EXPORT_FORMATS)},
+                )
+            )
+        for obj in objects:
+            name = _object_name(obj)
+            if not name.strip():
+                issues.append(_issue("EXPORT_OBJECT_NAME_EMPTY", "error", "Object has an empty name."))
+            if _visibility(obj).get("hide_render") and rules.get("warn_hidden_render", True):
+                issues.append(_issue("EXPORT_OBJECT_HIDE_RENDER", "warning", "Object is hidden from renders.", name))
+            if getattr(obj, "type", None) == "MESH":
+                stats = _mesh_stats(obj)
+                if stats["vertices"] == 0:
+                    issues.append(_issue("EXPORT_MESH_EMPTY", "error", "Mesh has no vertices.", name))
+        if not objects and not issues:
+            issues.append(_issue("EXPORT_NO_OBJECTS", "error", "No objects were selected for export validation."))
+        if not issues:
+            issues.append(_issue("EXPORT_READY", "info", "Export readiness validation passed."))
+        report = _make_report(
+            "export_readiness",
+            issues,
+            [_object_name(obj) for obj in objects]
+            + [name for name in object_names if _object_named(bpy, name) is None],
+            {"target_format": target, "preset_name": preset_name, "rules": rules},
+        )
+        return skill_success("Export readiness validation completed", report=report)
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to validate export readiness")
+
+
+def run_scene_checks(checks: Optional[List[str]] = None, object_names: Optional[List[str]] = None) -> dict:
+    """Run focused scene checks and store an aggregate report."""
+    try:
+        import bpy
+
+        selected_checks = checks or ["objects", "meshes", "materials", "animation"]
+        objects, issues = _objects_for_names(bpy, object_names)
+        if "objects" in selected_checks and not objects:
+            issues.append(_issue("SCENE_NO_OBJECTS", "warning", "Scene has no objects to validate."))
+        if "meshes" in selected_checks:
+            for obj in objects:
+                if getattr(obj, "type", None) == "MESH":
+                    stats = _mesh_stats(obj)
+                    if stats["vertices"] == 0:
+                        issues.append(_issue("MESH_NO_VERTICES", "error", "Mesh has no vertices.", _object_name(obj)))
+        if "materials" in selected_checks:
+            for obj in objects:
+                if getattr(obj, "type", None) == "MESH" and not [m for m in _object_materials(obj) if m is not None]:
+                    issues.append(
+                        _issue("MATERIALS_MISSING", "warning", "Mesh has no assigned materials.", _object_name(obj))
+                    )
+        if "animation" in selected_checks:
+            scene = bpy.context.scene
+            if int(getattr(scene, "frame_start", 1)) > int(getattr(scene, "frame_end", 1)):
+                issues.append(_issue("ANIMATION_FRAME_RANGE_INVALID", "error", "Scene frame range start is after end."))
+        unknown = sorted(set(selected_checks) - {"objects", "meshes", "materials", "animation"})
+        for check in unknown:
+            issues.append(
+                _issue("SCENE_CHECK_UNKNOWN", "warning", f"Unknown scene check: {check}", details={"check": check})
+            )
+        if not issues:
+            issues.append(_issue("SCENE_VALID", "info", "Scene checks passed."))
+        report = _make_report("scene", issues, [_object_name(obj) for obj in objects], {"checks": selected_checks})
+        return skill_success("Scene checks completed", report=report)
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to run scene checks")
+
+
+def get_validation_report(report_id: Optional[str] = None) -> dict:
+    """Return a stored validation report by id, or the latest report."""
+    target_id = report_id or _LATEST_REPORT_ID
+    if not target_id:
+        return skill_error("No validation report available", "Run a validation tool before requesting a report.")
+    report = _REPORTS.get(target_id)
+    if report is None:
+        return skill_error(f"Validation report not found: {target_id}", "No report exists for that id.")
+    return skill_success("Validation report retrieved", report=report)
+
+
+def get_asset_metadata(object_name: Optional[str] = None) -> dict:
+    """Return object asset metadata and project context."""
+    try:
+        import bpy
+
+        if object_name:
+            obj = _object_named(bpy, object_name)
+            if obj is None:
+                return skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+            objects = [obj]
+        else:
+            objects = _objects(bpy)
+        return skill_success(
+            "Asset metadata retrieved",
+            project_context=_project_context(bpy.context.scene),
+            assets=[
+                {"object_name": _object_name(obj), "metadata": _load_json_prop(obj, ASSET_METADATA_KEY)}
+                for obj in objects
+            ],
+            count=len(objects),
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get asset metadata")
+
+
+def tag_asset_metadata(object_name: str, metadata: Dict[str, Any]) -> dict:
+    """Merge asset metadata into one Blender object."""
+    try:
+        import bpy
+
+        obj = _object_named(bpy, object_name)
+        if obj is None:
+            return skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+        if not isinstance(metadata, dict):
+            return skill_error("Invalid metadata", "metadata must be an object.")
+        current = _load_json_prop(obj, ASSET_METADATA_KEY)
+        current.update(metadata)
+        _store_json_prop(obj, ASSET_METADATA_KEY, current)
+        return skill_success("Asset metadata updated", object_name=object_name, metadata=current)
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to tag asset metadata for {object_name}")
+
+
+def clear_asset_metadata(object_name: str, keys: Optional[List[str]] = None) -> dict:
+    """Clear selected asset metadata keys, or all metadata for one object."""
+    try:
+        import bpy
+
+        obj = _object_named(bpy, object_name)
+        if obj is None:
+            return skill_error(f"Object not found: {object_name}", f"No object named '{object_name}'.")
+        current = _load_json_prop(obj, ASSET_METADATA_KEY)
+        if keys:
+            removed = [key for key in keys if key in current]
+            for key in keys:
+                current.pop(key, None)
+            _store_json_prop(obj, ASSET_METADATA_KEY, current)
+        else:
+            removed = sorted(current)
+            _custom_delete(obj, ASSET_METADATA_KEY)
+            current = {}
+        return skill_success("Asset metadata cleared", object_name=object_name, removed=removed, metadata=current)
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to clear asset metadata for {object_name}")
+
+
+def set_project_context(
+    name: Optional[str] = None,
+    root: Optional[str] = None,
+    unit_scale: Optional[float] = None,
+    frame_rate: Optional[int] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> dict:
+    """Store local project context on the current scene."""
+    try:
+        import bpy
+
+        scene = bpy.context.scene
+        current = _load_json_prop(scene, PROJECT_CONTEXT_KEY)
+        if name is not None:
+            current["name"] = name
+        if root is not None:
+            current["root"] = root
+        if unit_scale is not None:
+            current["unit_scale"] = float(unit_scale)
+            unit_settings = getattr(scene, "unit_settings", None)
+            if unit_settings is not None and hasattr(unit_settings, "scale_length"):
+                unit_settings.scale_length = float(unit_scale)
+        if frame_rate is not None:
+            current["frame_rate"] = int(frame_rate)
+            render = getattr(scene, "render", None)
+            if render is not None and hasattr(render, "fps"):
+                render.fps = int(frame_rate)
+        if metadata:
+            current_metadata = current.get("metadata", {})
+            current_metadata.update(metadata)
+            current["metadata"] = current_metadata
+        _store_json_prop(scene, PROJECT_CONTEXT_KEY, current)
+        return skill_success("Project context updated", project_context=_project_context(scene))
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set project context")
+
+
+def _manifest_payload(
+    bpy, object_names: List[str], metadata: Optional[Dict[str, Any]] = None
+) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    objects, issues = _objects_for_names(bpy, object_names)
+    payload = {
+        "schema": "dcc-mcp-blender.publish-manifest.v1",
+        "created_at": _now(),
+        "project_context": _project_context(bpy.context.scene),
+        "metadata": metadata or {},
+        "assets": [_object_summary(obj) for obj in objects],
+        "validation": _make_report(
+            "publish_manifest",
+            issues or [_issue("PUBLISH_MANIFEST_READY", "info", "Publish manifest generated.")],
+            [_object_name(obj) for obj in objects],
+        ),
+    }
+    return payload, issues
+
+
+def create_publish_manifest(
+    object_names: List[str], output_path: str, metadata: Optional[Dict[str, Any]] = None
+) -> dict:
+    """Write a local JSON publish manifest for selected objects."""
+    try:
+        import bpy
+
+        path, error = _safe_json_path(output_path)
+        if error:
+            return error
+        payload, issues = _manifest_payload(bpy, object_names, metadata)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        return skill_success(
+            "Publish manifest created",
+            output_path=str(path),
+            issue_count=len(issues),
+            asset_count=len(payload["assets"]),
+            manifest=payload,
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create publish manifest")
+
+
+def prepare_publish_package(object_names: List[str], output_dir: str, preset_name: Optional[str] = None) -> dict:
+    """Create a local publish package directory with a manifest."""
+    try:
+        import bpy
+
+        package_dir, error = _safe_output_dir(output_dir)
+        if error:
+            return error
+        package_dir.mkdir(parents=True, exist_ok=True)
+        payload, issues = _manifest_payload(bpy, object_names, {"preset_name": preset_name} if preset_name else {})
+        manifest_path = package_dir / "publish_manifest.json"
+        manifest_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        readme_path = package_dir / "README.txt"
+        readme_path.write_text("Local package prepared by dcc-mcp-blender.\n", encoding="utf-8")
+        return skill_success(
+            "Publish package prepared",
+            output_dir=str(package_dir),
+            manifest_path=str(manifest_path),
+            readme_path=str(readme_path),
+            issue_count=len(issues),
+            asset_count=len(payload["assets"]),
+            preset_name=preset_name,
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to prepare publish package")

--- a/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
@@ -16,6 +16,8 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | `blender-interchange` | interchange, pipeline | Import FBX/OBJ files and export GLTF, USD, Alembic, or batch export jobs. | Load when assets move between DCC/game/pipeline formats. | Disk-writing and scene mutation for imports. | import file, import fbx, import obj, export gltf, export usd, export alembic |
 | `blender-export-preset` | interchange, pipeline | Save, list, load, and delete reusable scene-stored export option presets. | Load when export settings need repeatable named presets. | Mutating except preset listing/loading. | export preset, batch export, reusable export options |
 | `blender-shot-export` | interchange, shot | Inspect shot metadata and export camera metadata JSON. | Load for camera, shot, and animation delivery metadata. | Disk-writing except shot info. | shot export, camera metadata, frame range, camera json |
+| `blender-validation` | pipeline, diagnostics | Run scene, mesh, material, animation, and export-readiness checks with severity-coded reports. | Load before export, publish, or package preparation. | Read-only diagnostics. | validation report, scene checks, mesh validation, export readiness, severity |
+| `blender-pipeline` | pipeline, metadata, publish | Manage local asset metadata, project context, publish manifests, and lightweight publish packages. | Load for local publish preparation after validation passes or warnings are accepted. | Metadata mutation and local filesystem writes for manifests/packages. | asset metadata, project context, publish manifest, prepare package |
 | `blender-materials` | authoring, lookdev | Create, assign, edit, list, and delete materials. | Load before shader nodes when material slots or colors are enough. | Mutating except material listing. | material, assign, color, shader base, delete material |
 | `blender-shader-nodes` | authoring, node graph, lookdev | Inspect and edit shader/material node graphs plus shared node tree sockets, links, and values. | Load after materials when node-level shader edits or generic node graph operations are requested. | Mixed: read-only graph inspection plus node/link/socket mutations. | shader nodes, node graph, sockets, links, principled, texture node |
 | `blender-geometry-nodes` | authoring, node graph, procedural | Create Geometry Nodes groups, assign them to modifiers, set exposed inputs, and inspect procedural graph state. | Load for procedural geometry setup, modifier input updates, or geometry node group assignment. | Mixed: modifier/group creation plus read-only graph summaries. | geometry nodes, procedural, node group, modifier input, exposed socket |
@@ -45,6 +47,8 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | Physics setup | `blender-objects` -> `blender-mesh` -> `blender-physics` |
 | Shot and render delivery | `blender-camera` -> `blender-lighting` -> `blender-render` |
 | File interchange | `blender-scene` -> `blender-interchange` -> `blender-export-preset` when settings repeat |
+| Export validation | `blender-validation` -> `blender-interchange` -> `blender-export-preset` |
+| Local publish prep | `blender-validation` -> `blender-pipeline` -> `blender-interchange` when files need export |
 | Shot delivery | `blender-camera` -> `blender-animation` -> `blender-shot-export` -> `blender-interchange` |
 | Add-on diagnostics | `blender-dev` -> `blender-scripting` only when no diagnostic helper fits |
 | Custom fallback | Typed domain skill -> `blender-scripting` only for the missing operation |
@@ -56,6 +60,7 @@ This index helps agents choose typed Blender skills before falling back to raw P
 - Load authoring skills only when the requested task enters that domain; prefer `blender-mesh-ops` for topology, `blender-mesh` for modifiers, and `blender-rigging`/`blender-pose-library` for character setup.
 - Use `blender-shader-nodes` for graph-level socket/link edits; use `blender-materials` when material slots or simple colors are enough, and `blender-geometry-nodes` when the workflow is about modifier assignment or exposed procedural inputs.
 - Use `blender-interchange` and `blender-shot-export` for import/export and delivery before writing custom Python exporters.
+- Use `blender-validation` before interchange/export or publish prep, and use `blender-pipeline` for Blender-native metadata and local manifests/packages.
 - Use `blender-dev` for add-on/runtime diagnostics, structured UI metadata, module reloads, and reproducible development entrypoints before reaching for arbitrary Python.
 - Keep `blender-scripting` as the final escape hatch; mention which typed skills were checked first.
 - Treat disk-writing, render, and scripting tools as higher-risk operations and ask for explicit paths or intent when needed.

--- a/src/dcc_mcp_blender/skills/blender-pipeline/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-pipeline/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: blender-pipeline
+description: "Blender local asset metadata, project context, publish manifests, and package prep"
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, pipeline, metadata, publish, manifest, asset]
+    search-hint: "asset metadata, project context, publish manifest, prepare publish package, local pipeline"
+    tools: tools.yaml
+---
+
+# blender-pipeline
+
+Local-only pipeline helpers for asset metadata and publish preparation.
+
+This first version writes manifests and lightweight package directories on the
+local filesystem only. It deliberately avoids studio-specific paths, service
+names, hostnames, or external publishing integrations.

--- a/src/dcc_mcp_blender/skills/blender-pipeline/scripts/clear_asset_metadata.py
+++ b/src/dcc_mcp_blender/skills/blender-pipeline/scripts/clear_asset_metadata.py
@@ -1,0 +1,17 @@
+"""Clear Blender object asset metadata."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._asset_pipeline_ops import clear_asset_metadata
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`clear_asset_metadata`."""
+    return clear_asset_metadata(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-pipeline/scripts/create_publish_manifest.py
+++ b/src/dcc_mcp_blender/skills/blender-pipeline/scripts/create_publish_manifest.py
@@ -1,0 +1,17 @@
+"""Create a local Blender publish manifest."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._asset_pipeline_ops import create_publish_manifest
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_publish_manifest`."""
+    return create_publish_manifest(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-pipeline/scripts/get_asset_metadata.py
+++ b/src/dcc_mcp_blender/skills/blender-pipeline/scripts/get_asset_metadata.py
@@ -1,0 +1,17 @@
+"""Get Blender asset metadata."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._asset_pipeline_ops import get_asset_metadata
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_asset_metadata`."""
+    return get_asset_metadata(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-pipeline/scripts/prepare_publish_package.py
+++ b/src/dcc_mcp_blender/skills/blender-pipeline/scripts/prepare_publish_package.py
@@ -1,0 +1,17 @@
+"""Prepare a local Blender publish package."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._asset_pipeline_ops import prepare_publish_package
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`prepare_publish_package`."""
+    return prepare_publish_package(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-pipeline/scripts/set_project_context.py
+++ b/src/dcc_mcp_blender/skills/blender-pipeline/scripts/set_project_context.py
@@ -1,0 +1,17 @@
+"""Set Blender project context metadata."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._asset_pipeline_ops import set_project_context
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_project_context`."""
+    return set_project_context(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-pipeline/scripts/tag_asset_metadata.py
+++ b/src/dcc_mcp_blender/skills/blender-pipeline/scripts/tag_asset_metadata.py
@@ -1,0 +1,17 @@
+"""Tag Blender object asset metadata."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._asset_pipeline_ops import tag_asset_metadata
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`tag_asset_metadata`."""
+    return tag_asset_metadata(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-pipeline/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-pipeline/tools.yaml
@@ -1,0 +1,232 @@
+tools:
+  - name: get_asset_metadata
+    description: "Return object asset metadata and scene project context."
+    source_file: scripts/get_asset_metadata.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: tag_asset_metadata
+    description: "Merge metadata into a Blender object's local asset metadata."
+    source_file: scripts/tag_asset_metadata.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name, metadata]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+        metadata:
+          type: object
+          additionalProperties: true
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: clear_asset_metadata
+    description: "Clear selected asset metadata keys, or all metadata for an object."
+    source_file: scripts/clear_asset_metadata.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+        keys:
+          type: array
+          items:
+            type: string
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: set_project_context
+    description: "Store local project context on the current Blender scene."
+    source_file: scripts/set_project_context.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        root:
+          type: string
+        unit_scale:
+          type: number
+        frame_rate:
+          type: integer
+        metadata:
+          type: object
+          additionalProperties: true
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: create_publish_manifest
+    description: "Write a local JSON publish manifest for selected objects."
+    source_file: scripts/create_publish_manifest.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_names, output_path]
+      properties:
+        object_names:
+          type: array
+          minItems: 1
+          items:
+            type: string
+        output_path:
+          type: string
+          minLength: 1
+        metadata:
+          type: object
+          additionalProperties: true
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true
+
+  - name: prepare_publish_package
+    description: "Create a local publish package directory with a manifest."
+    source_file: scripts/prepare_publish_package.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_names, output_dir]
+      properties:
+        object_names:
+          type: array
+          minItems: 1
+          items:
+            type: string
+        output_dir:
+          type: string
+          minLength: 1
+        preset_name:
+          type: string
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true

--- a/src/dcc_mcp_blender/skills/blender-validation/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-validation/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: blender-validation
+description: "Blender scene, mesh, material, animation, and export readiness validation"
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, validation, pipeline, scene-checks, export-readiness]
+    search-hint: "validate scene, validate mesh, material validation, animation validation, export readiness, severity report"
+    tools: tools.yaml
+---
+
+# blender-validation
+
+Typed validation checks for Blender assets before export or publish.
+
+Validation tools return structured reports with stable issue codes and
+`info`/`warning`/`error` severities. Use these checks before interchange/export
+tools or local publish preparation so agents can reason over machine-readable
+failure causes instead of scraping arbitrary script output.

--- a/src/dcc_mcp_blender/skills/blender-validation/scripts/get_validation_report.py
+++ b/src/dcc_mcp_blender/skills/blender-validation/scripts/get_validation_report.py
@@ -1,0 +1,17 @@
+"""Return stored Blender validation reports."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._asset_pipeline_ops import get_validation_report
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_validation_report`."""
+    return get_validation_report(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-validation/scripts/run_scene_checks.py
+++ b/src/dcc_mcp_blender/skills/blender-validation/scripts/run_scene_checks.py
@@ -1,0 +1,17 @@
+"""Run Blender scene validation checks."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._asset_pipeline_ops import run_scene_checks
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`run_scene_checks`."""
+    return run_scene_checks(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-validation/scripts/validate_animation.py
+++ b/src/dcc_mcp_blender/skills/blender-validation/scripts/validate_animation.py
@@ -1,0 +1,17 @@
+"""Validate Blender animation data."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._asset_pipeline_ops import validate_animation
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`validate_animation`."""
+    return validate_animation(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-validation/scripts/validate_export_readiness.py
+++ b/src/dcc_mcp_blender/skills/blender-validation/scripts/validate_export_readiness.py
@@ -1,0 +1,17 @@
+"""Validate Blender export readiness."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._asset_pipeline_ops import validate_export_readiness
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`validate_export_readiness`."""
+    return validate_export_readiness(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-validation/scripts/validate_materials.py
+++ b/src/dcc_mcp_blender/skills/blender-validation/scripts/validate_materials.py
@@ -1,0 +1,17 @@
+"""Validate Blender material assignments."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._asset_pipeline_ops import validate_materials
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`validate_materials`."""
+    return validate_materials(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-validation/scripts/validate_mesh.py
+++ b/src/dcc_mcp_blender/skills/blender-validation/scripts/validate_mesh.py
@@ -1,0 +1,17 @@
+"""Validate a Blender mesh object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._asset_pipeline_ops import validate_mesh
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`validate_mesh`."""
+    return validate_mesh(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-validation/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-validation/tools.yaml
@@ -1,0 +1,231 @@
+tools:
+  - name: run_scene_checks
+    description: "Run focused scene-level validation checks."
+    source_file: scripts/run_scene_checks.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        checks:
+          type: array
+          items:
+            type: string
+        object_names:
+          type: array
+          items:
+            type: string
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: validate_mesh
+    description: "Validate one mesh object against geometry and optional pipeline rules."
+    source_file: scripts/validate_mesh.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+        rules:
+          type: object
+          additionalProperties: true
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: validate_materials
+    description: "Validate material assignments and optional material rules."
+    source_file: scripts/validate_materials.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        object_names:
+          type: array
+          items:
+            type: string
+        rules:
+          type: object
+          additionalProperties: true
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: validate_animation
+    description: "Validate animation frame ranges and optional keyframe requirements."
+    source_file: scripts/validate_animation.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        object_names:
+          type: array
+          items:
+            type: string
+        frame_range:
+          type: array
+          minItems: 2
+          maxItems: 2
+          items:
+            type: integer
+        rules:
+          type: object
+          additionalProperties: true
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: validate_export_readiness
+    description: "Validate selected objects for a target export format."
+    source_file: scripts/validate_export_readiness.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_names, target_format]
+      properties:
+        object_names:
+          type: array
+          minItems: 1
+          items:
+            type: string
+        target_format:
+          type: string
+          minLength: 1
+        preset_name:
+          type: string
+        rules:
+          type: object
+          additionalProperties: true
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: get_validation_report
+    description: "Return a stored validation report by id, or the latest report."
+    source_file: scripts/get_validation_report.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        report_id:
+          type: string
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false

--- a/tests/e2e/test_asset_pipeline_e2e.py
+++ b/tests/e2e/test_asset_pipeline_e2e.py
@@ -1,0 +1,49 @@
+"""E2E tests for Blender validation and local pipeline skills."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+bpy = pytest.importorskip("bpy", reason="bpy not available - run inside Blender Python interpreter")
+
+pytestmark = pytest.mark.e2e
+
+from tests.e2e.conftest import load_skill  # noqa: E402
+
+
+def _new_scene():
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+
+
+class TestAssetPipelineE2E:
+    def setup_method(self):
+        _new_scene()
+
+    def test_validate_scene_and_create_publish_manifest(self):
+        bpy.ops.mesh.primitive_cube_add()
+        cube_name = bpy.context.active_object.name
+
+        tag_mod = load_skill("blender-pipeline", "tag_asset_metadata")
+        tag_result = tag_mod.tag_asset_metadata(cube_name, {"asset_type": "prop", "department": "layout"})
+        assert tag_result["success"] is True
+
+        validate_mod = load_skill("blender-validation", "validate_mesh")
+        validate_result = validate_mod.validate_mesh(cube_name, rules={"require_uvs": False})
+        assert validate_result["success"] is True
+        assert validate_result["context"]["report"]["passed"] is True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = Path(tmp) / "publish_manifest.json"
+            manifest_mod = load_skill("blender-pipeline", "create_publish_manifest")
+            manifest_result = manifest_mod.create_publish_manifest(
+                object_names=[cube_name],
+                output_path=str(manifest_path),
+                metadata={"target": "smoke"},
+            )
+            assert manifest_result["success"] is True
+            payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+            assert payload["assets"][0]["metadata"]["asset_type"] == "prop"

--- a/tests/test_skills_asset_pipeline.py
+++ b/tests/test_skills_asset_pipeline.py
@@ -1,0 +1,259 @@
+"""Unit tests for validation and pipeline skill scripts."""
+
+from __future__ import annotations
+
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tests.conftest import load_and_call, make_mock_bpy
+
+
+class _ObjectCollection(list):
+    def get(self, name):
+        for obj in self:
+            if getattr(obj, "name", None) == name:
+                return obj
+        return None
+
+
+class _FakeScene(dict):
+    def __init__(self):
+        super().__init__()
+        self.frame_start = 1
+        self.frame_end = 24
+        self.render = SimpleNamespace(fps=24)
+        self.unit_settings = SimpleNamespace(scale_length=1.0)
+
+    def get(self, key, default=None):
+        return dict.get(self, key, default)
+
+
+class _FakeObject(dict):
+    def __init__(
+        self,
+        name="Cube",
+        type="MESH",
+        vertices=8,
+        polygons=6,
+        materials=None,
+        uv_layers=1,
+    ):
+        super().__init__()
+        self.name = name
+        self.type = type
+        self.hide_viewport = False
+        self.hide_render = False
+        self.animation_data = None
+        self.data = SimpleNamespace(
+            vertices=[object()] * vertices,
+            edges=[],
+            polygons=[object()] * polygons,
+            materials=materials if materials is not None else [],
+            uv_layers=[object()] * uv_layers,
+        )
+        self.material_slots = [SimpleNamespace(material=material) for material in self.data.materials]
+
+    def get(self, key, default=None):
+        return dict.get(self, key, default)
+
+    def hide_get(self):
+        return self.hide_viewport
+
+
+def _make_bpy(*objects):
+    bpy = make_mock_bpy()
+    bpy.data.objects = _ObjectCollection(objects)
+    bpy.context.scene = _FakeScene()
+    return bpy
+
+
+def _codes(result):
+    return {issue["code"] for issue in result["context"]["report"]["issues"]}
+
+
+class TestValidationSkills:
+    def test_validate_mesh_passes_with_info_report(self):
+        cube = _FakeObject()
+        bpy = _make_bpy(cube)
+
+        result = load_and_call("blender-validation/scripts/validate_mesh.py", bpy, object_name="Cube")
+
+        assert result["success"] is True
+        report = result["context"]["report"]
+        assert report["passed"] is True
+        assert report["counts"]["info"] == 1
+        assert "MESH_VALID" in _codes(result)
+
+    def test_validate_mesh_reports_empty_mesh_error(self):
+        cube = _FakeObject(vertices=0, polygons=0)
+        bpy = _make_bpy(cube)
+
+        result = load_and_call("blender-validation/scripts/validate_mesh.py", bpy, object_name="Cube")
+
+        assert result["success"] is True
+        assert result["context"]["report"]["passed"] is False
+        assert "MESH_NO_VERTICES" in _codes(result)
+
+    def test_validate_materials_reports_missing_object_and_materials(self):
+        cube = _FakeObject()
+        bpy = _make_bpy(cube)
+
+        result = load_and_call(
+            "blender-validation/scripts/validate_materials.py",
+            bpy,
+            object_names=["Cube", "Missing"],
+        )
+
+        assert result["success"] is True
+        assert {"OBJECT_MISSING", "MATERIALS_MISSING"}.issubset(_codes(result))
+
+    def test_validate_export_readiness_reports_unsupported_format(self):
+        cube = _FakeObject()
+        bpy = _make_bpy(cube)
+
+        result = load_and_call(
+            "blender-validation/scripts/validate_export_readiness.py",
+            bpy,
+            object_names=["Cube"],
+            target_format="unknown",
+        )
+
+        assert result["success"] is True
+        assert "EXPORT_FORMAT_UNSUPPORTED" in _codes(result)
+
+    def test_validate_animation_reports_invalid_frame_range(self):
+        cube = _FakeObject()
+        bpy = _make_bpy(cube)
+
+        result = load_and_call(
+            "blender-validation/scripts/validate_animation.py",
+            bpy,
+            object_names=["Cube"],
+            frame_range=[20, 1],
+        )
+
+        assert result["success"] is True
+        assert result["context"]["report"]["passed"] is False
+        assert "ANIMATION_FRAME_RANGE_INVALID" in _codes(result)
+
+    def test_get_validation_report_returns_latest_report(self):
+        from dcc_mcp_blender import _asset_pipeline_ops as ops
+
+        cube = _FakeObject()
+        bpy = _make_bpy(cube)
+        ops._REPORTS.clear()
+        ops._LATEST_REPORT_ID = None
+
+        with patch.dict(sys.modules, {"bpy": bpy}):
+            validate = ops.validate_mesh("Cube")
+            result = ops.get_validation_report()
+
+        assert result["success"] is True
+        assert result["context"]["report"]["report_id"] == validate["context"]["report"]["report_id"]
+
+
+class TestPipelineMetadata:
+    def test_asset_metadata_round_trip_and_clear_keys(self):
+        cube = _FakeObject()
+        bpy = _make_bpy(cube)
+
+        tag = load_and_call(
+            "blender-pipeline/scripts/tag_asset_metadata.py",
+            bpy,
+            object_name="Cube",
+            metadata={"asset_type": "prop", "variant": "hero"},
+        )
+        get = load_and_call("blender-pipeline/scripts/get_asset_metadata.py", bpy, object_name="Cube")
+        clear = load_and_call(
+            "blender-pipeline/scripts/clear_asset_metadata.py",
+            bpy,
+            object_name="Cube",
+            keys=["variant"],
+        )
+
+        assert tag["success"] is True
+        assert get["context"]["assets"][0]["metadata"]["asset_type"] == "prop"
+        assert clear["context"]["metadata"] == {"asset_type": "prop"}
+
+    def test_missing_object_returns_error_for_metadata(self):
+        bpy = _make_bpy()
+
+        result = load_and_call(
+            "blender-pipeline/scripts/tag_asset_metadata.py",
+            bpy,
+            object_name="Missing",
+            metadata={"asset_type": "prop"},
+        )
+
+        assert result["success"] is False
+
+    def test_set_project_context_updates_scene_settings(self):
+        bpy = _make_bpy()
+
+        result = load_and_call(
+            "blender-pipeline/scripts/set_project_context.py",
+            bpy,
+            name="Demo",
+            root="assets/demo",
+            unit_scale=0.01,
+            frame_rate=30,
+            metadata={"show": "test"},
+        )
+
+        assert result["success"] is True
+        assert bpy.context.scene.unit_settings.scale_length == 0.01
+        assert bpy.context.scene.render.fps == 30
+        assert result["context"]["project_context"]["name"] == "Demo"
+
+
+class TestPublishOutputs:
+    def test_create_publish_manifest_writes_local_json(self, tmp_path):
+        cube = _FakeObject()
+        bpy = _make_bpy(cube)
+        output_path = tmp_path / "manifest.json"
+
+        result = load_and_call(
+            "blender-pipeline/scripts/create_publish_manifest.py",
+            bpy,
+            object_names=["Cube"],
+            output_path=str(output_path),
+            metadata={"task": "export"},
+        )
+
+        assert result["success"] is True
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+        assert payload["schema"] == "dcc-mcp-blender.publish-manifest.v1"
+        assert payload["assets"][0]["name"] == "Cube"
+
+    def test_create_publish_manifest_rejects_url_path(self):
+        cube = _FakeObject()
+        bpy = _make_bpy(cube)
+
+        result = load_and_call(
+            "blender-pipeline/scripts/create_publish_manifest.py",
+            bpy,
+            object_names=["Cube"],
+            output_path="https://example.com/manifest.json",
+        )
+
+        assert result["success"] is False
+        assert "unsafe" in result["message"].lower()
+
+    def test_prepare_publish_package_writes_manifest_and_readme(self, tmp_path):
+        cube = _FakeObject()
+        bpy = _make_bpy(cube)
+        output_dir = tmp_path / "package"
+
+        result = load_and_call(
+            "blender-pipeline/scripts/prepare_publish_package.py",
+            bpy,
+            object_names=["Cube"],
+            output_dir=str(output_dir),
+            preset_name="game",
+        )
+
+        assert result["success"] is True
+        assert (output_dir / "publish_manifest.json").exists()
+        assert (output_dir / "README.txt").exists()


### PR DESCRIPTION
Summary:
- Add blender-validation for scene, mesh, material, animation, export-readiness checks with severity-coded reports.
- Add blender-pipeline for local asset metadata, project context, publish manifests, and lightweight package prep.
- Document the validation-before-export/publish flow and cover unit, Blender E2E, and HTTP MCP smoke paths.

Validation:
- python -m ruff check src tests packaging
- python -m ruff format --check src tests packaging
- python tools\lint_skills.py --warnings-as-errors
- python -m pytest tests\ -q
- Blender 4.4.3 background E2E: 107 collected / 1 skipped, all passed
- HTTP MCP smoke: 202 tools listed; tag_asset_metadata -> validate_mesh -> create_publish_manifest -> get_validation_report passed
- python -m build
- python packaging\assemble_zip.py --platform win64 --output-dir dist_addon

Closes #40