### PR TITLE
refactor: simplify blender dispatcher with core interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![GitHub release downloads](https://img.shields.io/github/downloads/loonghao/dcc-mcp-blender/total.svg?label=release%20downloads)](https://github.com/loonghao/dcc-mcp-blender/releases)
 [![GitHub Release](https://img.shields.io/github/v/release/loonghao/dcc-mcp-blender.svg)](https://github.com/loonghao/dcc-mcp-blender/releases)
 [![Coverage](https://img.shields.io/badge/coverage-pytest--cov-blue.svg)](https://github.com/loonghao/dcc-mcp-blender/blob/main/pyproject.toml)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.34-blue.svg)](https://github.com/loonghao/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.36-blue.svg)](https://github.com/loonghao/dcc-mcp-core)
 [![Blender](https://img.shields.io/badge/Blender-3.6%20LTS%20%7C%204.2%20LTS%20%7C%204.3%20%7C%204.4-orange.svg)](https://www.blender.org/download/releases/)
 [![MCP](https://img.shields.io/badge/MCP-2025--03--26-purple.svg)](https://modelcontextprotocol.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -44,7 +44,7 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.17.34"
+MIN_CORE_VERSION = "0.17.36"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,9 @@ classifiers = [
 ]
 
 dependencies = [
-    # Align with dcc-mcp-core 0.17.34: DccServerOptions composition root,
-    # HostExecutionBridge, diagnostics/resources contracts, gateway capability
-    # index expectations, and current skill-management/search/lint contracts.
-    "dcc-mcp-core>=0.17.34,<1.0.0",
+    # Align with dcc-mcp-core 0.17.36 public dispatcher, cancellation,
+    # execution-bridge, diagnostics/resources, and skill-management contracts.
+    "dcc-mcp-core>=0.17.36,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_blender/dispatcher/__init__.py
+++ b/src/dcc_mcp_blender/dispatcher/__init__.py
@@ -1,26 +1,4 @@
-"""Blender thread-affinity dispatchers.
-
-Public dispatcher symbols are re-exported from their focused submodules
-through the :pep:`8`-compliant ``__all__`` below.
-
-The implementation is split per Single Responsibility into:
-
-================  ====================================================
-Module            Purpose
-================  ====================================================
-``job``           ``_JobEntry`` + ``_current_job`` ContextVar
-``cancel``        ``check_blender_cancelled`` cooperative checkpoint
-``ui``            ``BlenderUiDispatcher`` (core-backed interactive)
-``standalone``    ``BlenderStandaloneDispatcher`` (background)
-``pump``          ``BlenderTimerPump`` + factory helpers
-================  ====================================================
-
-This re-export layer is **zero-overhead**: every name binds to the same
-object as the originating submodule.  External callers do not need to
-update their imports.
-
-See: https://github.com/loonghao/dcc-mcp-blender/issues/49
-"""
+"""Blender dispatcher compatibility exports backed by dcc-mcp-core."""
 
 from __future__ import annotations
 

--- a/src/dcc_mcp_blender/dispatcher/cancel.py
+++ b/src/dcc_mcp_blender/dispatcher/cancel.py
@@ -1,45 +1,31 @@
-"""Cooperative cancellation checkpoint for Blender.
-
-Provides ``check_blender_cancelled()`` — a lightweight function that
-skill authors can call periodically to abort long-running operations
-when the user requests cancellation.
-"""
+"""Blender cooperative-cancellation compatibility helpers."""
 
 # Import future modules
 from __future__ import annotations
 
 # Import built-in modules
-import logging
-
-logger = logging.getLogger(__name__)
-
-# Cancellation flag (module-level, can be set by external code)
-_cancelled = False
+from dcc_mcp_core import CancelledError, check_dcc_cancelled
 
 
 def set_blender_cancelled(value: bool = True) -> None:
-    """Set the cancellation flag.
+    """Deprecated no-op kept for callers from older adapter builds.
 
-    Args:
-        value: ``True`` to request cancellation, ``False`` to clear.
+    Cancellation state is now owned by dcc-mcp-core per request/job.
     """
-    global _cancelled  # noqa: PLW0603
-    _cancelled = value
-    if value:
-        logger.debug("Blender operation cancellation requested")
+    _ = value
 
 
 def check_blender_cancelled() -> bool:
-    """Return ``True`` when the current operation should be aborted.
+    """Return ``True`` when core reports the active request/job was cancelled.
 
-    Skill authors can call this periodically in long-running loops::
-
-        for i in range(large_number):
-            if check_blender_cancelled():
-                return blender_error("Operation cancelled")
-            # ... do work ...
-
-    Returns:
-        ``True`` if cancellation has been requested.
+    New code should call ``dcc_mcp_core.check_dcc_cancelled()``, which raises
+    ``CancelledError`` and composes MCP-request and host-dispatcher signals.
     """
-    return _cancelled
+    try:
+        check_dcc_cancelled()
+    except CancelledError:
+        return True
+    return False
+
+
+__all__ = ["check_blender_cancelled", "set_blender_cancelled"]

--- a/src/dcc_mcp_blender/dispatcher/job.py
+++ b/src/dcc_mcp_blender/dispatcher/job.py
@@ -1,84 +1,12 @@
-"""Job entry and timeout tracking for Blender.
-
-Provides ``_JobEntry`` (job metadata) and ``_current_job`` (ContextVar)
-for tracking the currently executing skill/action.
-"""
+"""Core-backed job aliases for Blender dispatcher compatibility."""
 
 # Import future modules
 from __future__ import annotations
 
-# Import built-in modules
-import contextvars
-import logging
-import time
-from typing import Any, Dict, Optional
+from dcc_mcp_core import DEFAULT_UI_JOB_TIMEOUT_MS, HostUiJobEntry, current_job
 
-logger = logging.getLogger(__name__)
+DEFAULT_JOB_TIMEOUT_MS = DEFAULT_UI_JOB_TIMEOUT_MS
+_JobEntry = HostUiJobEntry
+_current_job = current_job
 
-DEFAULT_JOB_TIMEOUT_MS = 30000  # 30 seconds
-
-# ContextVar holding the currently executing job
-_current_job: contextvars.ContextVar[Optional["_JobEntry"]] = contextvars.ContextVar("_current_job", default=None)
-
-
-class _JobEntry:
-    """Metadata for a single job (skill action execution)."""
-
-    def __init__(
-        self,
-        job_id: str,
-        action_name: str,
-        timeout_ms: int = DEFAULT_JOB_TIMEOUT_MS,
-    ) -> None:
-        self.job_id = job_id
-        self.action_name = action_name
-        self.timeout_ms = timeout_ms
-        self.start_time = time.time()
-        self.end_time: Optional[float] = None
-        self.result: Dict[str, Any] = {}
-        self.error: Optional[str] = None
-
-    def elapsed_ms(self) -> float:
-        """Return elapsed time in milliseconds."""
-        if self.end_time is not None:
-            return (self.end_time - self.start_time) * 1000
-        return (time.time() - self.start_time) * 1000
-
-    def is_timed_out(self) -> bool:
-        """Return ``True`` if the job has exceeded its timeout."""
-        return self.elapsed_ms() > self.timeout_ms
-
-    def finish(self, result: Dict[str, Any]) -> None:
-        """Mark the job as finished successfully."""
-        self.end_time = time.time()
-        self.result = result
-        logger.debug(
-            "Job %s (%s) finished in %.1fms",
-            self.job_id,
-            self.action_name,
-            self.elapsed_ms(),
-        )
-
-    def fail(self, error: str) -> None:
-        """Mark the job as failed."""
-        self.end_time = time.time()
-        self.error = error
-        logger.warning(
-            "Job %s (%s) failed after %.1fms: %s",
-            self.job_id,
-            self.action_name,
-            self.elapsed_ms(),
-            error,
-        )
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Return a dict representation of this job."""
-        return {
-            "job_id": self.job_id,
-            "action_name": self.action_name,
-            "timeout_ms": self.timeout_ms,
-            "elapsed_ms": self.elapsed_ms(),
-            "is_timed_out": self.is_timed_out(),
-            "finished": self.end_time is not None,
-            "error": self.error,
-        }
+__all__ = ["DEFAULT_JOB_TIMEOUT_MS", "_JobEntry", "_current_job"]

--- a/src/dcc_mcp_blender/dispatcher/pump.py
+++ b/src/dcc_mcp_blender/dispatcher/pump.py
@@ -2,41 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Optional
+from typing import Any
+
+from dcc_mcp_core import PyPumpedDispatcher
 
 from dcc_mcp_blender.host import BlenderTimerPump, BlenderUiDispatcher
 
 DEFAULT_BUDGET_MS = 200
 OVERRUN_MULTIPLIER = 1.0
 
-
-class _CorePump:
-    """Compatibility wrapper for code that only needs pump counters."""
-
-    def __init__(self, budget_ms: int = DEFAULT_BUDGET_MS) -> None:
-        self._pump = BlenderTimerPump(budget_ms=budget_ms)
-
-    @property
-    def stats(self):
-        """Return Blender timer-pump stats."""
-        return self._pump.stats
-
-    def pumped_ms(self) -> float:
-        """Return the most recent timer tick duration in milliseconds."""
-        return self._pump.stats.last_tick_ms
-
-    def pump_count(self) -> int:
-        """Return number of timer pump ticks."""
-        return self._pump.stats.ticks
-
-    def reset_stats(self) -> None:
-        """Reset pump statistics."""
-        self._pump.stats.ticks = 0
-        self._pump.stats.overrun_cycles = 0
-        self._pump.stats.last_tick_ms = 0.0
-
-
 BlenderUiPump = BlenderTimerPump
+_CorePump = BlenderTimerPump
 
 
 def create_dispatcher(
@@ -61,29 +37,6 @@ def create_pumped_dispatcher(
     if ui_mode:
         return BlenderUiDispatcher(timeout_ms=timeout_ms, budget_ms=budget_ms)
     return create_dispatcher(ui_mode=False, timeout_ms=timeout_ms)
-
-
-class PyPumpedDispatcher:
-    """Compatibility wrapper that pumps before delegating string-payload dispatch."""
-
-    def __init__(
-        self,
-        dispatcher: Any,
-        pump: Optional[_CorePump] = None,
-    ) -> None:
-        self.dispatcher = dispatcher
-        self._pump = pump
-
-    def dispatch(self, func: Callable, *args: Any, **kwargs: Any) -> Any:
-        """Dispatch after recording one optional pump tick."""
-        if self._pump:
-            self._pump.stats.ticks += 1
-        return self.dispatcher.dispatch(func, *args, **kwargs)
-
-    def pump(self) -> None:
-        """Record a manual pump tick for compatibility callers."""
-        if self._pump:
-            self._pump.stats.ticks += 1
 
 
 __all__ = [

--- a/src/dcc_mcp_blender/dispatcher/standalone.py
+++ b/src/dcc_mcp_blender/dispatcher/standalone.py
@@ -1,97 +1,78 @@
-"""Blender standalone dispatcher (background mode).
-
-Provides ``BlenderStandaloneDispatcher`` — a dispatcher that runs callbacks
-directly (no main-thread marshalling needed because there's no UI).
-
-In background mode (``blender --background``), all code runs in the
-main thread anyway, so no special dispatch is needed.
-"""
+"""Core-backed Blender standalone dispatcher compatibility wrapper."""
 
 # Import future modules
 from __future__ import annotations
 
-# Import built-in modules
-import logging
-import threading
-import time
+import uuid
 from typing import Any, Callable, Dict, Optional
 
-logger = logging.getLogger(__name__)
+from dcc_mcp_core import InProcessCallableDispatcher, JobOutcome
 
 
 class BlenderStandaloneDispatcher:
     """Dispatcher for Blender standalone (background) mode.
 
-    Runs callbacks directly — no main-thread marshalling needed.
+    Uses core's reference in-process dispatcher and keeps the adapter's small
+    historical ``dispatch`` / ``dispatch_async`` convenience API.
     """
 
     def __init__(self, timeout_ms: int = 30000) -> None:
         self.timeout_ms = timeout_ms
-        self._pending: Dict[str, Callable] = {}
+        self._dispatcher = InProcessCallableDispatcher()
         self._results: Dict[str, Any] = {}
-        self._errors: Dict[str, Exception] = {}
-        self._lock = threading.Lock()
+        self._errors: Dict[str, str] = {}
 
     def dispatch(self, func: Callable, *args: Any, **kwargs: Any) -> Any:
-        """Dispatch a call (runs directly in standalone mode).
-
-        Args:
-            func: The function to call.
-            *args: Positional arguments.
-            **kwargs: Keyword arguments.
-
-        Returns:
-            The function's return value.
-        """
-        return func(*args, **kwargs)
+        """Dispatch a call inline through core's in-process dispatcher."""
+        outcome = self._dispatcher.submit_callable(
+            self._request_id(func),
+            lambda: func(*args, **kwargs),
+            affinity="main",
+            timeout_ms=self.timeout_ms,
+        )
+        return self._value_or_raise(outcome)
 
     def dispatch_async(self, func: Callable, *args: Any, **kwargs: Any) -> str:
-        """Dispatch a call asynchronously.
+        """Dispatch a call asynchronously and return a pollable request id."""
+        job_id = self._request_id(func)
 
-        Returns a job ID that can be polled for completion.
+        def _complete(outcome: JobOutcome) -> None:
+            if outcome.ok:
+                self._results[job_id] = outcome.value
+            else:
+                self._errors[job_id] = outcome.error or "Blender standalone dispatch failed"
 
-        Args:
-            func: The function to call.
-            *args: Positional arguments.
-            **kwargs: Keyword arguments.
-
-        Returns:
-            Job ID string.
-        """
-        job_id = f"job_{time.time()}_{id(func)}"
-        try:
-            result = func(*args, **kwargs)
-            with self._lock:
-                self._results[job_id] = result
-        except Exception as e:
-            with self._lock:
-                self._errors[job_id] = e
+        self._dispatcher.submit_async_callable(
+            job_id,
+            lambda: func(*args, **kwargs),
+            affinity="main",
+            timeout_ms=self.timeout_ms,
+            on_complete=_complete,
+        )
         return job_id
 
     def get_result(self, job_id: str) -> Optional[Any]:
-        """Get the result of an async job.
-
-        Args:
-            job_id: The job ID returned by ``dispatch_async``.
-
-        Returns:
-            The job result, or ``None`` if not ready.
-        """
-        with self._lock:
-            if job_id in self._results:
-                return self._results[job_id]
-            if job_id in self._errors:
-                raise self._errors[job_id]
+        """Get an async job result, or ``None`` when still pending."""
+        if job_id in self._results:
+            return self._results[job_id]
+        if job_id in self._errors:
+            raise RuntimeError(self._errors[job_id])
         return None
 
     def is_done(self, job_id: str) -> bool:
-        """Check if an async job is done.
+        """Check whether an async job has finished."""
+        return job_id in self._results or job_id in self._errors
 
-        Args:
-            job_id: The job ID returned by ``dispatch_async``.
+    @staticmethod
+    def _request_id(func: Callable) -> str:
+        label = getattr(func, "__name__", "callable")
+        return f"{label}:{uuid.uuid4().hex}"
 
-        Returns:
-            ``True`` if the job is done (success or error).
-        """
-        with self._lock:
-            return job_id in self._results or job_id in self._errors
+    @staticmethod
+    def _value_or_raise(outcome: JobOutcome) -> Any:
+        if outcome.ok:
+            return outcome.value
+        raise RuntimeError(outcome.error or "Blender standalone dispatch failed")
+
+
+__all__ = ["BlenderStandaloneDispatcher"]

--- a/src/dcc_mcp_blender/host.py
+++ b/src/dcc_mcp_blender/host.py
@@ -8,7 +8,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
-from dcc_mcp_core._server.host_ui_dispatcher import HostUiDispatcherBase
+from dcc_mcp_core import HostUiDispatcherBase
 from dcc_mcp_core.host import BlockingDispatcher, HostAdapter
 
 TickFn = Callable[[], Optional[float]]
@@ -30,7 +30,7 @@ class BlenderTimerPump:
     primitive so future core pump abstractions can replace it cleanly.
     """
 
-    def __init__(self, *, budget_ms: float = 200.0) -> None:
+    def __init__(self, budget_ms: float = 200.0) -> None:
         if budget_ms <= 0:
             raise ValueError("budget_ms must be > 0")
         self.budget_ms = float(budget_ms)
@@ -89,6 +89,20 @@ class BlenderTimerPump:
             bpy.app.timers.unregister(tick_fn)
         self._registered_fn = None
         self._tick_fn = None
+
+    def pumped_ms(self) -> float:
+        """Return the most recent timer tick duration in milliseconds."""
+        return self.stats.last_tick_ms
+
+    def pump_count(self) -> int:
+        """Return the number of timer ticks."""
+        return self.stats.ticks
+
+    def reset_stats(self) -> None:
+        """Reset timer-pump counters."""
+        self.stats.ticks = 0
+        self.stats.overrun_cycles = 0
+        self.stats.last_tick_ms = 0.0
 
 
 class BlenderUiDispatcher(HostUiDispatcherBase):

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -38,10 +38,10 @@ def test_addon_entry_bl_info_version_is_static_tuple_literal():
 def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monkeypatch):
     """The add-on package root must directly contain ``server.py`` and skills."""
     assemble_zip = _load_assemble_zip_module()
-    fake_wheel = tmp_path / "dcc_mcp_core-0.17.34-cp38-abi3-win_amd64.whl"
+    fake_wheel = tmp_path / "dcc_mcp_core-0.17.36-cp38-abi3-win_amd64.whl"
     fake_wheel.write_bytes(b"fake wheel")
 
-    monkeypatch.setattr(assemble_zip, "resolve_core_version", lambda min_version="0.17.34": "0.17.34")
+    monkeypatch.setattr(assemble_zip, "resolve_core_version", lambda min_version="0.17.36": "0.17.36")
     monkeypatch.setattr(assemble_zip, "download_core_wheel", lambda version, platform, dest_dir: fake_wheel)
 
     zip_path = assemble_zip.assemble(platform="win64", output_dir=tmp_path)
@@ -57,7 +57,7 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     assert "skills/blender-scene/SKILL.md" in names
     assert not any(name.startswith("dcc_mcp_blender/") for name in names)
     assert '"version": (0, 1, 4)' in addon_init
-    assert "./wheels/dcc_mcp_core-0.17.34-cp38-abi3-win_amd64.whl" in manifest
+    assert "./wheels/dcc_mcp_core-0.17.36-cp38-abi3-win_amd64.whl" in manifest
     assert manifest.index("wheels = [") < manifest.index("[permissions]")
 
 

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -17,10 +17,10 @@ def _load_assemble_zip_module():
     return mod
 
 
-def test_core_dependency_floor_is_01734():
+def test_core_dependency_floor_is_01736():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert '"dcc-mcp-core>=0.17.34,<1.0.0"' in pyproject
+    assert '"dcc-mcp-core>=0.17.36,<1.0.0"' in pyproject
 
 
 def test_packaging_core_floor_matches_pyproject():

--- a/tests/test_host_adapter.py
+++ b/tests/test_host_adapter.py
@@ -102,7 +102,7 @@ def test_blender_callable_dispatcher_posts_work_to_tick_loop():
 
 
 def test_blender_ui_dispatcher_uses_core_queue_and_timer_pump():
-    from dcc_mcp_core._server.host_ui_dispatcher import HostUiDispatcherBase
+    from dcc_mcp_core import HostUiDispatcherBase
 
     from dcc_mcp_blender.host import BlenderUiDispatcher
 


### PR DESCRIPTION
## Summary
- Raise the dcc-mcp-core floor to 0.17.36 across dependency, packaging, docs, and tests.
- Replace adapter-local dispatcher compatibility code with thin wrappers around core public dispatcher, job, pump, and cancellation APIs.
- Switch host UI dispatcher imports to the public dcc_mcp_core export.

## Validation
- python -m pytest
- python -m ruff check .

Note: Real Blender e2e was not run locally because Blender is not installed on this machine.