### PR TITLE
feat: add blender light rig environment tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 | **blender-dev** | `attach_project`, `reload_modules`, `run_check`, `run_entrypoint`, `run_script`, `list_addons`, `get_addon_status`, `enable_addon`, `disable_addon`, `capture_ui_snapshot`, `find_ui_elements`, `start_debug_server`, `get_python_environment` |
 | **blender-animation** | `set_keyframe`, `set_frame_range`, `get_frame_range`, `set_current_frame`, `get_keyframes`, `delete_keyframes`, `bake_animation` |
 | **blender-lighting** | `create_light`, `set_light_properties`, `list_lights`, `set_world_background` |
+| **blender-light-rig** | `create_three_point_light_rig`, `create_area_softbox`, `create_hdri_world`, `list_light_rigs`, `set_light_rig_intensity`, `aim_light_at_object`, `group_lights`, `set_render_view_transform`, `get_lighting_summary` |
 | **blender-camera** | `create_camera`, `set_active_camera`, `set_camera_properties`, `list_cameras` |
 | **blender-collection** | `create_collection`, `link_to_collection`, `list_collections` |
 | **blender-geometry** | `create_sphere`, `save_blend`, `file_exists`, `export_fbx`, `export_obj` |

--- a/src/dcc_mcp_blender/_light_rig_ops.py
+++ b/src/dcc_mcp_blender/_light_rig_ops.py
@@ -1,0 +1,522 @@
+"""Blender light rig and environment setup helpers."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
+
+RIG_PROP = "dcc_mcp_light_rig"
+ORIGINAL_ENERGY_PROP = "dcc_mcp_original_energy"
+
+
+def _iter_collection(collection: Any) -> List[Any]:
+    try:
+        return list(collection)
+    except TypeError:
+        return []
+
+
+def _collection_get(collection: Any, name: str) -> Any:
+    getter = getattr(collection, "get", None)
+    if callable(getter):
+        return getter(name)
+    for item in _iter_collection(collection):
+        if getattr(item, "name", None) == name:
+            return item
+    return None
+
+
+def _custom_get(target: Any, key: str, default: Any = None) -> Any:
+    getter = getattr(target, "get", None)
+    if callable(getter):
+        return getter(key, default)
+    try:
+        return target[key]
+    except Exception:
+        return default
+
+
+def _custom_set(target: Any, key: str, value: Any) -> None:
+    try:
+        target[key] = value
+    except Exception:
+        setattr(target, key, value)
+
+
+def _safe_path(image_path: str) -> Tuple[Optional[Path], Optional[dict]]:
+    raw = str(image_path or "").strip()
+    if not raw:
+        return None, skill_error("Missing image path", "Pass a local HDRI/image path.")
+    if "://" in raw or raw.startswith("\\\\"):
+        return None, skill_error("Unsafe image path", "Use a local filesystem path, not a URL or UNC path.")
+    path = Path(raw).expanduser().resolve()
+    if not path.is_file():
+        return None, skill_error(f"Image not found: {path}", f"No image exists at '{path}'.")
+    return path, None
+
+
+def _vec(value: Optional[List[float]], fallback: Tuple[float, float, float]) -> List[float]:
+    if value is None:
+        return [float(item) for item in fallback]
+    if len(value) != 3:
+        raise ValueError("Vector values must have exactly 3 numbers.")
+    return [float(item) for item in value]
+
+
+def _rgb(value: Optional[List[float]], fallback: Tuple[float, float, float] = (1.0, 1.0, 1.0)) -> List[float]:
+    if value is None:
+        return [float(item) for item in fallback]
+    if len(value) not in (3, 4):
+        raise ValueError("Color values must have 3 or 4 numbers.")
+    return [float(item) for item in value[:3]]
+
+
+def _ensure_collection(bpy: Any, name: str) -> Any:
+    collection = _collection_get(bpy.data.collections, name)
+    if collection is not None:
+        return collection
+    collection = bpy.data.collections.new(name)
+    children = getattr(getattr(bpy.context.scene, "collection", None), "children", None)
+    linker = getattr(children, "link", None)
+    if callable(linker):
+        linker(collection)
+    return collection
+
+
+def _link_object(collection: Any, obj: Any) -> None:
+    objects = getattr(collection, "objects", None)
+    linker = getattr(objects, "link", None)
+    if callable(linker):
+        try:
+            linker(obj)
+        except Exception:
+            pass
+
+
+def _create_light_object(
+    bpy: Any,
+    name: str,
+    light_type: str,
+    location: List[float],
+    energy: float,
+    color: Optional[List[float]] = None,
+    size: Optional[float] = None,
+    rotation: Optional[List[float]] = None,
+    collection: Any = None,
+) -> Any:
+    light_data = bpy.data.lights.new(name=name, type=light_type)
+    light_data.energy = float(energy)
+    if color is not None:
+        light_data.color = _rgb(color)
+    if size is not None:
+        if hasattr(light_data, "size"):
+            light_data.size = float(size)
+        if hasattr(light_data, "shadow_soft_size"):
+            light_data.shadow_soft_size = float(size)
+    obj = bpy.data.objects.new(name=name, object_data=light_data)
+    obj.location = location
+    if rotation is not None:
+        obj.rotation_euler = rotation
+    _custom_set(obj, ORIGINAL_ENERGY_PROP, float(energy))
+    if collection is not None:
+        _link_object(collection, obj)
+    else:
+        bpy.context.scene.collection.objects.link(obj)
+    return obj
+
+
+def _light_info(obj: Any) -> Dict[str, Any]:
+    return {
+        "name": getattr(obj, "name", None),
+        "light_type": getattr(getattr(obj, "data", None), "type", None),
+        "energy": getattr(getattr(obj, "data", None), "energy", None),
+        "color": list(getattr(getattr(obj, "data", None), "color", []) or []),
+        "location": list(getattr(obj, "location", []) or []),
+    }
+
+
+def _rig_payload(name: str, light_names: List[str]) -> Dict[str, Any]:
+    return {"name": name, "lights": light_names}
+
+
+def _store_rig(collection: Any, name: str, light_names: List[str]) -> None:
+    _custom_set(collection, RIG_PROP, json.dumps(_rig_payload(name, light_names), sort_keys=True))
+
+
+def _load_rig(collection: Any) -> Optional[Dict[str, Any]]:
+    raw = _custom_get(collection, RIG_PROP, None)
+    if not raw:
+        return None
+    if isinstance(raw, dict):
+        return raw
+    try:
+        payload = json.loads(str(raw))
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _rig_collections(bpy: Any) -> List[Tuple[Any, Dict[str, Any]]]:
+    rigs = []
+    for collection in _iter_collection(bpy.data.collections):
+        payload = _load_rig(collection)
+        if payload:
+            rigs.append((collection, payload))
+    return rigs
+
+
+def _find_rig(bpy: Any, rig_name: str) -> Tuple[Any, Optional[Dict[str, Any]]]:
+    for collection, payload in _rig_collections(bpy):
+        if payload.get("name") == rig_name or getattr(collection, "name", None) == rig_name:
+            return collection, payload
+    return None, None
+
+
+def _aim_at(light: Any, target: Any) -> None:
+    _custom_set(light, "dcc_mcp_aim_target", getattr(target, "name", None))
+    try:
+        from mathutils import Vector
+
+        direction = Vector(target.location) - Vector(light.location)
+        if direction.length == 0:
+            return
+        light.rotation_euler = direction.to_track_quat("-Z", "Y").to_euler()
+    except Exception:
+        return
+
+
+def _world_info(world: Any) -> Dict[str, Any]:
+    if world is None:
+        return {}
+    return {
+        "name": getattr(world, "name", None),
+        "color": list(getattr(world, "color", []) or []),
+        "use_nodes": bool(getattr(world, "use_nodes", False)),
+    }
+
+
+def _view_settings_info(view_settings: Any) -> Dict[str, Any]:
+    return {
+        "view_transform": getattr(view_settings, "view_transform", None),
+        "look": getattr(view_settings, "look", None),
+        "exposure": getattr(view_settings, "exposure", None),
+        "gamma": getattr(view_settings, "gamma", None),
+    }
+
+
+def _set_vector_socket_value(socket: Any, values: List[float]) -> None:
+    default_value = getattr(socket, "default_value", None)
+    if default_value is None:
+        return
+    for index, value in enumerate(values):
+        try:
+            default_value[index] = float(value)
+        except Exception:
+            return
+
+
+def create_three_point_light_rig(
+    name: str,
+    target_object: Optional[str] = None,
+    key: Optional[Dict[str, Any]] = None,
+    fill: Optional[Dict[str, Any]] = None,
+    rim: Optional[Dict[str, Any]] = None,
+) -> dict:
+    """Create a three-point area-light rig in a dedicated collection."""
+    try:
+        import bpy
+
+        target = _collection_get(bpy.data.objects, target_object) if target_object else None
+        if target_object and target is None:
+            return skill_error(f"Object not found: {target_object}", f"No object named '{target_object}'.")
+        collection = _ensure_collection(bpy, name)
+        specs = [
+            ("Key", key or {}, (-3.0, -4.0, 5.0), 800.0, 4.0),
+            ("Fill", fill or {}, (4.0, -3.0, 3.0), 250.0, 5.5),
+            ("Rim", rim or {}, (0.0, 4.0, 4.0), 500.0, 3.0),
+        ]
+        lights = []
+        for label, options, fallback_location, fallback_energy, fallback_size in specs:
+            light = _create_light_object(
+                bpy,
+                f"{name}_{label}",
+                str(options.get("type", "AREA")).upper(),
+                _vec(options.get("location"), fallback_location),
+                float(options.get("energy", fallback_energy)),
+                options.get("color"),
+                float(options.get("size", fallback_size)),
+                collection=collection,
+            )
+            if target is not None:
+                _aim_at(light, target)
+            lights.append(light)
+        _store_rig(collection, name, [light.name for light in lights])
+        return skill_success(
+            "Three-point light rig created",
+            rig_name=name,
+            collection_name=getattr(collection, "name", name),
+            target_object=target_object,
+            lights=[_light_info(light) for light in lights],
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except ValueError as exc:
+        return skill_error("Invalid light rig option", str(exc))
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to create light rig {name}")
+
+
+def create_area_softbox(
+    name: str,
+    location: Optional[List[float]] = None,
+    rotation: Optional[List[float]] = None,
+    size: float = 5.0,
+    energy: float = 500.0,
+) -> dict:
+    """Create one large soft area light."""
+    try:
+        import bpy
+
+        light = _create_light_object(
+            bpy,
+            name,
+            "AREA",
+            _vec(location, (0.0, -3.0, 4.0)),
+            float(energy),
+            size=float(size),
+            rotation=_vec(rotation, (1.0, 0.0, 0.0)) if rotation is not None else None,
+        )
+        return skill_success("Area softbox created", light=_light_info(light), size=float(size))
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except ValueError as exc:
+        return skill_error("Invalid softbox option", str(exc))
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to create softbox {name}")
+
+
+def create_hdri_world(image_path: str, strength: float = 1.0, rotation: float = 0.0) -> dict:
+    """Create an environment-texture world from a local image."""
+    path, error = _safe_path(image_path)
+    if error:
+        return error
+    try:
+        import bpy
+
+        scene = bpy.context.scene
+        world = scene.world or bpy.data.worlds.new(name="World")
+        scene.world = world
+        world.use_nodes = True
+        nodes = world.node_tree.nodes
+        links = world.node_tree.links
+        background = _collection_get(nodes, "Background")
+        if background is None:
+            background = nodes.new(type="ShaderNodeBackground")
+            background.name = "Background"
+        env = _collection_get(nodes, "DCC MCP HDRI") or nodes.new(type="ShaderNodeTexEnvironment")
+        env.name = "DCC MCP HDRI"
+        env.image = bpy.data.images.load(str(path), check_existing=True)
+        texcoord = _collection_get(nodes, "DCC MCP Texture Coordinate") or nodes.new(type="ShaderNodeTexCoord")
+        texcoord.name = "DCC MCP Texture Coordinate"
+        mapping = _collection_get(nodes, "DCC MCP Mapping") or nodes.new(type="ShaderNodeMapping")
+        mapping.name = "DCC MCP Mapping"
+        rotation_socket = _collection_get(getattr(mapping, "inputs", {}), "Rotation")
+        if rotation_socket is not None:
+            _set_vector_socket_value(rotation_socket, [0.0, 0.0, math.radians(float(rotation))])
+        texcoord_output = _collection_get(getattr(texcoord, "outputs", {}), "Generated") or _collection_get(
+            getattr(texcoord, "outputs", {}), "Vector"
+        )
+        mapping_input = _collection_get(getattr(mapping, "inputs", {}), "Vector")
+        mapping_output = _collection_get(getattr(mapping, "outputs", {}), "Vector")
+        env_vector = _collection_get(getattr(env, "inputs", {}), "Vector")
+        if texcoord_output is not None and mapping_input is not None:
+            try:
+                links.new(texcoord_output, mapping_input)
+            except Exception:
+                pass
+        if mapping_output is not None and env_vector is not None:
+            try:
+                links.new(mapping_output, env_vector)
+            except Exception:
+                pass
+        color = _collection_get(getattr(env, "outputs", {}), "Color")
+        bg_color = _collection_get(getattr(background, "inputs", {}), "Color")
+        if color is not None and bg_color is not None:
+            try:
+                links.new(color, bg_color)
+            except Exception:
+                pass
+        strength_socket = _collection_get(getattr(background, "inputs", {}), "Strength")
+        if strength_socket is not None and hasattr(strength_socket, "default_value"):
+            strength_socket.default_value = float(strength)
+        else:
+            world.strength = float(strength)
+        _custom_set(world, "dcc_mcp_hdri_rotation", float(rotation))
+        return skill_success(
+            "HDRI world created",
+            image_path=str(path),
+            strength=float(strength),
+            rotation=float(rotation),
+            world=_world_info(world),
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create HDRI world")
+
+
+def list_light_rigs() -> dict:
+    """List light rigs created by this skill."""
+    try:
+        import bpy
+
+        rigs = []
+        for collection, payload in _rig_collections(bpy):
+            light_names = list(payload.get("lights", []))
+            rigs.append(
+                {
+                    "rig_name": payload.get("name", getattr(collection, "name", None)),
+                    "collection_name": getattr(collection, "name", None),
+                    "lights": light_names,
+                    "light_count": len(light_names),
+                }
+            )
+        return skill_success("Light rigs listed", rigs=rigs, count=len(rigs))
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list light rigs")
+
+
+def set_light_rig_intensity(rig_name: str, multiplier: float) -> dict:
+    """Scale every light in a rig from its original energy."""
+    try:
+        import bpy
+
+        _collection, payload = _find_rig(bpy, rig_name)
+        if payload is None:
+            return skill_error(f"Light rig not found: {rig_name}", "Create or group a rig before scaling it.")
+        updated = []
+        for light_name in payload.get("lights", []):
+            light = _collection_get(bpy.data.objects, light_name)
+            if light is None or getattr(light, "type", None) != "LIGHT":
+                continue
+            original = _custom_get(light, ORIGINAL_ENERGY_PROP, getattr(light.data, "energy", 0.0))
+            light.data.energy = float(original) * float(multiplier)
+            updated.append(_light_info(light))
+        return skill_success(
+            "Light rig intensity updated", rig_name=rig_name, multiplier=float(multiplier), lights=updated
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to set light rig intensity for {rig_name}")
+
+
+def aim_light_at_object(light_name: str, target_object: str) -> dict:
+    """Aim one light at a target object."""
+    try:
+        import bpy
+
+        light = _collection_get(bpy.data.objects, light_name)
+        if light is None:
+            return skill_error(f"Light not found: {light_name}", f"No object named '{light_name}'.")
+        if getattr(light, "type", None) != "LIGHT":
+            return skill_error(f"{light_name} is not a light", "Expected an object of type LIGHT.")
+        target = _collection_get(bpy.data.objects, target_object)
+        if target is None:
+            return skill_error(f"Object not found: {target_object}", f"No object named '{target_object}'.")
+        _aim_at(light, target)
+        return skill_success("Light aimed at object", light_name=light_name, target_object=target_object)
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to aim light {light_name}")
+
+
+def group_lights(light_names: List[str], collection_name: str) -> dict:
+    """Group existing light objects into a rig collection."""
+    try:
+        import bpy
+
+        lights = []
+        for light_name in light_names:
+            light = _collection_get(bpy.data.objects, light_name)
+            if light is None:
+                return skill_error(f"Light not found: {light_name}", f"No object named '{light_name}'.")
+            if getattr(light, "type", None) != "LIGHT":
+                return skill_error(f"{light_name} is not a light", "Only LIGHT objects can be grouped.")
+            lights.append(light)
+        collection = _ensure_collection(bpy, collection_name)
+        for light in lights:
+            _link_object(collection, light)
+            _custom_set(light, ORIGINAL_ENERGY_PROP, float(getattr(light.data, "energy", 0.0)))
+        _store_rig(collection, collection_name, [light.name for light in lights])
+        return skill_success(
+            "Lights grouped",
+            rig_name=collection_name,
+            collection_name=getattr(collection, "name", collection_name),
+            lights=[_light_info(light) for light in lights],
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to group lights into {collection_name}")
+
+
+def set_render_view_transform(
+    view_transform: Optional[str] = None,
+    look: Optional[str] = None,
+    exposure: Optional[float] = None,
+    gamma: Optional[float] = None,
+) -> dict:
+    """Set scene view transform and exposure controls."""
+    try:
+        import bpy
+
+        view_settings = getattr(bpy.context.scene, "view_settings", None)
+        if view_settings is None:
+            return skill_error("Render view settings unavailable", "Scene view_settings is not available.")
+        try:
+            if view_transform is not None:
+                view_settings.view_transform = view_transform
+            if look is not None:
+                view_settings.look = look
+            if exposure is not None:
+                view_settings.exposure = float(exposure)
+            if gamma is not None:
+                view_settings.gamma = float(gamma)
+        except Exception as exc:
+            return skill_error("Unsupported render view setting", str(exc))
+        return skill_success("Render view transform updated", current=_view_settings_info(view_settings))
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set render view transform")
+
+
+def get_lighting_summary() -> dict:
+    """Return lights, rig, world, and render-view summary."""
+    try:
+        import bpy
+
+        lights = [
+            _light_info(obj) for obj in _iter_collection(bpy.data.objects) if getattr(obj, "type", None) == "LIGHT"
+        ]
+        rigs = list_light_rigs()
+        return skill_success(
+            "Lighting summary retrieved",
+            lights=lights,
+            light_count=len(lights),
+            rigs=rigs.get("context", {}).get("rigs", []),
+            world=_world_info(getattr(bpy.context.scene, "world", None)),
+            view_settings=_view_settings_info(getattr(bpy.context.scene, "view_settings", None)),
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get lighting summary")

--- a/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
@@ -29,6 +29,7 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | `blender-animation` | animation, shot | Set, inspect, delete, and bake keyframes plus frame ranges and current frame. | Load when timing, frame range, keyframe, curve inspection, deletion, or baking work starts. | Mutating except frame-range and keyframe reads. | keyframe, timeline, frame range, current frame, bake animation |
 | `blender-camera` | shot, layout, render | Create cameras, set the active camera, edit camera properties, and list cameras. | Load when view, shot, or render framing is requested. | Mutating except camera listing. | camera, lens, active camera, shot, framing |
 | `blender-lighting` | lookdev, render | Create lights, edit light properties, list lights, and set world background. | Load when visibility or render quality depends on lighting. | Mutating except light listing. | light, world background, sun, area light, exposure |
+| `blender-light-rig` | lookdev, render, environment | Create reusable light rigs, softboxes, HDRI worlds, grouped light collections, and view-transform settings. | Load after basic lighting when scenes need repeatable studio or environment lighting. | Mutating except rig listing and summary. | three point light, softbox, hdri world, light rig, view transform, lighting summary |
 | `blender-render` | render, diagnostics, delivery | Configure renders, render scenes, inspect render settings, and capture viewport images. | Load after scene/camera/lighting setup when output is needed. | Disk/output producing; read-only for render info. | render, viewport capture, image output, resolution |
 | `blender-dev` | diagnostics, development | Inspect add-ons, Python environment, structured UI metadata, module reloads, debug listeners, and development entrypoints. | Load for adapter/add-on debugging before falling back to arbitrary scripting; avoid for normal scene authoring. | Mixed: read-only diagnostics plus explicit development code execution, path mutation, module reload, and add-on enable/disable. | addon diagnostics, reload modules, run check, debug server, UI snapshot, Python environment |
 | `blender-scripting` | diagnostics, escape hatch | Execute Python snippets or script files and inspect Blender runtime info. | Load last, after checking typed skills and only when custom logic is required. | Potentially arbitrary; use with explicit user intent. | python, script, custom, escape hatch, blender info |
@@ -49,7 +50,8 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | Shader node graph edit | `blender-materials` -> `blender-shader-nodes` (`list_node_sockets` before `connect_nodes`/`set_node_input`) |
 | Procedural node setup | `blender-objects` -> `blender-geometry-nodes` -> `blender-shader-nodes` for low-level graph edits -> `blender-render` |
 | Physics setup | `blender-objects` -> `blender-mesh` -> `blender-physics` |
-| Shot and render delivery | `blender-camera` -> `blender-lighting` -> `blender-render` |
+| Shot and render delivery | `blender-camera` -> `blender-lighting` or `blender-light-rig` -> `blender-render` |
+| Studio lookdev setup | `blender-materials` -> `blender-material-library` -> `blender-light-rig` -> `blender-render` |
 | File interchange | `blender-scene` -> `blender-interchange` -> `blender-export-preset` when settings repeat |
 | Export validation | `blender-validation` -> `blender-interchange` -> `blender-export-preset` |
 | Local publish prep | `blender-validation` -> `blender-pipeline` -> `blender-interchange` when files need export |
@@ -64,6 +66,7 @@ This index helps agents choose typed Blender skills before falling back to raw P
 - Load authoring skills only when the requested task enters that domain; prefer `blender-mesh-ops` for topology, `blender-mesh` for modifiers, and `blender-rigging`/`blender-pose-library` for character setup.
 - Use `blender-shader-nodes` for graph-level socket/link edits; use `blender-materials` when material slots or simple colors are enough, `blender-material-library` for reusable looks, texture files, and color management, and `blender-geometry-nodes` when the workflow is about modifier assignment or exposed procedural inputs.
 - Use `blender-texture-bake` only after mesh, UV, and material setup are explicit; prefer `dry_run` before writing bake outputs in automation.
+- Use `blender-lighting` for individual lights and quick world color edits; use `blender-light-rig` for grouped three-point rigs, softboxes, HDRI worlds, and render view-transform coordination.
 - Use `blender-interchange` and `blender-shot-export` for import/export and delivery before writing custom Python exporters.
 - Use `blender-validation` before interchange/export or publish prep, and use `blender-pipeline` for Blender-native metadata and local manifests/packages.
 - Use `blender-dev` for add-on/runtime diagnostics, structured UI metadata, module reloads, and reproducible development entrypoints before reaching for arbitrary Python.

--- a/src/dcc_mcp_blender/skills/blender-light-rig/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-light-rig/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: blender-light-rig
+description: "Blender reusable light rigs, HDRI/world setup, light grouping, and render-view controls"
+license: "MIT"
+allowed-tools: ["Bash", "Read"]
+metadata:
+  dcc-mcp:
+    dcc: blender
+    version: "1.0.0"
+    tags: [blender, lighting, light-rig, hdri, world, lookdev]
+    search-hint: "three point light rig, softbox, hdri world, group lights, view transform, lighting summary"
+    tools: tools.yaml
+---
+
+# blender-light-rig
+
+Rig-oriented lighting helpers for repeatable Blender look-development setups.
+
+Use this skill when a scene needs grouped lights, reusable three-point rigs,
+HDRI/world setup, light aiming, or render view-transform coordination. Single
+light creation and basic property edits remain in `blender-lighting`.

--- a/src/dcc_mcp_blender/skills/blender-light-rig/scripts/aim_light_at_object.py
+++ b/src/dcc_mcp_blender/skills/blender-light-rig/scripts/aim_light_at_object.py
@@ -1,0 +1,17 @@
+"""Aim a Blender light at an object."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._light_rig_ops import aim_light_at_object
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`aim_light_at_object`."""
+    return aim_light_at_object(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-light-rig/scripts/create_area_softbox.py
+++ b/src/dcc_mcp_blender/skills/blender-light-rig/scripts/create_area_softbox.py
@@ -1,0 +1,17 @@
+"""Create a Blender area softbox."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._light_rig_ops import create_area_softbox
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_area_softbox`."""
+    return create_area_softbox(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-light-rig/scripts/create_hdri_world.py
+++ b/src/dcc_mcp_blender/skills/blender-light-rig/scripts/create_hdri_world.py
@@ -1,0 +1,17 @@
+"""Create a Blender HDRI world."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._light_rig_ops import create_hdri_world
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_hdri_world`."""
+    return create_hdri_world(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-light-rig/scripts/create_three_point_light_rig.py
+++ b/src/dcc_mcp_blender/skills/blender-light-rig/scripts/create_three_point_light_rig.py
@@ -1,0 +1,17 @@
+"""Create a three-point Blender light rig."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._light_rig_ops import create_three_point_light_rig
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`create_three_point_light_rig`."""
+    return create_three_point_light_rig(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-light-rig/scripts/get_lighting_summary.py
+++ b/src/dcc_mcp_blender/skills/blender-light-rig/scripts/get_lighting_summary.py
@@ -1,0 +1,17 @@
+"""Get Blender lighting summary."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._light_rig_ops import get_lighting_summary
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_lighting_summary`."""
+    return get_lighting_summary(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-light-rig/scripts/group_lights.py
+++ b/src/dcc_mcp_blender/skills/blender-light-rig/scripts/group_lights.py
@@ -1,0 +1,17 @@
+"""Group Blender lights into a rig collection."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._light_rig_ops import group_lights
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`group_lights`."""
+    return group_lights(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-light-rig/scripts/list_light_rigs.py
+++ b/src/dcc_mcp_blender/skills/blender-light-rig/scripts/list_light_rigs.py
@@ -1,0 +1,17 @@
+"""List Blender light rigs."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._light_rig_ops import list_light_rigs
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_light_rigs`."""
+    return list_light_rigs(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-light-rig/scripts/set_light_rig_intensity.py
+++ b/src/dcc_mcp_blender/skills/blender-light-rig/scripts/set_light_rig_intensity.py
@@ -1,0 +1,17 @@
+"""Set Blender light rig intensity."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._light_rig_ops import set_light_rig_intensity
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_light_rig_intensity`."""
+    return set_light_rig_intensity(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-light-rig/scripts/set_render_view_transform.py
+++ b/src/dcc_mcp_blender/skills/blender-light-rig/scripts/set_render_view_transform.py
@@ -1,0 +1,17 @@
+"""Set Blender render view transform controls."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import run_main, skill_entry
+
+from dcc_mcp_blender._light_rig_ops import set_render_view_transform
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`set_render_view_transform`."""
+    return set_render_view_transform(**kwargs)
+
+
+if __name__ == "__main__":
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-light-rig/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-light-rig/tools.yaml
@@ -1,0 +1,260 @@
+tools:
+  - name: create_three_point_light_rig
+    description: "Create a grouped three-point light rig with key, fill, and rim lights."
+    source_file: scripts/create_three_point_light_rig.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+        target_object:
+          type: string
+          minLength: 1
+        key:
+          type: object
+          additionalProperties: true
+        fill:
+          type: object
+          additionalProperties: true
+        rim:
+          type: object
+          additionalProperties: true
+    output_schema: &result_schema
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        context:
+          type: object
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations: &mutating
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+
+  - name: create_area_softbox
+    description: "Create a large area-light softbox."
+    source_file: scripts/create_area_softbox.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+        location:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items:
+            type: number
+        rotation:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items:
+            type: number
+        size:
+          type: number
+          default: 5.0
+        energy:
+          type: number
+          default: 500.0
+    output_schema: *result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations: *mutating
+
+  - name: create_hdri_world
+    description: "Create a node-based HDRI/world environment from a local image path."
+    source_file: scripts/create_hdri_world.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [image_path]
+      properties:
+        image_path:
+          type: string
+          minLength: 1
+        strength:
+          type: number
+          default: 1.0
+        rotation:
+          type: number
+          default: 0.0
+    output_schema: *result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: true
+
+  - name: list_light_rigs
+    description: "List grouped light rigs created by this skill."
+    source_file: scripts/list_light_rigs.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties: {}
+    output_schema: *result_schema
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations: &read_only
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: set_light_rig_intensity
+    description: "Scale all lights in a rig from their original energies."
+    source_file: scripts/set_light_rig_intensity.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [rig_name, multiplier]
+      properties:
+        rig_name:
+          type: string
+          minLength: 1
+        multiplier:
+          type: number
+    output_schema: *result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: aim_light_at_object
+    description: "Aim one light object at a target object."
+    source_file: scripts/aim_light_at_object.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [light_name, target_object]
+      properties:
+        light_name:
+          type: string
+          minLength: 1
+        target_object:
+          type: string
+          minLength: 1
+    output_schema: *result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: group_lights
+    description: "Group existing light objects into a rig collection."
+    source_file: scripts/group_lights.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [light_names, collection_name]
+      properties:
+        light_names:
+          type: array
+          minItems: 1
+          items:
+            type: string
+        collection_name:
+          type: string
+          minLength: 1
+    output_schema: *result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: set_render_view_transform
+    description: "Set scene view transform, look, exposure, and gamma."
+    source_file: scripts/set_render_view_transform.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        view_transform:
+          type: string
+        look:
+          type: string
+        exposure:
+          type: number
+        gamma:
+          type: number
+    output_schema: *result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: get_lighting_summary
+    description: "Return lights, rigs, world, and view-transform settings."
+    source_file: scripts/get_lighting_summary.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties: {}
+    output_schema: *result_schema
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations: *read_only

--- a/tests/e2e/test_light_rig_e2e.py
+++ b/tests/e2e/test_light_rig_e2e.py
@@ -1,0 +1,66 @@
+"""E2E tests for light rig and environment skills."""
+
+from __future__ import annotations
+
+import math
+import tempfile
+from pathlib import Path
+
+import pytest
+
+bpy = pytest.importorskip("bpy", reason="bpy not available - run inside Blender Python interpreter")
+
+pytestmark = pytest.mark.e2e
+
+from tests.e2e.conftest import load_skill  # noqa: E402
+
+
+def _new_scene():
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+
+
+class TestLightRigE2E:
+    def setup_method(self):
+        _new_scene()
+
+    def test_create_light_rig_hdri_world_and_summary(self):
+        bpy.ops.mesh.primitive_cube_add()
+        cube_name = bpy.context.object.name
+
+        rig_mod = load_skill("blender-light-rig", "create_three_point_light_rig")
+        rig = rig_mod.create_three_point_light_rig(name="E2ERig", target_object=cube_name)
+        assert rig["success"] is True
+        assert len(rig["context"]["lights"]) == 3
+        for light in rig["context"]["lights"]:
+            assert light["name"] in bpy.data.objects
+
+        intensity_mod = load_skill("blender-light-rig", "set_light_rig_intensity")
+        intensity = intensity_mod.set_light_rig_intensity(rig_name="E2ERig", multiplier=0.25)
+        assert intensity["success"] is True
+        assert intensity["context"]["lights"][0]["energy"] > 0
+
+        with tempfile.TemporaryDirectory() as tmp:
+            image_path = Path(tmp) / "studio.png"
+            image = bpy.data.images.new("E2EHDRI", width=2, height=2, alpha=True)
+            image.filepath_raw = str(image_path)
+            image.file_format = "PNG"
+            image.save()
+
+            hdri_mod = load_skill("blender-light-rig", "create_hdri_world")
+            hdri = hdri_mod.create_hdri_world(image_path=str(image_path), strength=0.5, rotation=15.0)
+            assert hdri["success"] is True
+            assert bpy.context.scene.world.use_nodes is True
+            mapping = bpy.context.scene.world.node_tree.nodes.get("DCC MCP Mapping")
+            assert mapping is not None
+            assert round(mapping.inputs["Rotation"].default_value[2], 3) == round(math.radians(15.0), 3)
+
+        view_mod = load_skill("blender-light-rig", "set_render_view_transform")
+        view = view_mod.set_render_view_transform(view_transform="Standard", exposure=0.1)
+        assert view["success"] is True
+        assert bpy.context.scene.view_settings.view_transform == "Standard"
+
+        summary_mod = load_skill("blender-light-rig", "get_lighting_summary")
+        summary = summary_mod.get_lighting_summary()
+        assert summary["success"] is True
+        assert summary["context"]["light_count"] >= 3
+        assert summary["context"]["rigs"][0]["rig_name"] == "E2ERig"

--- a/tests/test_skills_light_rig.py
+++ b/tests/test_skills_light_rig.py
@@ -1,0 +1,245 @@
+"""Unit tests for blender-light-rig skill scripts."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tests.conftest import load_and_call, make_mock_bpy
+
+
+class _Collection(list):
+    def get(self, name):
+        for item in self:
+            if getattr(item, "name", None) == name:
+                return item
+        return None
+
+
+class _LinkList(list):
+    def link(self, item):
+        if item not in self:
+            self.append(item)
+
+
+class _FakeCollection(dict):
+    def __init__(self, name):
+        super().__init__()
+        self.name = name
+        self.objects = _LinkList()
+        self.children = _LinkList()
+
+    def get(self, key, default=None):
+        return dict.get(self, key, default)
+
+
+class _CollectionCollection(_Collection):
+    def new(self, name):
+        collection = _FakeCollection(name)
+        self.append(collection)
+        return collection
+
+
+class _FakeLightData:
+    def __init__(self, name, light_type):
+        self.name = name
+        self.type = light_type
+        self.energy = 0.0
+        self.color = [1.0, 1.0, 1.0]
+        self.size = 1.0
+        self.shadow_soft_size = 1.0
+
+
+class _LightCollection(_Collection):
+    def new(self, name, type):  # noqa: A002
+        light = _FakeLightData(name, type)
+        self.append(light)
+        return light
+
+
+class _FakeObject(dict):
+    def __init__(self, name, obj_type="MESH", data=None, location=None):
+        super().__init__()
+        self.name = name
+        self.type = obj_type
+        self.data = data
+        self.location = location or [0.0, 0.0, 0.0]
+        self.rotation_euler = [0.0, 0.0, 0.0]
+
+    def get(self, key, default=None):
+        return dict.get(self, key, default)
+
+
+class _ObjectCollection(_Collection):
+    def new(self, name, object_data=None):
+        obj_type = "LIGHT" if object_data is not None else "EMPTY"
+        obj = _FakeObject(name, obj_type, object_data)
+        self.append(obj)
+        return obj
+
+
+class _FakeScene:
+    def __init__(self):
+        self.collection = _FakeCollection("Scene Collection")
+        self.world = None
+        self.view_settings = SimpleNamespace(view_transform="AgX", look="None", exposure=0.0, gamma=1.0)
+
+
+def _make_bpy(*objects):
+    bpy = make_mock_bpy()
+    bpy.context.scene = _FakeScene()
+    bpy.data.objects = _ObjectCollection(objects)
+    bpy.data.lights = _LightCollection()
+    bpy.data.collections = _CollectionCollection()
+    return bpy
+
+
+def _make_light(name="Light", energy=100.0):
+    data = _FakeLightData(name, "POINT")
+    data.energy = energy
+    return _FakeObject(name, "LIGHT", data, [0.0, 0.0, 3.0])
+
+
+class TestLightRig:
+    def test_create_three_point_rig_and_scale_intensity(self):
+        target = _FakeObject("Cube")
+        bpy = _make_bpy(target)
+
+        created = load_and_call(
+            "blender-light-rig/scripts/create_three_point_light_rig.py",
+            bpy,
+            name="HeroRig",
+            target_object="Cube",
+        )
+        listed = load_and_call("blender-light-rig/scripts/list_light_rigs.py", bpy)
+        scaled = load_and_call(
+            "blender-light-rig/scripts/set_light_rig_intensity.py",
+            bpy,
+            rig_name="HeroRig",
+            multiplier=0.5,
+        )
+
+        assert created["success"] is True
+        assert len(created["context"]["lights"]) == 3
+        assert listed["context"]["count"] == 1
+        assert scaled["success"] is True
+        assert scaled["context"]["lights"][0]["energy"] == 400.0
+
+    def test_create_three_point_rig_missing_target(self):
+        bpy = _make_bpy()
+
+        result = load_and_call(
+            "blender-light-rig/scripts/create_three_point_light_rig.py",
+            bpy,
+            name="MissingTargetRig",
+            target_object="Ghost",
+        )
+
+        assert result["success"] is False
+
+    def test_create_area_softbox(self):
+        bpy = _make_bpy()
+
+        result = load_and_call(
+            "blender-light-rig/scripts/create_area_softbox.py",
+            bpy,
+            name="Softbox",
+            size=6.0,
+            energy=750.0,
+        )
+
+        assert result["success"] is True
+        assert result["context"]["light"]["light_type"] == "AREA"
+        assert result["context"]["light"]["energy"] == 750.0
+
+    def test_create_area_softbox_invalid_vector(self):
+        bpy = _make_bpy()
+
+        result = load_and_call(
+            "blender-light-rig/scripts/create_area_softbox.py",
+            bpy,
+            name="BadSoftbox",
+            location=[1.0, 2.0],
+        )
+
+        assert result["success"] is False
+
+    def test_set_light_rig_intensity_missing_rig(self):
+        bpy = _make_bpy()
+
+        result = load_and_call(
+            "blender-light-rig/scripts/set_light_rig_intensity.py",
+            bpy,
+            rig_name="GhostRig",
+            multiplier=1.0,
+        )
+
+        assert result["success"] is False
+
+    def test_group_lights_and_summary(self):
+        key = _make_light("Key", 100.0)
+        fill = _make_light("Fill", 50.0)
+        bpy = _make_bpy(key, fill)
+
+        grouped = load_and_call(
+            "blender-light-rig/scripts/group_lights.py",
+            bpy,
+            light_names=["Key", "Fill"],
+            collection_name="GroupedRig",
+        )
+        summary = load_and_call("blender-light-rig/scripts/get_lighting_summary.py", bpy)
+
+        assert grouped["success"] is True
+        assert len(grouped["context"]["lights"]) == 2
+        assert summary["context"]["light_count"] == 2
+        assert summary["context"]["rigs"][0]["rig_name"] == "GroupedRig"
+
+    def test_group_lights_rejects_non_light(self):
+        mesh = _FakeObject("Cube")
+        bpy = _make_bpy(mesh)
+
+        result = load_and_call(
+            "blender-light-rig/scripts/group_lights.py",
+            bpy,
+            light_names=["Cube"],
+            collection_name="BadRig",
+        )
+
+        assert result["success"] is False
+
+    def test_aim_light_at_missing_target(self):
+        light = _make_light("Key")
+        bpy = _make_bpy(light)
+
+        result = load_and_call(
+            "blender-light-rig/scripts/aim_light_at_object.py",
+            bpy,
+            light_name="Key",
+            target_object="Missing",
+        )
+
+        assert result["success"] is False
+
+    def test_hdri_world_rejects_invalid_path(self):
+        bpy = _make_bpy()
+
+        result = load_and_call(
+            "blender-light-rig/scripts/create_hdri_world.py",
+            bpy,
+            image_path="https://example.com/studio.exr",
+        )
+
+        assert result["success"] is False
+
+    def test_set_render_view_transform(self):
+        bpy = _make_bpy()
+
+        result = load_and_call(
+            "blender-light-rig/scripts/set_render_view_transform.py",
+            bpy,
+            view_transform="Standard",
+            exposure=0.25,
+        )
+
+        assert result["success"] is True
+        assert result["context"]["current"]["view_transform"] == "Standard"
+        assert result["context"]["current"]["exposure"] == 0.25


### PR DESCRIPTION
## Summary
- add blender-light-rig skill with grouped three-point rigs, softboxes, HDRI world setup, light grouping, rig intensity, light aiming, view transform, and lighting summary tools
- add shared light-rig operations with structured errors for missing targets, invalid paths/options, and unsupported view settings
- document the new skill in README and the staged skills index

Closes #37

## Validation
- python -m ruff check src tests packaging
- python -m ruff format --check src tests packaging
- python tools\lint_skills.py --warnings-as-errors
- python -m pytest tests\ -q
- Blender 4.4.3 background E2E via .github\scripts\run_blender_e2e.py
- HTTP MCP smoke against http://127.0.0.1:8765/mcp, 228 tools discovered
- python -m build
- python packaging\assemble_zip.py --platform win64 --output-dir dist_addon
- git diff --check