### PR TITLE
feat: latest dcc-mcp-core integrations + agent install skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ See [`src/dcc_mcp_blender/skills/SKILLS_INDEX.md`](src/dcc_mcp_blender/skills/SK
 
 ## Installation
 
+### Agent install (recommended)
+
+Want an AI agent to install the Blender-side dependencies, write the MCP host
+config, and walk you through enabling the add-on? Just ask your agent:
+
+```text
+帮我参考 loonghao/dcc-mcp-blender/install.md 去安装
+```
+
+The agent follows [`install.md`](install.md), which delegates the setup workflow
+to [`skills/dcc-mcp-blender-setup`](skills/dcc-mcp-blender-setup). The remaining
+options below are for manual installation.
+
 ### Option 1 — Install as Blender Addon (ZIP)
 
 1. Download the latest platform ZIP from the [Releases](https://github.com/loonghao/dcc-mcp-blender/releases) page:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![GitHub release downloads](https://img.shields.io/github/downloads/loonghao/dcc-mcp-blender/total.svg?label=release%20downloads)](https://github.com/loonghao/dcc-mcp-blender/releases)
 [![GitHub Release](https://img.shields.io/github/v/release/loonghao/dcc-mcp-blender.svg)](https://github.com/loonghao/dcc-mcp-blender/releases)
 [![Coverage](https://img.shields.io/badge/coverage-pytest--cov-blue.svg)](https://github.com/loonghao/dcc-mcp-blender/blob/main/pyproject.toml)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.36-blue.svg)](https://github.com/loonghao/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.47-blue.svg)](https://github.com/loonghao/dcc-mcp-core)
 [![Blender](https://img.shields.io/badge/Blender-3.6%20LTS%20%7C%204.2%20LTS%20%7C%204.3%20%7C%204.4-orange.svg)](https://www.blender.org/download/releases/)
 [![MCP](https://img.shields.io/badge/MCP-2025--03--26-purple.svg)](https://modelcontextprotocol.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/install.md
+++ b/install.md
@@ -1,0 +1,85 @@
+# dcc-mcp-blender Agent Install
+
+Use this page when an agent is asked to install or configure
+`loonghao/dcc-mcp-blender` for Blender.
+
+## Agent Instruction
+
+If the user says "帮我参考 loonghao/dcc-mcp-blender/install.md 去安装",
+do this:
+
+1. Read `skills/dcc-mcp-blender-setup/SKILL.md`.
+2. Run the setup script from the repository root.
+3. Help the user enable the Blender add-on (or start the server in Blender).
+4. Configure the MCP host with the generated Streamable HTTP JSON.
+5. Run the smoke prompt to prove the connection works.
+
+## One Command
+
+From the repository root:
+
+```bash
+python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py
+```
+
+For an end-user install from PyPI instead of this checkout:
+
+```bash
+python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py --source pypi
+```
+
+If Blender's bundled Python is not auto-detected:
+
+```bash
+python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py --blender-python "C:\Program Files\Blender Foundation\Blender 4.2\4.2\python\bin\python.exe"
+```
+
+Blender ships its own Python at `<blender>/<major.minor>/python/bin/python(.exe)`.
+The script discovers it via env vars (`BLENDER_PYTHON`, `DCC_MCP_BLENDER_PYTHON`),
+the `--blender-python` / `--python` argument, a `blender` launcher on `PATH`, or
+common install locations, then runs `<blender_python> -m pip install ...`.
+
+## Blender Add-on Step
+
+After the script finishes, the user must enable the add-on in Blender:
+
+1. Open Blender (4.2+ recommended).
+2. Go to `Edit > Preferences > Extensions > Install from Disk…`.
+3. Select the release ZIP (`dcc_mcp_blender_addon_<platform>_vX.Y.Z.zip`).
+4. Enable **DCC MCP Blender** — the embedded server starts automatically.
+
+The Blender 4.2+ add-on ZIP bundles the matching `dcc-mcp-core` wheel inside the
+extension's isolated environment, so the manual pip step is only needed for
+pip / CI scenarios. For those, start the server from Blender's Python console:
+
+```python
+import dcc_mcp_blender
+dcc_mcp_blender.start_server()
+```
+
+Blender uses first-wins auto-gateway on port `8765`, so the MCP server is
+exposed at:
+
+```text
+http://127.0.0.1:8765/mcp
+```
+
+## MCP Config
+
+Use this JSON for Cursor, Claude Desktop, or any MCP Streamable HTTP host:
+
+```json
+{
+  "mcpServers": {
+    "blender": {
+      "url": "http://127.0.0.1:8765/mcp"
+    }
+  }
+}
+```
+
+The setup script also writes the config snippet and a smoke prompt under:
+
+```text
+.dcc-mcp/agent-setup/
+```

--- a/packaging/addon_entry/__init__.py
+++ b/packaging/addon_entry/__init__.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 bl_info = {
     "name": "DCC MCP Blender",
     "author": "Long Hao",
-    "version": (0, 1, 4),
+    "version": (0, 1, 5),
     "blender": (4, 2, 0),
     "location": "Top Bar > DCC MCP",
     "description": "Embeds an MCP HTTP server inside Blender for AI-driven 3D workflows",

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -44,7 +44,7 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.17.36"
+MIN_CORE_VERSION = "0.17.47"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,10 @@ classifiers = [
 ]
 
 dependencies = [
-    # Align with dcc-mcp-core 0.17.36 public dispatcher, cancellation,
-    # execution-bridge, diagnostics/resources, and skill-management contracts.
-    "dcc-mcp-core>=0.17.36,<1.0.0",
+    # 0.17.43+: builtin registration passes skills to recipes; 0.17.47 semantic
+    # wheel fixes; AdapterReadinessBinder (0.17.32+) and
+    # register_metadata_driven_tools (0.17.34+) for unified sidecar registration.
+    "dcc-mcp-core>=0.17.47,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/skills/dcc-mcp-blender-setup/SKILL.md
+++ b/skills/dcc-mcp-blender-setup/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: dcc-mcp-blender-setup
+description: |-
+  Set up dcc-mcp-blender for an agent or operator: install Blender Python
+  dependencies with Blender's bundled interpreter, generate MCP host
+  configuration, guide the user through enabling the Blender add-on, and run a
+  first live-tool smoke prompt.
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: blender
+    layer: operator
+    stage: bootstrap
+    version: 1.0.0
+    tags:
+    - blender
+    - mcp
+    - setup
+    - addon
+    - bootstrap
+---
+# dcc-mcp-blender setup
+
+Use this skill when a user wants an agent to prepare a machine so any MCP
+host can use `dcc-mcp-blender` with Blender.
+
+This is an operator skill, not a Blender runtime skill. Do not load it through
+the Blender MCP server. Run it from the repository checkout or copy its steps
+into another agent's instructions.
+
+If the user says "帮我参考 `loonghao/dcc-mcp-blender/install.md` 去安装", read the
+root `install.md` first, then follow this skill.
+
+## Goal
+
+End with:
+
+- `dcc-mcp-blender` and its pip dependencies installed into the target Blender
+  bundled-Python environment (or available via the add-on ZIP's isolated
+  wheels).
+- An MCP host config snippet that points to the Blender MCP server.
+- The user guided to enable the **DCC MCP Blender** add-on so the embedded
+  server starts.
+- A live smoke prompt that proves the agent can discover and call Blender tools.
+
+## Fast Path
+
+From the repository root, run:
+
+```bash
+python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py
+```
+
+The script:
+
+1. Finds Blender's bundled Python from `--blender-python` / `--python`,
+   `BLENDER_PYTHON`, `DCC_MCP_BLENDER_PYTHON`, a `blender` launcher on `PATH`,
+   or common install locations on Windows/macOS/Linux
+   (`<blender>/<major.minor>/python/bin/python(.exe)`).
+2. Installs this checkout into Blender's Python: `python -m pip install -e .`.
+   `dcc-mcp-blender` ships no optional extras, so the package is installed
+   plainly and `dcc-mcp-core` is resolved transitively.
+3. Verifies `import dcc_mcp_blender`.
+4. Writes a reusable MCP JSON snippet and smoke prompt under
+   `.dcc-mcp/agent-setup/`.
+
+Use PyPI instead of the local checkout when setting up an end-user machine:
+
+```bash
+python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py --source pypi
+```
+
+If discovery fails, ask the user for the full Blender Python path and re-run:
+
+```bash
+python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py --blender-python "C:\Program Files\Blender Foundation\Blender 4.2\4.2\python\bin\python.exe"
+```
+
+> Blender 4.2+ add-on installs (Option 1 in `README.md`) bundle the
+> `dcc-mcp-core` wheel inside the extension's isolated environment, so a manual
+> pip step into Blender's Python is only required for pip/CI scenarios or older
+> Blender add-on layouts.
+
+## MCP Configuration
+
+Blender uses first-wins auto-gateway on port `8765`. Configure the MCP host
+with:
+
+```json
+{
+  "mcpServers": {
+    "blender": {
+      "url": "http://127.0.0.1:8765/mcp"
+    }
+  }
+}
+```
+
+When multiple Blender instances run, the first to bind `8765` becomes the
+gateway and later instances register behind it; point your host at `8765`.
+
+When editing an existing MCP config, preserve unrelated servers. Merge only the
+`blender` server entry unless the user asks for a different server name.
+
+## User Hand-Off: Enable the Blender Add-on
+
+After pip setup and MCP JSON generation, tell the user:
+
+1. Open Blender (4.2+ recommended).
+2. Go to `Edit > Preferences > Extensions > Install from Disk…`.
+3. Select the release ZIP
+   (`dcc_mcp_blender_addon_<platform>_vX.Y.Z.zip` from the Releases page).
+4. Enable **DCC MCP Blender**.
+5. The embedded MCP server starts automatically; use the top-bar
+   `DCC MCP > Show Server URLs…` menu to confirm the URL.
+
+The expected URL is `http://127.0.0.1:8765/mcp`.
+
+For pip/CI installs without the add-on, start the server from Blender's Python
+console instead:
+
+```python
+import dcc_mcp_blender
+dcc_mcp_blender.start_server()
+```
+
+Or run headless:
+
+```bash
+blender --background --python src/dcc_mcp_blender/blender_bootstrap.py
+```
+
+## First Live Smoke Prompt
+
+Ask the MCP host to run this prompt after Blender is open and the add-on is
+enabled:
+
+```text
+Use the Blender MCP server. First call dcc_capability_manifest with loaded_only=false.
+Then load the blender-geometry skill, create a sphere named mcp_setup_smoke_sphere
+with radius 2, list scene objects, and tell me the MCP URL and created object name.
+Use typed tools where available and avoid execute_python unless no typed tool fits.
+```
+
+Expected behavior:
+
+- The agent discovers capabilities without dumping every schema.
+- The agent loads `blender-geometry`.
+- The agent calls `blender_geometry__create_sphere`.
+- The new object appears in the Blender scene.
+- `blender_scene__list_objects` or another scene query confirms it exists.
+
+## Troubleshooting
+
+- Blender Python not found: ask for the exact Blender version and the
+  `<blender>/<major.minor>/python/bin/python(.exe)` path, then pass
+  `--blender-python`.
+- Pip bootstrap fails: run `<blender_python> -m ensurepip --upgrade`, then
+  repeat the install.
+- MCP connection refused: Blender is not running, the add-on is not enabled, or
+  the embedded server has not started yet.
+- Tool missing: call `dcc_capability_manifest` or `search_skills`, then
+  `load_skill("<skill-name>")`.
+- Add-on enabled but no server: check Blender's system console for
+  `[DCC MCP Blender]` startup lines, and verify firewall/localhost rules.

--- a/skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py
+++ b/skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py
@@ -1,0 +1,224 @@
+"""Prepare a Blender bundled-Python environment for dcc-mcp-blender MCP use."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+DEFAULT_MCP_URL = "http://127.0.0.1:8765/mcp"
+
+
+def run(command: list[str], cwd: Optional[Path] = None) -> None:
+    print("+ " + " ".join(command))
+    subprocess.check_call(command, cwd=str(cwd) if cwd else None)
+
+
+def _glob_blender_python(root: str) -> Iterable[Path]:
+    """Yield Blender bundled interpreters under *root* (``<ver>/python/bin/python*``)."""
+    if not root:
+        return
+    exe = "python.exe" if os.name == "nt" else "python*"
+    # Blender layouts:
+    #   Windows: <root>/Blender X.Y/X.Y/python/bin/python.exe
+    #   Linux:   <root>/blender-X.Y.Z/X.Y/python/bin/python3.X
+    #   macOS:   <root>/Blender.app/Contents/Resources/X.Y/python/bin/python3.X
+    patterns = [
+        os.path.join(root, "*", "*", "python", "bin", exe),
+        os.path.join(root, "*", "python", "bin", exe),
+        os.path.join(root, "*", "Contents", "Resources", "*", "python", "bin", exe),
+        os.path.join(root, "Contents", "Resources", "*", "python", "bin", exe),
+        os.path.join(root, "*", "*", "Contents", "Resources", "*", "python", "bin", exe),
+    ]
+    matches: list[str] = []
+    for pattern in patterns:
+        matches.extend(glob.glob(pattern))
+    # Prefer the newest Blender version (lexical sort is good enough for X.Y dirs).
+    for match in sorted(matches, reverse=True):
+        yield Path(match)
+
+
+def candidate_blender_python_paths() -> Iterable[Path]:
+    env_value = os.environ.get("BLENDER_PYTHON") or os.environ.get("DCC_MCP_BLENDER_PYTHON")
+    if env_value:
+        yield Path(env_value)
+
+    # If a `blender` launcher is on PATH, its bundled python sits next to it
+    # under <install>/<major.minor>/python/bin/python(.exe).
+    blender_launcher = shutil.which("blender")
+    if blender_launcher:
+        install_root = Path(blender_launcher).resolve().parent
+        for found in _glob_blender_python(str(install_root)):
+            yield found
+
+    if os.name == "nt":
+        roots = [
+            os.environ.get("ProgramFiles"),
+            os.environ.get("ProgramFiles(x86)"),
+        ]
+        for root in roots:
+            if not root:
+                continue
+            yield from _glob_blender_python(os.path.join(root, "Blender Foundation"))
+    elif sys.platform == "darwin":
+        yield from _glob_blender_python("/Applications")
+        yield from _glob_blender_python(os.path.expanduser("~/Applications"))
+    else:
+        yield from _glob_blender_python("/usr/share/blender")
+        yield from _glob_blender_python("/opt/blender")
+        yield from _glob_blender_python(os.path.expanduser("~/blender"))
+        snap = shutil.which("blender")
+        if snap:
+            yield from _glob_blender_python("/snap/blender/current")
+
+
+def resolve_blender_python(explicit: Optional[str]) -> Path:
+    if explicit:
+        path = Path(explicit).expanduser()
+        if path.exists():
+            return path
+        raise SystemExit("Blender Python does not exist: %s" % path)
+
+    seen = set()
+    for path in candidate_blender_python_paths():
+        expanded = path.expanduser()
+        key = str(expanded).lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        if expanded.exists():
+            return expanded
+
+    raise SystemExit(
+        "Could not find Blender's bundled Python. Re-run with --blender-python "
+        '(e.g. "C:\\Program Files\\Blender Foundation\\Blender 4.2\\4.2\\python\\bin\\python.exe"), '
+        "or set BLENDER_PYTHON to the full path."
+    )
+
+
+def find_repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for parent in [current] + list(current.parents):
+        if (parent / "pyproject.toml").exists() and (parent / "src" / "dcc_mcp_blender").exists():
+            return parent
+    return Path.cwd()
+
+
+def install_package(blender_python: Path, source: str, repo_root: Path, skip_install: bool) -> None:
+    if skip_install:
+        print("Skipping pip install because --skip-install was passed.")
+        return
+
+    run([str(blender_python), "-m", "ensurepip", "--upgrade"])
+    run([str(blender_python), "-m", "pip", "install", "--upgrade", "pip"])
+
+    # dcc-mcp-blender ships no optional install extras (no `[sidecar]`); install
+    # the package plainly. The dcc-mcp-core dependency is resolved transitively.
+    if source == "local":
+        run([str(blender_python), "-m", "pip", "install", "-e", "."], cwd=repo_root)
+    elif source == "pypi":
+        run([str(blender_python), "-m", "pip", "install", "--upgrade", "dcc-mcp-blender"])
+    else:
+        raise SystemExit("Unknown source: %s" % source)
+
+
+def verify_import(blender_python: Path) -> None:
+    code = (
+        "import dcc_mcp_blender; "
+        "print('dcc-mcp-blender', dcc_mcp_blender.__version__); "
+        "import dcc_mcp_core; "
+        "print('dcc-mcp-core import ok')"
+    )
+    run([str(blender_python), "-c", code])
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print("Wrote %s" % path)
+
+
+def write_mcp_snippets(out_dir: Path, server_name: str, mcp_url: str) -> None:
+    payload = {"mcpServers": {server_name: {"url": mcp_url}}}
+    write_json(out_dir / "mcp-streamable-http.json", payload)
+
+    smoke_prompt = """Use the Blender MCP server. First call dcc_capability_manifest with loaded_only=false.
+Then load the blender-geometry skill, create a sphere named mcp_setup_smoke_sphere
+with radius 2, list scene objects, and tell me the MCP URL and created object name.
+Use typed tools where available and avoid execute_python unless no typed tool fits.
+"""
+    smoke_path = out_dir / "smoke-prompt.txt"
+    smoke_path.write_text(smoke_prompt, encoding="utf-8")
+    print("Wrote %s" % smoke_path)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--blender-python",
+        "--python",
+        dest="blender_python",
+        help="Full path to Blender's bundled Python interpreter.",
+    )
+    parser.add_argument(
+        "--source",
+        choices=["local", "pypi"],
+        default="local",
+        help="Install from this checkout or from PyPI. Default: local.",
+    )
+    parser.add_argument(
+        "--mcp-url",
+        default=DEFAULT_MCP_URL,
+        help="MCP URL to write into generated host config. Default: %s." % DEFAULT_MCP_URL,
+    )
+    parser.add_argument(
+        "--server-name",
+        default="blender",
+        help="MCP server name in generated config. Default: blender.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=".dcc-mcp/agent-setup",
+        help="Directory for generated MCP snippets. Default: .dcc-mcp/agent-setup.",
+    )
+    parser.add_argument(
+        "--skip-install",
+        action="store_true",
+        help="Only verify imports and write MCP snippets.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo_root = find_repo_root()
+    blender_python = resolve_blender_python(args.blender_python)
+    out_dir = (repo_root / args.out_dir).resolve()
+
+    print("Repository: %s" % repo_root)
+    print("Blender Python: %s" % blender_python)
+    print("MCP URL: %s" % args.mcp_url)
+
+    install_package(blender_python, args.source, repo_root, args.skip_install)
+    if not args.skip_install:
+        verify_import(blender_python)
+    write_mcp_snippets(out_dir, args.server_name, args.mcp_url)
+
+    print("")
+    print("Next:")
+    print("1. Open Blender.")
+    print("2. Edit > Preferences > Extensions > Install from Disk (the release ZIP), then enable 'DCC MCP Blender'.")
+    print("3. Configure the MCP host with %s." % (out_dir / "mcp-streamable-http.json"))
+    print("4. Run the smoke prompt in %s." % (out_dir / "smoke-prompt.txt"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/dcc_mcp_blender/__init__.py
+++ b/src/dcc_mcp_blender/__init__.py
@@ -3,8 +3,47 @@
 from __future__ import annotations
 
 from dcc_mcp_blender.__version__ import __version__
+from dcc_mcp_blender._capability_manifest import (
+    BlenderCapabilityManifestBuilder,
+    CapabilityRecord,
+    build_manifest_payload,
+    register_capability_mcp_tool,
+)
+from dcc_mcp_blender._project_tools import (
+    ENV_PROJECT_TOOLS,
+    BlenderSceneResolver,
+    ProjectToolsIntegration,
+)
+from dcc_mcp_blender._project_tools import (
+    attach_to_server as attach_project_tools,
+)
+from dcc_mcp_blender._readiness import (
+    ENV_READINESS_TIMEOUT_SECS,
+    ReadinessBinder,
+    install_readiness,
+    resolve_readiness_timeout_secs,
+)
+from dcc_mcp_blender._resources import (
+    DEFAULT_SCENE_HANDLERS,
+    DEFAULT_SCENE_THROTTLE_SECS,
+    ENV_RESOURCES,
+    SCHEME_BLENDER_DATA,
+    BlenderResourceBinder,
+    install_resources,
+)
+from dcc_mcp_blender._semantic_index import (
+    ENV_SEMANTIC_EMBEDDER,
+    ENV_SEMANTIC_INDEX,
+    BlenderSemanticIndex,
+    build_semantic_index,
+)
 from dcc_mcp_blender.api import skill_entry, skill_error, skill_exception, skill_success
 from dcc_mcp_blender.capabilities import blender_capabilities, blender_capabilities_dict
+from dcc_mcp_blender.context_snapshot import (
+    BlenderContextSnapshotProvider,
+    collect_gateway_metadata,
+    make_snapshot_provider,
+)
 from dcc_mcp_blender.host import BlenderHost, BlenderTimerPump, BlenderUiDispatcher
 from dcc_mcp_blender.server import (
     DEFAULT_PORT,
@@ -34,4 +73,35 @@ __all__ = [
     "get_server",
     "start_server",
     "stop_server",
+    # Capability manifest
+    "CapabilityRecord",
+    "BlenderCapabilityManifestBuilder",
+    "build_manifest_payload",
+    "register_capability_mcp_tool",
+    # Context snapshot
+    "BlenderContextSnapshotProvider",
+    "collect_gateway_metadata",
+    "make_snapshot_provider",
+    # Project-state persistence
+    "ENV_PROJECT_TOOLS",
+    "BlenderSceneResolver",
+    "ProjectToolsIntegration",
+    "attach_project_tools",
+    # Resource publishing
+    "ENV_RESOURCES",
+    "DEFAULT_SCENE_HANDLERS",
+    "DEFAULT_SCENE_THROTTLE_SECS",
+    "SCHEME_BLENDER_DATA",
+    "BlenderResourceBinder",
+    "install_resources",
+    # Runtime readiness
+    "ENV_READINESS_TIMEOUT_SECS",
+    "ReadinessBinder",
+    "install_readiness",
+    "resolve_readiness_timeout_secs",
+    # Semantic skill recall (opt-in)
+    "ENV_SEMANTIC_INDEX",
+    "ENV_SEMANTIC_EMBEDDER",
+    "BlenderSemanticIndex",
+    "build_semantic_index",
 ]

--- a/src/dcc_mcp_blender/_capability_manifest.py
+++ b/src/dcc_mcp_blender/_capability_manifest.py
@@ -1,0 +1,502 @@
+"""Compact Blender capability manifest for gateway indexing.
+
+Ports :mod:`dcc_mcp_maya.capability_manifest` to Blender.  Provides a compact
+per-action record set the gateway capability index can ingest without
+exploding every unloaded skill's full MCP schema into ``tools/list``.
+
+* :class:`CapabilityRecord` — value object; no behaviour.
+* :class:`BlenderCapabilityManifestBuilder` — projects the live skill catalog
+  into a list of :class:`CapabilityRecord`.
+* :func:`build_manifest_payload` — pure function turning records into the
+  final manifest dict (adds instance metadata + totals).
+* :func:`register_capability_mcp_tool` — registers the
+  ``dcc_capability_manifest`` MCP tool.
+
+No code here talks to Blender directly — it only projects what the catalog
+already discovered, so calling it during startup is safe.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "CapabilityRecord",
+    "BlenderCapabilityManifestBuilder",
+    "build_manifest_payload",
+    "register_capability_mcp_tool",
+]
+
+_SKILL_STUB_PREFIX = "__skill__"
+_GROUP_STUB_PREFIX = "__group__"
+
+_DCC_NAME = "blender"
+
+
+@dataclass(frozen=True)
+class CapabilityRecord:
+    """Compact per-action record (field semantics match core CapabilityIndex)."""
+
+    tool_slug: str
+    backend_tool: str
+    skill_name: str
+    summary: str
+    loaded: bool
+    tags: List[str] = field(default_factory=list)
+    execution: Optional[str] = None
+    affinity: Optional[str] = None
+    timeout_hint_secs: Optional[int] = None
+    has_schema: bool = False
+    group: Optional[str] = None
+    load_hint: Dict[str, Any] = field(default_factory=dict)
+    requires_load_skill: bool = False
+    callable_id: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Plain dict form suitable for JSON serialisation (token-budget friendly)."""
+        payload = asdict(self)
+        out = {k: v for k, v in payload.items() if v not in (None, [], "", {})}
+        if out.get("requires_load_skill") is False:
+            out.pop("requires_load_skill", None)
+        if out.get("callable_id") == out.get("backend_tool"):
+            out.pop("callable_id", None)
+        return out
+
+
+class BlenderCapabilityManifestBuilder:
+    """Turn live catalog state into a list of :class:`CapabilityRecord`."""
+
+    def __init__(
+        self,
+        dcc_name: str = _DCC_NAME,
+        *,
+        skill_lister: Optional[Callable[[], List[Any]]] = None,
+        action_lister: Optional[Callable[[], List[Any]]] = None,
+        is_loaded: Optional[Callable[[str], bool]] = None,
+        skill_info_lister: Optional[Callable[[str], Any]] = None,
+    ) -> None:
+        self._dcc_name = dcc_name
+        self._skill_lister = skill_lister
+        self._action_lister = action_lister
+        self._is_loaded = is_loaded
+        self._skill_info_lister = skill_info_lister
+
+    # ------------------------------------------------------------------ API
+
+    def build(self) -> List[CapabilityRecord]:
+        """Return records for every non-stub action (loaded and unloaded)."""
+        skills_by_name = self._collect_skill_info()
+        records: List[CapabilityRecord] = []
+        covered_tools: set = set()
+
+        for action in self._collect_actions():
+            record = self._project_action(action, skills_by_name)
+            if record is None:
+                continue
+            records.append(record)
+            covered_tools.add(record.backend_tool)
+
+        for skill_name, skill_info in skills_by_name.items():
+            if self._is_loaded_safe(skill_name):
+                continue
+            for tool in self._collect_skill_tools(skill_name, skill_info):
+                record = self._project_unloaded_action(
+                    skill_name=skill_name,
+                    tool=tool,
+                    skill_info=skill_info,
+                )
+                if record is None or record.backend_tool in covered_tools:
+                    continue
+                records.append(record)
+                covered_tools.add(record.backend_tool)
+
+        return records
+
+    # ------------------------------------------------------------ internals
+
+    def _collect_skill_info(self) -> Dict[str, Dict[str, Any]]:
+        skills: Dict[str, Dict[str, Any]] = {}
+        if self._skill_lister is None:
+            return skills
+        try:
+            raw = self._skill_lister() or []
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("capability manifest: skill_lister failed: %s", exc)
+            return skills
+        for item in raw:
+            entry = _as_dict(item)
+            name = entry.get("name") or entry.get("skill_name")
+            if not name:
+                continue
+            skills[name] = entry
+        return skills
+
+    def _collect_actions(self) -> List[Dict[str, Any]]:
+        if self._action_lister is None:
+            return []
+        try:
+            raw = self._action_lister() or []
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("capability manifest: action_lister failed: %s", exc)
+            return []
+        return [_as_dict(a) for a in raw if a]
+
+    def _project_action(
+        self,
+        action: Dict[str, Any],
+        skills_by_name: Dict[str, Dict[str, Any]],
+    ) -> Optional[CapabilityRecord]:
+        name = action.get("name") or action.get("tool")
+        if not name or _is_stub(name):
+            return None
+
+        skill_name = action.get("skill") or action.get("skill_name") or _derive_skill(name)
+        skill_info = skills_by_name.get(skill_name or "", {})
+        summary = _truncate(
+            _first_nonempty(
+                action.get("summary"),
+                action.get("description"),
+                skill_info.get("summary"),
+                skill_info.get("description"),
+                "",
+            ),
+            200,
+        )
+
+        tags: List[str] = []
+        for source in (
+            action.get("tags"),
+            skill_info.get("tags"),
+            [action.get("category")],
+            [action.get("group")],
+        ):
+            tags.extend(_as_str_list(source))
+        tags = sorted({t for t in tags if t})
+
+        loaded = self._is_loaded_safe(skill_name) if skill_name else False
+        has_schema = bool(action.get("input_schema") or action.get("inputSchema"))
+
+        return CapabilityRecord(
+            tool_slug=_slugify_tool_slug(self._dcc_name, name),
+            backend_tool=name,
+            skill_name=skill_name or "",
+            summary=summary or "",
+            loaded=bool(loaded),
+            tags=tags,
+            execution=_maybe_str(action.get("execution")),
+            affinity=_maybe_str(action.get("affinity")),
+            timeout_hint_secs=_maybe_int(action.get("timeout_hint_secs")),
+            has_schema=has_schema,
+            group=_maybe_str(action.get("group")),
+            callable_id=name,
+        )
+
+    def _collect_skill_tools(
+        self,
+        skill_name: str,
+        skill_info: Dict[str, Any],
+    ) -> List[Dict[str, Any]]:
+        tools = skill_info.get("tools") or skill_info.get("actions")
+        if isinstance(tools, list) and tools and isinstance(tools[0], dict):
+            return [dict(t) for t in tools]
+        if self._skill_info_lister is None:
+            return []
+        try:
+            info = self._skill_info_lister(skill_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("capability manifest: skill_info(%r) raised %s", skill_name, exc)
+            return []
+        if not info:
+            return []
+        entry = _as_dict(info)
+        collected = entry.get("tools") or entry.get("actions") or []
+        return [_as_dict(t) for t in collected if t]
+
+    def _project_unloaded_action(
+        self,
+        *,
+        skill_name: str,
+        tool: Dict[str, Any],
+        skill_info: Dict[str, Any],
+    ) -> Optional[CapabilityRecord]:
+        tool_name = tool.get("name") or tool.get("tool")
+        if not tool_name or _is_stub(tool_name):
+            return None
+
+        backend_tool = "{}__{}".format(skill_name.replace("-", "_"), tool_name)
+        summary = _truncate(_first_nonempty(tool.get("summary"), tool.get("description"), ""), 160)
+
+        tags: List[str] = []
+        for source in (
+            tool.get("tags"),
+            skill_info.get("tags"),
+            [tool.get("category")],
+            [tool.get("group")],
+        ):
+            tags.extend(_as_str_list(source))
+        tags = sorted({t for t in tags if t})
+
+        schema = tool.get("input_schema") or tool.get("inputSchema")
+        has_schema = bool(schema) and not _is_stub(tool_name)
+
+        return CapabilityRecord(
+            tool_slug=_slugify_tool_slug(self._dcc_name, backend_tool),
+            backend_tool=backend_tool,
+            skill_name=skill_name,
+            summary=summary,
+            loaded=False,
+            tags=tags,
+            execution=_maybe_str(tool.get("execution")),
+            affinity=_maybe_str(tool.get("affinity")),
+            timeout_hint_secs=_maybe_int(tool.get("timeout_hint_secs")),
+            has_schema=has_schema,
+            group=_maybe_str(tool.get("group")),
+            requires_load_skill=True,
+            load_hint={"tool": "load_skill", "arguments": {"skill_name": skill_name}},
+            callable_id=backend_tool,
+        )
+
+    def _is_loaded_safe(self, skill_name: str) -> bool:
+        if self._is_loaded is None:
+            return False
+        try:
+            return bool(self._is_loaded(skill_name))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("capability manifest: is_loaded(%r) raised %s", skill_name, exc)
+            return False
+
+
+# ---------------------------------------------------------------------------
+# Payload assembly
+# ---------------------------------------------------------------------------
+
+
+def build_manifest_payload(
+    records: List[CapabilityRecord],
+    *,
+    dcc_name: str = _DCC_NAME,
+    dcc_version: Optional[str] = None,
+    scene: Optional[str] = None,
+    display_name: Optional[str] = None,
+    instance_id: Optional[str] = None,
+    documents: Optional[List[str]] = None,
+    extra_metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Wrap records with instance metadata for gateway ingestion."""
+    loaded_records = [r for r in records if r.loaded]
+    unloaded_records = [r for r in records if not r.loaded]
+    manifest = {
+        "schema_version": "1",
+        "dcc_type": dcc_name,
+        "metadata": {
+            "instance_id": instance_id,
+            "dcc_version": dcc_version,
+            "scene": scene,
+            "display_name": display_name,
+            "documents": documents or [],
+        },
+        "totals": {
+            "actions": len(records),
+            "loaded_actions": len(loaded_records),
+            "unloaded_actions": len(unloaded_records),
+            "skills": len({r.skill_name for r in records if r.skill_name}),
+            "loaded_skills": len({r.skill_name for r in loaded_records if r.skill_name}),
+            "unloaded_skills": len({r.skill_name for r in unloaded_records if r.skill_name}),
+        },
+        "capabilities": [r.to_dict() for r in records],
+    }
+    if extra_metadata:
+        manifest["metadata"].update({k: v for k, v in extra_metadata.items() if v is not None})
+    manifest["metadata"] = {k: v for k, v in manifest["metadata"].items() if v not in (None, "")}
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# MCP tool registration
+# ---------------------------------------------------------------------------
+
+
+def register_capability_mcp_tool(server: Any, *, builder: BlenderCapabilityManifestBuilder) -> bool:
+    """Register ``dcc_capability_manifest`` as an MCP tool. Returns success."""
+    inner = getattr(server, "_server", None)
+    if inner is None:
+        logger.debug("capability manifest: server has no inner _server; skipping")
+        return False
+
+    tool_name = "dcc_capability_manifest"
+    description = (
+        "Return a compact Blender capability manifest listing every discoverable "
+        "action (loaded and unloaded), tagged by skill/group. Prefer this over "
+        "tools/list when the caller only needs to decide which skill to load."
+    )
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "loaded_only": {
+                "type": "boolean",
+                "description": "When true, omit records for unloaded skills.",
+                "default": False,
+            },
+        },
+        "additionalProperties": False,
+    }
+
+    def handler(params: Dict[str, Any]) -> Dict[str, Any]:
+        records = builder.build()
+        if params.get("loaded_only"):
+            records = [r for r in records if r.loaded]
+        instance_id = _extract_instance_id(server)
+        scene = getattr(getattr(server, "_config", None), "scene", None)
+        version = getattr(getattr(server, "_config", None), "dcc_version", None)
+        payload = build_manifest_payload(
+            records,
+            dcc_name=_DCC_NAME,
+            dcc_version=version,
+            scene=scene,
+            instance_id=instance_id,
+        )
+        return {"success": True, "message": "Blender capability manifest", "context": payload}
+
+    registry = getattr(inner, "registry", None)
+    declared = False
+    if registry is not None and hasattr(registry, "register"):
+        try:
+            registry.register(
+                tool_name,
+                description=description,
+                category="dcc",
+                tags=["capability", "manifest", "dcc", "blender"],
+                dcc=_DCC_NAME,
+                input_schema=json.dumps(input_schema),
+                skill_name="dcc-adapter",
+                group="capability",
+                execution="sync",
+                thread_affinity="any",
+                enabled=True,
+            )
+            declared = True
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("capability manifest: registry.register failed: %s", exc)
+
+    if not declared:
+        logger.debug("capability manifest: could not declare tool — skipping")
+        return False
+
+    try:
+        inner.register_handler(tool_name, handler)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("capability manifest: register_handler failed: %s", exc)
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_SLUG_CLEAN_RE = re.compile(r"[^A-Za-z0-9_]")
+
+
+def _slugify_tool_slug(dcc_name: str, tool_name: str) -> str:
+    clean_dcc = _SLUG_CLEAN_RE.sub("_", dcc_name)
+    clean_tool = _SLUG_CLEAN_RE.sub("_", tool_name)
+    return "{}.instance.{}".format(clean_dcc, clean_tool)
+
+
+def _is_stub(name: str) -> bool:
+    return name.startswith(_SKILL_STUB_PREFIX) or name.startswith(_GROUP_STUB_PREFIX)
+
+
+def _derive_skill(tool_name: str) -> Optional[str]:
+    if "__" not in tool_name:
+        return None
+    return tool_name.split("__", 1)[0].replace("_", "-")
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        try:
+            result = to_dict()
+            if isinstance(result, dict):
+                return result
+        except (TypeError, ValueError, AttributeError) as exc:
+            logger.debug("capability manifest: to_dict(%r) failed: %s", type(value), exc)
+    out: Dict[str, Any] = {}
+    for attr in dir(value):
+        if attr.startswith("_"):
+            continue
+        try:
+            candidate = getattr(value, attr)
+        except (AttributeError, TypeError) as exc:
+            logger.debug("capability manifest: getattr(%r, %s) failed: %s", type(value), attr, exc)
+            continue
+        if callable(candidate):
+            continue
+        out[attr] = candidate
+    return out
+
+
+def _as_str_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [str(v) for v in value if v]
+    return [str(value)]
+
+
+def _first_nonempty(*values: Any) -> str:
+    for v in values:
+        if v:
+            return str(v)
+    return ""
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _maybe_str(value: Any) -> Optional[str]:
+    if value is None or value == "":
+        return None
+    return str(value)
+
+
+def _maybe_int(value: Any) -> Optional[int]:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_instance_id(server: Any) -> Optional[str]:
+    for chain in (
+        ("instance_id",),
+        ("_config", "instance_id"),
+        ("_server", "instance_id"),
+        ("_handle", "instance_id"),
+    ):
+        target = server
+        try:
+            for part in chain:
+                target = getattr(target, part)
+            if target:
+                return str(target)
+        except AttributeError:
+            continue
+    return None

--- a/src/dcc_mcp_blender/_env.py
+++ b/src/dcc_mcp_blender/_env.py
@@ -27,11 +27,34 @@ ENV_DISABLE_EXECUTE_PYTHON = "DCC_MCP_BLENDER_DISABLE_EXECUTE_PYTHON"
 ENV_DISABLE_ARBITRARY_SCRIPT = "DCC_MCP_BLENDER_DISABLE_ARBITRARY_SCRIPT"
 ENV_BLENDER_PATH = "DCC_MCP_BLENDER_PATH"
 ENV_BLENDER_VERSION = "BLENDER_VERSION"
+#: Advisory readiness probe timeout (positive integer seconds) — parity with
+#: Maya / Houdini ``_readiness`` wiring.
+ENV_READINESS_TIMEOUT_SECS = "DCC_MCP_BLENDER_READINESS_TIMEOUT_SECS"
+#: Opt out of the four ``project_*`` MCP tools (``"0"`` disables).
+ENV_PROJECT_TOOLS = "DCC_MCP_BLENDER_PROJECT_TOOLS"
+#: Opt out of MCP resource publishing such as ``scene://current`` (``"0"`` disables).
+ENV_RESOURCES = "DCC_MCP_BLENDER_RESOURCES"
+#: Enable the opt-in lexical+vector semantic skill recall augmentation.
+ENV_SEMANTIC_INDEX = "DCC_MCP_BLENDER_SEMANTIC_INDEX"
+#: ``hashed`` (default, zero-dep) or ``onnx`` (requires the ``[semantic]`` extra).
+ENV_SEMANTIC_EMBEDDER = "DCC_MCP_BLENDER_SEMANTIC_EMBEDDER"
 DEFAULT_JOB_DB_FILENAME = "jobs.db"
+
+_TRUTHY = ("1", "true", "yes", "on")
 
 
 def _env_truthy(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes", "on")
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+def _resolve_opt_out(env_name: str, flag: Optional[bool]) -> bool:
+    """Resolve an opt-out flag: explicit arg > env (``"0"`` disables) > ``True``."""
+    if flag is not None:
+        return bool(flag)
+    raw = os.environ.get(env_name)
+    if raw is None:
+        return True
+    return raw.strip() != "0"
 
 
 def resolve_execute_python_disabled() -> bool:
@@ -119,3 +142,60 @@ def resolve_blender_path() -> Optional[str]:
     """
     path = os.environ.get(ENV_BLENDER_PATH, "").strip()
     return path if path else None
+
+
+def resolve_readiness_timeout_secs(readiness_timeout_secs: Optional[int] = None) -> Optional[int]:
+    """Resolve :data:`ENV_READINESS_TIMEOUT_SECS` into a positive integer or ``None``.
+
+    Priority: explicit argument > ``DCC_MCP_BLENDER_READINESS_TIMEOUT_SECS`` > ``None``.
+    Invalid / non-positive values resolve to ``None`` (no advisory timeout).
+    """
+    if readiness_timeout_secs is not None:
+        try:
+            val = int(readiness_timeout_secs)
+        except (TypeError, ValueError):
+            return None
+        return val if val > 0 else None
+
+    raw = os.environ.get(ENV_READINESS_TIMEOUT_SECS)
+    if not raw or not raw.strip():
+        return None
+    try:
+        val = int(raw.strip())
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid %s=%r (expected positive integer seconds)",
+            ENV_READINESS_TIMEOUT_SECS,
+            raw,
+        )
+        return None
+    return val if val > 0 else None
+
+
+def resolve_project_tools_enabled(flag: Optional[bool] = None) -> bool:
+    """Resolve whether the ``project_*`` tools should be wired in.
+
+    Priority: explicit ``flag`` > ``DCC_MCP_BLENDER_PROJECT_TOOLS`` (``"0"`` disables) > ``True``.
+    """
+    return _resolve_opt_out(ENV_PROJECT_TOOLS, flag)
+
+
+def resolve_resources_enabled(flag: Optional[bool] = None) -> bool:
+    """Resolve whether MCP resource publishing should run.
+
+    Priority: explicit ``flag`` > ``DCC_MCP_BLENDER_RESOURCES`` (``"0"`` disables) > ``True``.
+    """
+    return _resolve_opt_out(ENV_RESOURCES, flag)
+
+
+def resolve_semantic_index_enabled(env: Optional[dict] = None) -> bool:
+    """Return ``True`` when ``DCC_MCP_BLENDER_SEMANTIC_INDEX`` is truthy (default off)."""
+    environ = env if env is not None else os.environ
+    return str(environ.get(ENV_SEMANTIC_INDEX, "")).strip().lower() in _TRUTHY
+
+
+def resolve_semantic_embedder_kind(env: Optional[dict] = None) -> str:
+    """Return the requested embedder kind: ``"hashed"`` (default) or ``"onnx"``."""
+    environ = env if env is not None else os.environ
+    kind = str(environ.get(ENV_SEMANTIC_EMBEDDER, "hashed")).strip().lower()
+    return "onnx" if kind == "onnx" else "hashed"

--- a/src/dcc_mcp_blender/_project_tools.py
+++ b/src/dcc_mcp_blender/_project_tools.py
@@ -1,0 +1,167 @@
+"""Blender integration for ``dcc_mcp_core.register_project_tools``.
+
+Ports :mod:`dcc_mcp_maya._project_tools` to Blender.  Wires the four
+project-persistence MCP/REST tools from ``dcc-mcp-core``:
+
+* ``project_save``   — persist current Blender project state to ``.dcc-mcp/project.json``
+* ``project_load``   — read an existing ``project.json`` back
+* ``project_resume`` — return the rehydration payload an agent needs to restore
+  scene, assets, active skills, tool groups and checkpoint IDs
+* ``project_status`` — pure-read snapshot of the current state
+
+The scene resolver discovers the current ``.blend`` file through
+``bpy.data.filepath`` inside a guarded import so this module stays usable
+outside Blender (tests, ``--background`` with no file open, gateway-only
+deployments).
+
+Opt-out: set ``DCC_MCP_BLENDER_PROJECT_TOOLS=0``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from dcc_mcp_blender import _env
+
+logger = logging.getLogger(__name__)
+
+ENV_PROJECT_TOOLS = _env.ENV_PROJECT_TOOLS
+
+_DCC_NAME = "blender"
+
+
+class BlenderSceneResolver:
+    """Resolve the *current* Blender file path, if one is open.
+
+    Returns ``None`` when no file is saved (unsaved ``.blend`` has an empty
+    ``bpy.data.filepath``).  The default implementation guards the ``bpy``
+    import so the module remains importable in plain Python.
+    """
+
+    def current_scene(self) -> Optional[str]:
+        """Return the absolute ``.blend`` path, or ``None`` when unavailable."""
+        try:
+            import bpy  # noqa: PLC0415
+        except Exception:  # noqa: BLE001 — Blender unavailable
+            return None
+        try:
+            filepath = bpy.data.filepath
+        except Exception as exc:  # noqa: BLE001 — Blender in odd state
+            logger.debug("BlenderSceneResolver: bpy.data.filepath failed: %s", exc)
+            return None
+        filepath = (filepath or "").strip()
+        return filepath or None
+
+
+def resolve_enabled(flag: Optional[bool] = None) -> bool:
+    """Resolve whether project tools should be wired in (``"0"`` disables)."""
+    return _env.resolve_project_tools_enabled(flag)
+
+
+class ProjectToolsIntegration:
+    """Bind ``register_project_tools`` against a :class:`BlenderMcpServer`."""
+
+    def __init__(
+        self,
+        *,
+        dcc_name: str = _DCC_NAME,
+        scene_resolver: Optional[BlenderSceneResolver] = None,
+    ) -> None:
+        self.dcc_name = dcc_name
+        self.scene_resolver = scene_resolver or BlenderSceneResolver()
+        self.bound_scene: Optional[str] = None
+        self.bound_project: Any = None
+        self.registered: bool = False
+
+    # ── Public API ──────────────────────────────────────────────────────
+
+    def bind(
+        self,
+        server: Any,
+        *,
+        project_factory: Optional[Callable[[str], Any]] = None,
+        explicit_project: Any = None,
+    ) -> bool:
+        """Register the four project tools on *server*. Returns success."""
+        from dcc_mcp_core import DccProject, register_project_tools  # noqa: PLC0415
+
+        inner = self._inner_server(server)
+        if inner is None:
+            return False
+
+        project = explicit_project
+        if project is None:
+            scene = self._safe_resolve_scene()
+            if scene:
+                factory = project_factory or DccProject.open
+                try:
+                    project = factory(scene)
+                except Exception as exc:  # noqa: BLE001 — unwriteable dir, etc.
+                    logger.debug("ProjectToolsIntegration.bind: DccProject.open(%s) failed: %s", scene, exc)
+                    project = None
+
+        try:
+            register_project_tools(inner, dcc_name=self.dcc_name, project=project)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("ProjectToolsIntegration.bind: register_project_tools raised: %s", exc)
+            return False
+
+        self.bound_scene = getattr(project, "state", None) and project.state.scene_path
+        self.bound_project = project
+        self.registered = True
+        logger.info(
+            "[%s] project tools registered (default scene=%s)",
+            self.dcc_name,
+            self.bound_scene or "<none>",
+        )
+        return True
+
+    # ── Internals ───────────────────────────────────────────────────────
+
+    @staticmethod
+    def _inner_server(server: Any) -> Any:
+        """Return the inner Rust ``McpHttpServer`` exposing registry + handler."""
+        inner = getattr(server, "_server", None)
+        if inner is None:
+            return None
+        if not hasattr(inner, "register_handler") or not hasattr(inner, "registry"):
+            return None
+        return inner
+
+    def _safe_resolve_scene(self) -> Optional[str]:
+        try:
+            scene = self.scene_resolver.current_scene()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("ProjectToolsIntegration: scene resolver raised: %s", exc)
+            return None
+        if not scene:
+            return None
+        try:
+            scene = str(Path(scene))
+        except Exception:  # noqa: BLE001
+            scene = str(scene)
+        return scene
+
+
+def attach_to_server(
+    server: Any,
+    *,
+    enabled: Optional[bool] = None,
+    dcc_name: str = _DCC_NAME,
+    scene_resolver: Optional[BlenderSceneResolver] = None,
+    project_factory: Optional[Callable[[str], Any]] = None,
+    explicit_project: Any = None,
+) -> Optional[ProjectToolsIntegration]:
+    """One-shot helper used by :meth:`BlenderMcpServer.register_builtin_actions`.
+
+    Returns the bound :class:`ProjectToolsIntegration`, or ``None`` when the
+    env var disabled the surface or registration failed.
+    """
+    if not resolve_enabled(enabled):
+        return None
+    integration = ProjectToolsIntegration(dcc_name=dcc_name, scene_resolver=scene_resolver)
+    if integration.bind(server, project_factory=project_factory, explicit_project=explicit_project):
+        return integration
+    return None

--- a/src/dcc_mcp_blender/_readiness.py
+++ b/src/dcc_mcp_blender/_readiness.py
@@ -1,8 +1,12 @@
 """Runtime readiness wiring for :class:`BlenderMcpServer`.
 
-Ports the Houdini three-state readiness binder to Blender.  The probe itself
-(``process`` / ``dispatcher`` / ``dcc`` bits) lives in ``dcc-mcp-core`` as
-:class:`dcc_mcp_core.ReadinessProbe`; this module only owns the *wiring*:
+Delegates probe lifecycle to core :class:`dcc_mcp_core.readiness.AdapterReadinessBinder`
+(0.17.32+) while retaining the Blender-specific dispatcher-probe pattern via
+:func:`_default_probe_scheduler`.
+
+The probe itself (``process`` / ``dispatcher`` / ``dcc`` bits) lives in
+``dcc-mcp-core`` as :class:`dcc_mcp_core.ReadinessProbe`; this module only
+owns the *wiring*:
 
 * ``process``    — flipped by core the moment the server object exists.
 * ``dispatcher`` — flipped as soon as the binder runs (the execution bridge
@@ -20,6 +24,8 @@ from __future__ import annotations
 
 import logging
 from typing import Any, Callable, Optional
+
+from dcc_mcp_core.readiness import AdapterReadinessBinder
 
 from dcc_mcp_blender import _env
 
@@ -40,11 +46,12 @@ def _default_probe_scheduler(dispatcher: Any, on_done: Callable[[], None]) -> bo
     """Schedule a dcc-ready probe on *dispatcher*.
 
     Prefers ``submit_async_callable`` (core UI dispatchers) so the no-op
-    runs on Blender's main thread; falls back to ``submit_callable`` and
-    finally to an immediate ``on_done()`` when no async path exists.
+    runs on Blender's main thread; falls back to an immediate ``on_done()``
+    when no async path exists (post/tick-style dispatchers).
     """
     submit_async = getattr(dispatcher, "submit_async_callable", None)
     if callable(submit_async):
+
         def _on_complete(_result: Any) -> None:
             on_done()
 
@@ -67,7 +74,7 @@ def _default_probe_scheduler(dispatcher: Any, on_done: Callable[[], None]) -> bo
 
 
 class ReadinessBinder:
-    """Drive a :class:`dcc_mcp_core.ReadinessProbe` across a Blender lifecycle."""
+    """Drive readiness using core :class:`AdapterReadinessBinder` with Blender lifecycle hooks."""
 
     def __init__(
         self,
@@ -78,12 +85,17 @@ class ReadinessBinder:
         from dcc_mcp_core import ReadinessProbe  # noqa: PLC0415
 
         self.timeout_secs: Optional[int] = resolve_readiness_timeout_secs(timeout_secs)
-        self.probe = ReadinessProbe()
+        self.probe: ReadinessProbe = ReadinessProbe()
         self.probe_scheduler: ProbeScheduler = probe_scheduler or _default_probe_scheduler
+        self._adapter_binder: Optional[AdapterReadinessBinder] = None
         self.bound_server: Any = None
         self.bound_dispatcher: Any = None
         self.dcc_scheduled: bool = False
-        self.published_to_server: bool = False
+
+    @property
+    def published_to_server(self) -> bool:
+        """Whether the probe was published to the inner Rust server."""
+        return self._adapter_binder.published if self._adapter_binder else False
 
     def report(self) -> dict:
         """Return the current three-state readiness snapshot."""
@@ -94,30 +106,22 @@ class ReadinessBinder:
         return self.probe.is_ready()
 
     def bind(self, server: Any) -> bool:
-        """Wire the probe into *server*.
-
-        Publishes the probe through ``server._server.set_readiness_probe`` so
-        MCP ``tools/call``, REST ``/v1/readyz`` and ``/v1/call`` share state,
-        flips the ``dispatcher`` bit, then schedules the ``dcc`` probe on the
-        attached host dispatcher (or marks it ready immediately when none is
-        attached — background / standalone mode).
-        """
+        """Wire the probe into *server*."""
         if self.bound_server is server:
             return self.dcc_scheduled
         self.bound_server = server
 
-        try:
-            server._server.set_readiness_probe(self.probe)
-            self.published_to_server = True
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("[blender] readiness: set_readiness_probe failed: %s", exc)
-
-        self.mark_dispatcher_ready()
+        self._adapter_binder = AdapterReadinessBinder(server, probe=self.probe, publish=True)
+        self._adapter_binder.mark_dispatcher_ready(
+            True,
+            host_execution_bridge_ready=True,
+            main_thread_executor_ready=True,
+        )
 
         dispatcher = getattr(server, "_blender_dispatcher", None)
         if dispatcher is None:
             self.bound_dispatcher = None
-            self.mark_dcc_ready()
+            self._adapter_binder.mark_inline_ready()
             self.dcc_scheduled = True
             return True
 

--- a/src/dcc_mcp_blender/_readiness.py
+++ b/src/dcc_mcp_blender/_readiness.py
@@ -1,0 +1,169 @@
+"""Runtime readiness wiring for :class:`BlenderMcpServer`.
+
+Ports the Houdini three-state readiness binder to Blender.  The probe itself
+(``process`` / ``dispatcher`` / ``dcc`` bits) lives in ``dcc-mcp-core`` as
+:class:`dcc_mcp_core.ReadinessProbe`; this module only owns the *wiring*:
+
+* ``process``    — flipped by core the moment the server object exists.
+* ``dispatcher`` — flipped as soon as the binder runs (the execution bridge
+  is wired during ``__init__``).
+* ``dcc``        — flipped after a no-op is marshalled onto Blender's main
+  thread (via the attached host dispatcher / ``bpy.app.timers`` pump), or
+  immediately in background (``--background``) / standalone mode where the
+  HTTP worker thread *is* the pump.
+
+Every step degrades gracefully: a missing ``ReadinessProbe`` API or a
+dispatcher without async submission still produces a usable binder.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Optional
+
+from dcc_mcp_blender import _env
+
+logger = logging.getLogger(__name__)
+
+ENV_READINESS_TIMEOUT_SECS = _env.ENV_READINESS_TIMEOUT_SECS
+READINESS_PROBE_REQUEST_ID = "dcc_mcp_blender__readiness__dcc_ready_probe"
+
+ProbeScheduler = Callable[[Any, Callable[[], None]], bool]
+
+
+def resolve_readiness_timeout_secs(readiness_timeout_secs: Optional[int] = None) -> Optional[int]:
+    """Resolve :data:`ENV_READINESS_TIMEOUT_SECS` into a positive integer or ``None``."""
+    return _env.resolve_readiness_timeout_secs(readiness_timeout_secs)
+
+
+def _default_probe_scheduler(dispatcher: Any, on_done: Callable[[], None]) -> bool:
+    """Schedule a dcc-ready probe on *dispatcher*.
+
+    Prefers ``submit_async_callable`` (core UI dispatchers) so the no-op
+    runs on Blender's main thread; falls back to ``submit_callable`` and
+    finally to an immediate ``on_done()`` when no async path exists.
+    """
+    submit_async = getattr(dispatcher, "submit_async_callable", None)
+    if callable(submit_async):
+        def _on_complete(_result: Any) -> None:
+            on_done()
+
+        try:
+            submit_async(
+                request_id=READINESS_PROBE_REQUEST_ID,
+                task=lambda: None,
+                affinity="main",
+                timeout_ms=5_000,
+                on_complete=_on_complete,
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[blender] readiness: submit_async_callable failed: %s", exc)
+
+    # No async path available — flip the bit immediately so a usable
+    # dispatcher never leaves ``dcc`` permanently red.
+    on_done()
+    return True
+
+
+class ReadinessBinder:
+    """Drive a :class:`dcc_mcp_core.ReadinessProbe` across a Blender lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        timeout_secs: Optional[int] = None,
+        probe_scheduler: Optional[ProbeScheduler] = None,
+    ) -> None:
+        from dcc_mcp_core import ReadinessProbe  # noqa: PLC0415
+
+        self.timeout_secs: Optional[int] = resolve_readiness_timeout_secs(timeout_secs)
+        self.probe = ReadinessProbe()
+        self.probe_scheduler: ProbeScheduler = probe_scheduler or _default_probe_scheduler
+        self.bound_server: Any = None
+        self.bound_dispatcher: Any = None
+        self.dcc_scheduled: bool = False
+        self.published_to_server: bool = False
+
+    def report(self) -> dict:
+        """Return the current three-state readiness snapshot."""
+        return self.probe.report()
+
+    def is_ready(self) -> bool:
+        """Return ``True`` when all three bits are green."""
+        return self.probe.is_ready()
+
+    def bind(self, server: Any) -> bool:
+        """Wire the probe into *server*.
+
+        Publishes the probe through ``server._server.set_readiness_probe`` so
+        MCP ``tools/call``, REST ``/v1/readyz`` and ``/v1/call`` share state,
+        flips the ``dispatcher`` bit, then schedules the ``dcc`` probe on the
+        attached host dispatcher (or marks it ready immediately when none is
+        attached — background / standalone mode).
+        """
+        if self.bound_server is server:
+            return self.dcc_scheduled
+        self.bound_server = server
+
+        try:
+            server._server.set_readiness_probe(self.probe)
+            self.published_to_server = True
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[blender] readiness: set_readiness_probe failed: %s", exc)
+
+        self.mark_dispatcher_ready()
+
+        dispatcher = getattr(server, "_blender_dispatcher", None)
+        if dispatcher is None:
+            self.bound_dispatcher = None
+            self.mark_dcc_ready()
+            self.dcc_scheduled = True
+            return True
+
+        self.bound_dispatcher = dispatcher
+        try:
+            self.dcc_scheduled = bool(self.probe_scheduler(dispatcher, self.mark_dcc_ready))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[blender] readiness: probe scheduler raised: %s", exc)
+            self.mark_dcc_ready()
+            self.dcc_scheduled = True
+        return self.dcc_scheduled
+
+    def mark_dispatcher_ready(self, value: bool = True) -> None:
+        """Flip the ``dispatcher`` bit."""
+        try:
+            self.probe.set_dispatcher_ready(value)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[blender] readiness: set_dispatcher_ready failed: %s", exc)
+
+    def mark_dcc_ready(self, value: bool = True) -> None:
+        """Flip the ``dcc`` bit."""
+        try:
+            self.probe.set_dcc_ready(value)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[blender] readiness: set_dcc_ready failed: %s", exc)
+            return
+        if value:
+            logger.info("[blender] readiness: dcc-ready — main thread is pumping")
+
+
+def install_readiness(
+    server: Any,
+    *,
+    timeout_secs: Optional[int] = None,
+    probe_scheduler: Optional[ProbeScheduler] = None,
+) -> Optional[ReadinessBinder]:
+    """One-shot helper used by :class:`BlenderMcpServer.__init__`.
+
+    Returns the bound :class:`ReadinessBinder`, or ``None`` when the core
+    ``ReadinessProbe`` API is unavailable (older core) so startup never
+    raises on an optional integration.
+    """
+    try:
+        binder = ReadinessBinder(timeout_secs=timeout_secs, probe_scheduler=probe_scheduler)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[blender] readiness unavailable: %s", exc)
+        return None
+    binder.bind(server)
+    return binder

--- a/src/dcc_mcp_blender/_resources.py
+++ b/src/dcc_mcp_blender/_resources.py
@@ -1,0 +1,337 @@
+"""Blender resource publishing wiring.
+
+Ports the Maya resource binder to Blender.  Core ships
+``McpHttpServer.resources()`` → ``ResourceHandle`` with ``set_scene`` /
+``register_producer`` / ``notify_updated``.  ``scene://current`` is a built-in
+resource URI that returns ``status: no_scene_published`` until the embedding
+adapter calls ``set_scene(...)``.  This module is that adapter for Blender.
+
+Blender has no ``scriptJob`` API, so scene-change republishing is driven by
+``bpy.app.handlers`` (``save_post`` / ``load_post`` / ``depsgraph_update_post``)
+through an injectable installer.  Every Blender access is lazy and guarded so
+the module is importable in plain Python (tests, ``--background``).
+
+Opt-out: set ``DCC_MCP_BLENDER_RESOURCES=0``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+from dcc_mcp_blender import _env
+
+logger = logging.getLogger(__name__)
+
+ENV_RESOURCES = _env.ENV_RESOURCES
+
+#: Throttle for ``scene://current`` republishing.  ``depsgraph_update_post``
+#: fires extremely frequently, so collapse storms into one publish per window.
+DEFAULT_SCENE_THROTTLE_SECS: float = 0.5
+
+#: ``bpy.app.handlers`` names whose firing triggers a republish.
+DEFAULT_SCENE_HANDLERS: tuple = (
+    "save_post",
+    "load_post",
+    "depsgraph_update_post",
+)
+
+#: Blender-specific dynamic resource scheme exposing ``bpy.data`` counts.
+SCHEME_BLENDER_DATA = "blender-data://"
+
+
+def resolve_enabled(flag: Optional[bool] = None) -> bool:
+    """Resolve whether resource wiring should run (``"0"`` disables)."""
+    return _env.resolve_resources_enabled(flag)
+
+
+# ---------------------------------------------------------------------------
+# Producer callables — pure functions, lazy bpy import
+# ---------------------------------------------------------------------------
+
+
+def _read_text(text: str, mime: str = "text/plain") -> Dict[str, Any]:
+    return {"mimeType": mime, "text": text}
+
+
+def _bpy():
+    """Lazy ``bpy`` import; returns ``None`` outside Blender."""
+    try:
+        import bpy  # noqa: PLC0415
+
+        return bpy
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _blender_data_producer(uri: str) -> Dict[str, Any]:  # noqa: ARG001 — single scheme
+    """Producer for ``blender-data://current`` returning a ``bpy.data`` summary."""
+    bpy = _bpy()
+    if bpy is None:
+        return _read_text(json.dumps({"status": "blender_unavailable"}), mime="application/json")
+    summary: Dict[str, Any] = {}
+    for collection in ("objects", "meshes", "materials", "collections", "lights", "cameras", "node_groups"):
+        try:
+            summary[collection] = len(getattr(bpy.data, collection))
+        except Exception:  # noqa: BLE001
+            continue
+    try:
+        summary["filepath"] = str(bpy.data.filepath or "")
+    except Exception:  # noqa: BLE001
+        pass
+    return _read_text(json.dumps({"data": summary}), mime="application/json")
+
+
+# ---------------------------------------------------------------------------
+# Scene-event installer (bpy.app.handlers)
+# ---------------------------------------------------------------------------
+
+
+SnapshotProvider = Callable[[], Dict[str, Any]]
+EventInstaller = Callable[[Callable[[], None], tuple], List[Callable]]
+BusyChecker = Callable[[], bool]
+
+
+def _default_event_installer(callback: Callable[[], None], handlers: tuple) -> List[Callable]:
+    """Append a wrapper to each ``bpy.app.handlers`` list in *handlers*.
+
+    Returns the list of installed wrapper callables (for cleanup).  Best
+    effort: unknown handler names are skipped, a missing ``bpy`` yields ``[]``.
+    """
+    bpy = _bpy()
+    if bpy is None:
+        return []
+    installed: List[Callable] = []
+    for name in handlers:
+        handler_list = getattr(bpy.app.handlers, name, None)
+        if handler_list is None:
+            continue
+
+        def _wrapper(*_args: Any, _cb=callback) -> None:
+            _cb()
+
+        try:
+            handler_list.append(_wrapper)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("resources: handler append(%s) refused: %s", name, exc)
+            continue
+        installed.append(_wrapper)
+        # Stash the handler-list name on the wrapper for removal.
+        setattr(_wrapper, "_dcc_handler_name", name)
+    return installed
+
+
+def _default_event_remover(wrappers: List[Callable]) -> None:
+    """Remove wrappers installed by :func:`_default_event_installer`."""
+    bpy = _bpy()
+    if bpy is None:
+        return
+    for wrapper in wrappers:
+        name = getattr(wrapper, "_dcc_handler_name", None)
+        handler_list = getattr(bpy.app.handlers, name, None) if name else None
+        if handler_list is None:
+            continue
+        try:
+            handler_list.remove(wrapper)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("resources: handler remove(%s) failed: %s", name, exc)
+
+
+# ---------------------------------------------------------------------------
+# Blender-side binder
+# ---------------------------------------------------------------------------
+
+
+class BlenderResourceBinder:
+    """Compose every ``server._server.resources()`` call for Blender."""
+
+    def __init__(
+        self,
+        *,
+        snapshot_provider: Optional[SnapshotProvider] = None,
+        event_installer: Optional[EventInstaller] = None,
+        busy_checker: Optional[BusyChecker] = None,
+        throttle_secs: float = DEFAULT_SCENE_THROTTLE_SECS,
+        handlers: tuple = DEFAULT_SCENE_HANDLERS,
+    ) -> None:
+        self.snapshot_provider: Optional[SnapshotProvider] = snapshot_provider
+        self.event_installer: EventInstaller = event_installer or _default_event_installer
+        self.busy_checker: Optional[BusyChecker] = busy_checker
+        self.throttle_secs: float = max(0.0, float(throttle_secs))
+        self.handlers: tuple = handlers
+
+        self.bound_server: Any = None
+        self.handle: Any = None
+        self.registered_producers: List[str] = []
+        self.scene_event_handles: List[Callable] = []
+        self.scene_publish_count: int = 0
+
+        self._lock = threading.Lock()
+        self._pending_publish: bool = False
+        self._last_publish_at: float = 0.0
+        self._publish_timer: Optional[threading.Timer] = None
+        self._unbound: bool = False
+
+    # ── Public API ──────────────────────────────────────────────────────
+
+    def bind(self, server: Any) -> bool:
+        """Resolve the resource handle, register producers, publish a snapshot."""
+        if self.bound_server is server:
+            return True
+        self.bound_server = server
+        self._unbound = False
+
+        try:
+            self.handle = server._server.resources()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("resources: server.resources() unavailable: %s", exc)
+            return False
+
+        self._register_producer(SCHEME_BLENDER_DATA, _blender_data_producer)
+
+        if self.snapshot_provider is not None:
+            self._publish_scene_now()
+        return True
+
+    def install_scene_events(self) -> List[Callable]:
+        """Hook ``bpy.app.handlers`` so scene mutations republish ``scene://current``."""
+        if self.bound_server is None:
+            return []
+        if self.scene_event_handles:
+            return list(self.scene_event_handles)
+        handles = self.event_installer(self._on_scene_event, self.handlers)
+        self.scene_event_handles = list(handles)
+        return list(self.scene_event_handles)
+
+    def unbind(self) -> None:
+        """Detach handlers and stop pending publishes.  Idempotent."""
+        if self._unbound:
+            return
+        self._unbound = True
+
+        with self._lock:
+            timer = self._publish_timer
+            self._publish_timer = None
+            self._pending_publish = False
+        if timer is not None:
+            try:
+                timer.cancel()
+            except Exception:  # noqa: BLE001
+                pass
+
+        if self.scene_event_handles:
+            try:
+                _default_event_remover(self.scene_event_handles)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("resources: event remover raised: %s", exc)
+            self.scene_event_handles = []
+
+    def publish_scene(self, payload: Optional[Dict[str, Any]] = None) -> None:
+        """Publish a scene snapshot now, bypassing throttling."""
+        if self.handle is None:
+            return
+        if payload is None:
+            if self.snapshot_provider is None:
+                return
+            try:
+                payload = self.snapshot_provider()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("resources: snapshot provider raised: %s", exc)
+                return
+        try:
+            self.handle.set_scene(payload)
+            self.scene_publish_count += 1
+            self._last_publish_at = time.monotonic()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("resources: set_scene raised: %s", exc)
+
+    # ── Internals ───────────────────────────────────────────────────────
+
+    def _register_producer(self, scheme: str, producer: Callable[[str], Dict[str, Any]]) -> None:
+        if self.handle is None:
+            return
+        try:
+            self.handle.register_producer(scheme, producer)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("resources: register_producer(%s) raised: %s", scheme, exc)
+            return
+        self.registered_producers.append(scheme)
+
+    def _is_executor_busy(self) -> bool:
+        if self.busy_checker is None:
+            return False
+        try:
+            return bool(self.busy_checker())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("resources: busy checker raised: %s", exc)
+            return False
+
+    def _on_scene_event(self) -> None:
+        """Handler callback: schedule a throttled scene republish."""
+        if self._unbound or self._is_executor_busy():
+            return
+        with self._lock:
+            now = time.monotonic()
+            since = now - self._last_publish_at
+            if since >= self.throttle_secs:
+                schedule_now = True
+                self._pending_publish = False
+            else:
+                schedule_now = False
+                if not self._pending_publish:
+                    delay = self.throttle_secs - since
+                    self._pending_publish = True
+                    self._publish_timer = threading.Timer(delay, self._on_throttle_fire)
+                    self._publish_timer.daemon = True
+                    self._publish_timer.start()
+        if schedule_now:
+            self._publish_scene_now()
+
+    def _on_throttle_fire(self) -> None:
+        if self._unbound or self._is_executor_busy():
+            return
+        with self._lock:
+            self._pending_publish = False
+            self._publish_timer = None
+        self._publish_scene_now()
+
+    def _publish_scene_now(self) -> None:
+        self.publish_scene()
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience
+# ---------------------------------------------------------------------------
+
+
+def install_resources(
+    server: Any,
+    *,
+    enabled: Optional[bool] = None,
+    snapshot_provider: Optional[SnapshotProvider] = None,
+    install_scene_events: bool = True,
+    busy_checker: Optional[BusyChecker] = None,
+    throttle_secs: float = DEFAULT_SCENE_THROTTLE_SECS,
+) -> Optional[BlenderResourceBinder]:
+    """One-shot helper called from :meth:`BlenderMcpServer.register_builtin_actions`.
+
+    Returns the :class:`BlenderResourceBinder` when installation succeeded, or
+    ``None`` when resources were disabled (``DCC_MCP_BLENDER_RESOURCES=0``) or
+    the inner Rust ``McpHttpServer.resources()`` raised.
+    """
+    if not resolve_enabled(enabled):
+        logger.debug("resources: disabled via env var")
+        return None
+    binder = BlenderResourceBinder(
+        snapshot_provider=snapshot_provider,
+        busy_checker=busy_checker,
+        throttle_secs=throttle_secs,
+    )
+    if not binder.bind(server):
+        return None
+    if install_scene_events:
+        binder.install_scene_events()
+    return binder

--- a/src/dcc_mcp_blender/_semantic_index.py
+++ b/src/dcc_mcp_blender/_semantic_index.py
@@ -1,0 +1,211 @@
+"""Optional morphology-aware semantic skill recall for Blender.
+
+Ports :mod:`dcc_mcp_maya._semantic_index`.  ``BlenderMcpServer.search_skills``
+routes through the Rust BM25-lite scorer in ``dcc-mcp-skills``, which misses
+morphology variants a natural-language agent commonly produces (``"rendering
+the active frame"`` does not tokenise to the literal ``render`` token).
+
+This module fuses the Python-side ``VectorSkillIndex`` (``HashedEmbedder``
+char-3-gram defaults, zero runtime deps) with a ``LexicalSkillIndex`` through
+``RrfFusionIndex``.  The fused index is used **only to augment** the canonical
+base results: base ordering is preserved verbatim and vector-only recalls are
+appended afterwards.
+
+Unlike the Maya port, Blender's ``search_skills`` / ``list_skills`` return
+plain dicts, so the helpers below accept either dicts or attribute objects.
+
+Gated behind ``DCC_MCP_BLENDER_SEMANTIC_INDEX=1`` (default off).  When the
+optional ``dcc-mcp-core[semantic]`` extra is installed,
+``DCC_MCP_BLENDER_SEMANTIC_EMBEDDER=onnx`` swaps in the dense ``OnnxEmbedder``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional, Sequence
+
+from dcc_mcp_blender import _env
+
+logger = logging.getLogger(__name__)
+
+ENV_SEMANTIC_INDEX = _env.ENV_SEMANTIC_INDEX
+ENV_SEMANTIC_EMBEDDER = _env.ENV_SEMANTIC_EMBEDDER
+
+
+def resolve_semantic_index_enabled(env: Optional[dict] = None) -> bool:
+    """Return ``True`` when ``DCC_MCP_BLENDER_SEMANTIC_INDEX`` is truthy."""
+    return _env.resolve_semantic_index_enabled(env)
+
+
+def resolve_embedder_kind(env: Optional[dict] = None) -> str:
+    """Return the requested embedder kind: ``"hashed"`` (default) or ``"onnx"``."""
+    return _env.resolve_semantic_embedder_kind(env)
+
+
+def _get(summary: Any, key: str, default: Any = None) -> Any:
+    """Read *key* from a dict or attribute object summary."""
+    if isinstance(summary, dict):
+        return summary.get(key, default)
+    return getattr(summary, key, default)
+
+
+def _summary_text(summary: Any) -> str:
+    """Best-effort description string from a summary dict / object."""
+    parts: List[str] = []
+    for key in ("description", "search_hint"):
+        value = _get(summary, key, "") or ""
+        if value and str(value) not in parts:
+            parts.append(str(value))
+    return " ".join(parts)
+
+
+def _summary_name(summary: Any) -> Optional[str]:
+    name = _get(summary, "name", None) or _get(summary, "skill_name", None)
+    return str(name) if name else None
+
+
+def _summary_tags(summary: Any) -> tuple:
+    tags = _get(summary, "tags", None) or ()
+    return tuple(str(t) for t in tags)
+
+
+def _summary_dcc(summary: Any) -> str:
+    return str(_get(summary, "dcc", "") or _get(summary, "dcc_name", "") or "")
+
+
+def _build_embedder(kind: str) -> Any:
+    """Construct the requested embedder, falling back to ``HashedEmbedder``."""
+    from dcc_mcp_core import HashedEmbedder  # noqa: PLC0415
+
+    if kind != "onnx":
+        return HashedEmbedder()
+    try:
+        from dcc_mcp_core import OnnxEmbedder  # noqa: PLC0415
+
+        return OnnxEmbedder()
+    except Exception as exc:  # noqa: BLE001 — EmbedderError / ImportError
+        logger.warning(
+            "[blender] DCC_MCP_BLENDER_SEMANTIC_EMBEDDER=onnx requested but unavailable "
+            "(%s); falling back to HashedEmbedder. Install dcc-mcp-core[semantic].",
+            exc,
+        )
+        return HashedEmbedder()
+
+
+class BlenderSemanticIndex:
+    """Lexical + vector fusion index used to augment base ``search_skills``."""
+
+    def __init__(self, fusion: Any, embedder_kind: str) -> None:
+        self._fusion = fusion
+        self.embedder_kind = embedder_kind
+        self._signature: Optional[frozenset] = None
+
+    # ── construction ────────────────────────────────────────────────────
+    @classmethod
+    def build(cls, *, embedder_kind: Optional[str] = None) -> Optional["BlenderSemanticIndex"]:
+        """Build the fused index, or ``None`` when core lacks the semantic API."""
+        try:
+            from dcc_mcp_core import LexicalSkillIndex, RrfFusionIndex, VectorSkillIndex  # noqa: PLC0415
+        except Exception as exc:  # noqa: BLE001 — older core without the vector API
+            logger.info(
+                "[blender] semantic index requested but dcc-mcp-core lacks "
+                "VectorSkillIndex (%s); needs dcc-mcp-core>=0.17.38.",
+                exc,
+            )
+            return None
+        kind = embedder_kind or resolve_embedder_kind()
+        try:
+            fusion = (
+                RrfFusionIndex()
+                .register("lex", LexicalSkillIndex())
+                .register("vec", VectorSkillIndex(embedder=_build_embedder(kind)))
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[blender] failed to build semantic fusion index: %s", exc)
+            return None
+        return cls(fusion, kind)
+
+    # ── indexing / recall ───────────────────────────────────────────────
+    def rebuild(self, summaries: Sequence[Any]) -> None:
+        """(Re)index ``summaries`` only when the skill set changed."""
+        from dcc_mcp_core import SkillDocument  # noqa: PLC0415
+
+        signature = frozenset(
+            (name, str(_get(s, "version", "") or ""))
+            for s, name in ((s, _summary_name(s)) for s in summaries)
+            if name is not None
+        )
+        if signature == self._signature:
+            return
+        docs = []
+        for summary in summaries:
+            name = _summary_name(summary)
+            if name is None:
+                continue
+            docs.append(
+                SkillDocument(
+                    skill_id=name,
+                    name=name,
+                    summary=_summary_text(summary),
+                    tags=_summary_tags(summary),
+                    dcc_name=_summary_dcc(summary),
+                )
+            )
+        self._fusion.clear()
+        if docs:
+            self._fusion.index(docs)
+        self._signature = signature
+
+    def recall(self, query: str, *, k: int = 16) -> List[str]:
+        """Return fused-rank ``skill_id``s for ``query`` (best first)."""
+        if not query or not str(query).strip():
+            return []
+        try:
+            hits = self._fusion.search(str(query), k=k)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[blender] semantic recall failed for %r: %s", query, exc)
+            return []
+        return [hit.skill_id for hit in hits]
+
+    # ── fusion / augmentation ───────────────────────────────────────────
+    def augment(
+        self,
+        base: Sequence[Any],
+        query: Optional[str],
+        all_summaries: Sequence[Any],
+        *,
+        limit: Optional[int] = None,
+    ) -> List[Any]:
+        """Append morphology-recalled skills after the canonical ``base`` list.
+
+        ``base`` ordering is preserved verbatim — RRF promotes, never demotes.
+        Skills surfaced only by the vector backend are appended in fused-rank
+        order.
+        """
+        result = list(base)
+        if not query or not str(query).strip():
+            return result
+        try:
+            self.rebuild(all_summaries)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[blender] semantic rebuild failed: %s", exc)
+            return result
+
+        by_name = {name: s for s, name in ((s, _summary_name(s)) for s in all_summaries) if name is not None}
+        present = {_summary_name(s) for s in result}
+        for skill_id in self.recall(query):
+            if skill_id in present or skill_id not in by_name:
+                continue
+            result.append(by_name[skill_id])
+            present.add(skill_id)
+
+        if limit is not None and limit >= 0:
+            result = result[:limit]
+        return result
+
+
+def build_semantic_index() -> Optional[BlenderSemanticIndex]:
+    """Return a ready index when the feature is enabled, else ``None``."""
+    if not resolve_semantic_index_enabled():
+        return None
+    return BlenderSemanticIndex.build()

--- a/src/dcc_mcp_blender/context_snapshot.py
+++ b/src/dcc_mcp_blender/context_snapshot.py
@@ -1,0 +1,208 @@
+"""Blender context snapshot provider for gateway routing and REST ``/v1/context``.
+
+Mirrors :mod:`dcc_mcp_maya.context_snapshot`: a small, pure, headless-safe
+callable that returns a fresh context dict describing live Blender state
+(open file, scene name, selection, frame range, version).  It feeds:
+
+* core's post-tool ``append_context_snapshot`` wrapper, and
+* :meth:`DccServerBase.update_gateway_metadata` (scene / version / documents /
+  display_name) via :func:`collect_gateway_metadata`.
+
+Every Blender probe is guarded so importing this module from plain Python
+(tests, ``--background`` without a scene) returns
+``{"dcc": "blender", "available": False}`` instead of raising.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "BlenderContextSnapshotProvider",
+    "collect_gateway_metadata",
+    "make_snapshot_provider",
+]
+
+
+class BlenderContextSnapshotProvider:
+    """Callable returning a fresh Blender context snapshot.
+
+    Parameters
+    ----------
+    bpy_provider:
+        Optional factory returning the ``bpy`` module (or a duck-typed
+        stand-in for tests).  Defaults to a lazy import of ``bpy`` with a
+        headless-safe fallback to ``None``.
+    """
+
+    def __init__(self, bpy_provider: Optional[Callable[[], Any]] = None) -> None:
+        self._bpy_provider = bpy_provider or _default_bpy_provider
+
+    def __call__(self) -> Dict[str, Any]:
+        return self.collect()
+
+    def collect(self) -> Dict[str, Any]:
+        """Return a fresh context snapshot dict (never raises).
+
+        Keys (all optional, omitted when unavailable)::
+
+            {
+                "dcc":          "blender",
+                "scene":        "/path/to/file.blend",
+                "scene_name":   "Scene",
+                "scene_modified": True | False,
+                "selection":    ["Cube", ...],
+                "frame":        1,
+                "frame_range":  [1, 250],
+                "version":      "4.0.0",
+                "display_name": "Blender 4.0.0 — file.blend",
+                "pid":          12345,
+                "available":    True | False,
+            }
+        """
+        snapshot: Dict[str, Any] = {
+            "dcc": "blender",
+            "pid": os.getpid(),
+            "available": False,
+        }
+
+        bpy = self._safe_bpy()
+        if bpy is None:
+            return snapshot
+
+        snapshot["available"] = True
+
+        # Open file path -----------------------------------------------------
+        filepath = _safe_getattr(getattr(bpy, "data", None), "filepath", "")
+        if filepath:
+            snapshot["scene"] = str(filepath)
+
+        is_dirty = _safe_getattr(getattr(bpy, "data", None), "is_dirty", None)
+        if is_dirty is not None:
+            snapshot["scene_modified"] = bool(is_dirty)
+
+        # Version ------------------------------------------------------------
+        version = _safe_getattr(getattr(bpy, "app", None), "version_string", "")
+        if version:
+            snapshot["version"] = str(version)
+
+        scene = _safe_getattr(getattr(bpy, "context", None), "scene", None)
+        if scene is not None:
+            name = _safe_getattr(scene, "name", None)
+            if name:
+                snapshot["scene_name"] = str(name)
+            frame = _safe_getattr(scene, "frame_current", None)
+            if frame is not None:
+                try:
+                    snapshot["frame"] = int(frame)
+                except (TypeError, ValueError):
+                    pass
+            start = _safe_getattr(scene, "frame_start", None)
+            end = _safe_getattr(scene, "frame_end", None)
+            if start is not None and end is not None:
+                try:
+                    snapshot["frame_range"] = [int(start), int(end)]
+                except (TypeError, ValueError):
+                    pass
+
+        selection = self._selection(bpy)
+        if selection is not None:
+            snapshot["selection"] = selection
+
+        display = _derive_display_name(snapshot.get("scene"), snapshot.get("version"))
+        if display:
+            snapshot["display_name"] = display
+        return snapshot
+
+    # ── internals ───────────────────────────────────────────────────────
+
+    def _safe_bpy(self) -> Any:
+        try:
+            return self._bpy_provider()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("BlenderContextSnapshotProvider: bpy unavailable: %s", exc)
+            return None
+
+    @staticmethod
+    def _selection(bpy: Any) -> Optional[List[str]]:
+        context = getattr(bpy, "context", None)
+        selected = _safe_getattr(context, "selected_objects", None)
+        if selected is None:
+            return None
+        try:
+            return [str(obj.name) for obj in selected]
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("BlenderContextSnapshotProvider: selection read failed: %s", exc)
+            return None
+
+
+def collect_gateway_metadata(
+    provider: Optional[Callable[[], Dict[str, Any]]] = None,
+) -> Dict[str, Optional[Any]]:
+    """Return the subset consumed by :meth:`update_gateway_metadata`.
+
+    Blender is a single-document host, so ``documents`` becomes ``[scene]``
+    when a file is open, otherwise ``[]``.
+    """
+    if provider is None:
+        provider = BlenderContextSnapshotProvider()
+    snapshot = provider() or {}
+    scene = snapshot.get("scene")
+    documents: Optional[List[str]] = [scene] if scene else []
+    return {
+        "scene": scene if scene else None,
+        "version": snapshot.get("version"),
+        "documents": documents,
+        "display_name": snapshot.get("display_name"),
+    }
+
+
+def make_snapshot_provider(
+    bpy_provider: Optional[Callable[[], Any]] = None,
+) -> BlenderContextSnapshotProvider:
+    """Factory for a :class:`BlenderContextSnapshotProvider` (test seam)."""
+    return BlenderContextSnapshotProvider(bpy_provider=bpy_provider)
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_bpy_provider() -> Any:
+    """Return ``bpy`` when available, else ``None``."""
+    try:
+        import bpy  # noqa: PLC0415
+
+        return bpy
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _safe_getattr(target: Any, name: str, default: Any = None) -> Any:
+    if target is None:
+        return default
+    try:
+        return getattr(target, name, default)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("BlenderContextSnapshot: getattr(%s) raised %s", name, exc)
+        return default
+
+
+def _derive_display_name(scene: Optional[str], version: Optional[str]) -> Optional[str]:
+    """Produce a human-readable instance label for gateway disambiguation."""
+    if scene:
+        try:
+            basename = os.path.basename(scene) or scene
+        except Exception:  # noqa: BLE001
+            basename = scene
+        if version:
+            return "Blender {} — {}".format(version, basename)
+        return "Blender — {}".format(basename)
+    if version:
+        return "Blender {}".format(version)
+    return None

--- a/src/dcc_mcp_blender/server.py
+++ b/src/dcc_mcp_blender/server.py
@@ -362,8 +362,7 @@ class BlenderMcpServer(DccServerBase):
             include_bundled=include_bundled,
             minimal_mode=minimal_mode,
         )
-        self._register_recipes_tools(extra_skill_paths, include_bundled)
-        self._register_skill_reference_docs_tools(extra_skill_paths, include_bundled)
+        self._register_metadata_driven_tools(extra_skill_paths, include_bundled)
         self._register_introspect_tools()
         self._register_feedback_tool()
         self._register_capability_manifest_tool()
@@ -371,57 +370,17 @@ class BlenderMcpServer(DccServerBase):
         self._attach_resources()
         return self
 
-    def _register_recipes_tools(
+    def _register_metadata_driven_tools(
         self,
         extra_skill_paths: Optional[List[str]] = None,
         include_bundled: bool = True,
     ) -> None:
-        """Expose ``recipes__*`` tools for skills declaring ``metadata.dcc-mcp.recipes``."""
+        """Register ``recipes__*`` and ``skill_refs__*`` via core metadata registration."""
         try:
-            from dcc_mcp_core.recipes import register_recipes_tools  # noqa: PLC0415
+            from dcc_mcp_core.metadata_registration import register_metadata_driven_tools  # noqa: PLC0415
         except ImportError as exc:
-            logger.debug("[%s] recipes tools skipped (import): %s", _DCC_NAME, exc)
+            logger.debug("[%s] metadata_driven_tools skipped (import): %s", _DCC_NAME, exc)
             return
-        self._register_skill_metadata_tools(register_recipes_tools, "recipes", extra_skill_paths, include_bundled)
-
-    def _register_skill_reference_docs_tools(
-        self,
-        extra_skill_paths: Optional[List[str]] = None,
-        include_bundled: bool = True,
-    ) -> None:
-        """Expose ``skill_refs__*`` for sibling reference docs."""
-        try:
-            from dcc_mcp_core.skill_reference_docs import register_skill_reference_docs_tools  # noqa: PLC0415
-        except ImportError as exc:
-            logger.debug("[%s] skill_refs tools skipped (import): %s", _DCC_NAME, exc)
-            return
-        self._register_skill_metadata_tools(
-            register_skill_reference_docs_tools,
-            "skill_refs",
-            extra_skill_paths,
-            include_bundled,
-        )
-
-    def _register_skill_metadata_tools(
-        self,
-        register_fn: Any,
-        kind: str,
-        extra_skill_paths: Optional[List[str]],
-        include_bundled: bool,
-    ) -> None:
-        try:
-            skills = self._scan_skill_metadata_for_sidecars(extra_skill_paths, include_bundled)
-            register_fn(self._server, skills=skills, dcc_name=_DCC_NAME)
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("[%s] %s tools failed: %s", _DCC_NAME, kind, exc)
-
-    def _scan_skill_metadata_for_sidecars(
-        self,
-        extra_skill_paths: Optional[List[str]],
-        include_bundled: bool,
-    ) -> List[Any]:
-        """Return ``SkillMetadata`` list aligned with discovery (read-only scan)."""
-        from dcc_mcp_core import scan_and_load_lenient  # noqa: PLC0415
 
         extra = list(extra_skill_paths) if extra_skill_paths else []
         paths = self.collect_skill_search_paths(
@@ -429,8 +388,23 @@ class BlenderMcpServer(DccServerBase):
             include_bundled=include_bundled,
             filter_existing=True,
         )
-        skills, _skipped = scan_and_load_lenient(extra_paths=paths or None, dcc_name=_DCC_NAME)
-        return skills
+        try:
+            report = register_metadata_driven_tools(
+                self._server,
+                dcc_name=_DCC_NAME,
+                extra_paths=paths,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] metadata_driven_tools registration failed: %s", _DCC_NAME, exc)
+            return
+        if not report.ok:
+            logger.debug(
+                "[%s] metadata_driven_tools: %d registered, %d skipped, %d failed",
+                _DCC_NAME,
+                report.registered_count,
+                report.skipped_count,
+                report.failed_count,
+            )
 
     def _register_introspect_tools(self) -> None:
         """Register the shared core ``dcc_introspect__*`` tools."""

--- a/src/dcc_mcp_blender/server.py
+++ b/src/dcc_mcp_blender/server.py
@@ -30,8 +30,16 @@ from typing import Any, Dict, List, Optional
 from dcc_mcp_core import DccServerOptions, HostExecutionBridge
 from dcc_mcp_core.server_base import DccServerBase
 
-from dcc_mcp_blender import _env
+from dcc_mcp_blender import (
+    _capability_manifest,
+    _env,
+    _project_tools,
+    _readiness,
+    _resources,
+    _semantic_index,
+)
 from dcc_mcp_blender.__version__ import __version__
+from dcc_mcp_blender.context_snapshot import BlenderContextSnapshotProvider
 from dcc_mcp_blender.host import BlenderInlineCallableDispatcher
 
 logger = logging.getLogger(__name__)
@@ -242,6 +250,44 @@ class BlenderMcpServer(DccServerBase):
         if gateway_port_arg == 0 or (gateway_port_arg is None and not enable_gw):
             self._config.gateway_port = 0
 
+        # Host dispatcher (if any) is owned by core's execution bridge; expose
+        # it under a stable attribute so the readiness binder can schedule its
+        # main-thread probe.  ``None`` in background / standalone mode.
+        self._blender_dispatcher: Any = getattr(self, "_dcc_dispatcher", None)
+
+        # ── Context snapshot + capability manifest ──────────────────────────
+        self._snapshot_provider_impl: BlenderContextSnapshotProvider = BlenderContextSnapshotProvider()
+        try:
+            self.set_context_snapshot_provider(self._snapshot_provider_impl)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] set_context_snapshot_provider failed: %s", _DCC_NAME, exc)
+
+        self._capability_builder = _capability_manifest.BlenderCapabilityManifestBuilder(
+            dcc_name=_DCC_NAME,
+            skill_lister=self.list_skills,
+            action_lister=getattr(self, "list_actions", None),
+            is_loaded=self.is_skill_loaded,
+            skill_info_lister=getattr(self, "get_skill_info", None),
+        )
+
+        # Populated by :meth:`register_builtin_actions`; ``None`` means the
+        # surface was disabled by env var or the core call failed.
+        self._project_tools: Optional[_project_tools.ProjectToolsIntegration] = None
+        self._resources: Optional[_resources.BlenderResourceBinder] = None
+
+        # ── Runtime readiness probe (three-state) ───────────────────────────
+        self._readiness_timeout_secs: Optional[int] = _readiness.resolve_readiness_timeout_secs(None)
+        self.readiness: Optional[_readiness.ReadinessBinder] = _readiness.install_readiness(self)
+
+        # ── Morphology-aware semantic recall (opt-in) ───────────────────────
+        try:
+            self._semantic: Optional[_semantic_index.BlenderSemanticIndex] = _semantic_index.build_semantic_index()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] semantic index init failed: %s", _DCC_NAME, exc)
+            self._semantic = None
+        if self._semantic is not None:
+            logger.info("[%s] semantic skill recall enabled (embedder=%s)", _DCC_NAME, self._semantic.embedder_kind)
+
     # ── Blender version detection ──────────────────────────────────────────────
 
     def _version_string(self) -> str:
@@ -286,6 +332,168 @@ class BlenderMcpServer(DccServerBase):
         """Start the MCP HTTP server.  Returns *self* for chaining."""
         super().start(install_atexit_hook=install_atexit_hook)
         return self
+
+    def stop(self) -> None:
+        """Detach MCP resource handlers, then stop the HTTP server."""
+        if self._resources is not None:
+            try:
+                self._resources.unbind()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[%s] resources.unbind failed: %s", _DCC_NAME, exc)
+        super().stop()
+
+    # ── Builtin action registration + core integrations ────────────────────────
+
+    def register_builtin_actions(
+        self,
+        extra_skill_paths: Optional[List[str]] = None,
+        include_bundled: bool = True,
+        minimal_mode: Any = None,
+    ) -> "BlenderMcpServer":
+        """Discover skills and attach Blender-specific core integrations.
+
+        Runs core's discovery first, then wires the optional adapter
+        integrations (recipes/docs/introspect/feedback/capability manifest/
+        project tools/resources).  Every integration degrades gracefully so a
+        missing optional core API never breaks startup.
+        """
+        super().register_builtin_actions(
+            extra_skill_paths=extra_skill_paths,
+            include_bundled=include_bundled,
+            minimal_mode=minimal_mode,
+        )
+        self._register_recipes_tools(extra_skill_paths, include_bundled)
+        self._register_skill_reference_docs_tools(extra_skill_paths, include_bundled)
+        self._register_introspect_tools()
+        self._register_feedback_tool()
+        self._register_capability_manifest_tool()
+        self._attach_project_tools()
+        self._attach_resources()
+        return self
+
+    def _register_recipes_tools(
+        self,
+        extra_skill_paths: Optional[List[str]] = None,
+        include_bundled: bool = True,
+    ) -> None:
+        """Expose ``recipes__*`` tools for skills declaring ``metadata.dcc-mcp.recipes``."""
+        try:
+            from dcc_mcp_core.recipes import register_recipes_tools  # noqa: PLC0415
+        except ImportError as exc:
+            logger.debug("[%s] recipes tools skipped (import): %s", _DCC_NAME, exc)
+            return
+        self._register_skill_metadata_tools(register_recipes_tools, "recipes", extra_skill_paths, include_bundled)
+
+    def _register_skill_reference_docs_tools(
+        self,
+        extra_skill_paths: Optional[List[str]] = None,
+        include_bundled: bool = True,
+    ) -> None:
+        """Expose ``skill_refs__*`` for sibling reference docs."""
+        try:
+            from dcc_mcp_core.skill_reference_docs import register_skill_reference_docs_tools  # noqa: PLC0415
+        except ImportError as exc:
+            logger.debug("[%s] skill_refs tools skipped (import): %s", _DCC_NAME, exc)
+            return
+        self._register_skill_metadata_tools(
+            register_skill_reference_docs_tools,
+            "skill_refs",
+            extra_skill_paths,
+            include_bundled,
+        )
+
+    def _register_skill_metadata_tools(
+        self,
+        register_fn: Any,
+        kind: str,
+        extra_skill_paths: Optional[List[str]],
+        include_bundled: bool,
+    ) -> None:
+        try:
+            skills = self._scan_skill_metadata_for_sidecars(extra_skill_paths, include_bundled)
+            register_fn(self._server, skills=skills, dcc_name=_DCC_NAME)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] %s tools failed: %s", _DCC_NAME, kind, exc)
+
+    def _scan_skill_metadata_for_sidecars(
+        self,
+        extra_skill_paths: Optional[List[str]],
+        include_bundled: bool,
+    ) -> List[Any]:
+        """Return ``SkillMetadata`` list aligned with discovery (read-only scan)."""
+        from dcc_mcp_core import scan_and_load_lenient  # noqa: PLC0415
+
+        extra = list(extra_skill_paths) if extra_skill_paths else []
+        paths = self.collect_skill_search_paths(
+            extra_paths=extra + self._extra_skill_paths,
+            include_bundled=include_bundled,
+            filter_existing=True,
+        )
+        skills, _skipped = scan_and_load_lenient(extra_paths=paths or None, dcc_name=_DCC_NAME)
+        return skills
+
+    def _register_introspect_tools(self) -> None:
+        """Register the shared core ``dcc_introspect__*`` tools."""
+        try:
+            from dcc_mcp_core import register_introspect_tools  # noqa: PLC0415
+
+            register_introspect_tools(self._server, dcc_name=_DCC_NAME)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] introspect tools registration failed: %s", _DCC_NAME, exc)
+
+    def _register_feedback_tool(self) -> None:
+        """Register the shared core ``dcc_feedback__report`` tool."""
+        try:
+            from dcc_mcp_core import register_feedback_tool  # noqa: PLC0415
+
+            register_feedback_tool(self._server, dcc_name=_DCC_NAME)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] feedback tool registration failed: %s", _DCC_NAME, exc)
+
+    def _register_capability_manifest_tool(self) -> None:
+        try:
+            _capability_manifest.register_capability_mcp_tool(self, builder=self._capability_builder)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] capability manifest MCP tool registration failed: %s", _DCC_NAME, exc)
+
+    def _attach_project_tools(self) -> None:
+        try:
+            self._project_tools = _project_tools.attach_to_server(self)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] project tools registration failed: %s", _DCC_NAME, exc)
+
+    def _attach_resources(self) -> None:
+        try:
+            self._resources = _resources.install_resources(
+                self,
+                snapshot_provider=self._snapshot_provider_impl.collect,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] resources registration failed: %s", _DCC_NAME, exc)
+
+    # ── Readiness + capability manifest (programmatic access) ──────────────────
+
+    def readiness_report(self) -> dict:
+        """Return the current three-state readiness snapshot as a dict."""
+        if self.readiness is None:
+            return {"process": True, "dispatcher": False, "dcc": False}
+        return self.readiness.report()
+
+    def build_capability_manifest(self, *, loaded_only: bool = False) -> dict:
+        """Return the compact Blender capability manifest as a dict."""
+        records = self._capability_builder.build()
+        if loaded_only:
+            records = [r for r in records if r.loaded]
+        instance_id = getattr(self, "instance_id", None)
+        scene = getattr(self._config, "scene", None)
+        version = getattr(self._config, "dcc_version", None)
+        return _capability_manifest.build_manifest_payload(
+            records,
+            dcc_name=_DCC_NAME,
+            dcc_version=version,
+            scene=scene,
+            instance_id=instance_id,
+        )
 
     # ── Progressive skill loading ──────────────────────────────────────────────
 
@@ -383,7 +591,7 @@ class BlenderMcpServer(DccServerBase):
         if self._handle is None:
             return []
         try:
-            return list(
+            base = list(
                 self._server.search_skills(
                     query=query,
                     tags=tags or [],
@@ -395,6 +603,16 @@ class BlenderMcpServer(DccServerBase):
         except Exception as exc:  # noqa: BLE001
             logger.debug("BlenderMcpServer: search_skills failed: %s", exc)
             return []
+
+        # Opt-in semantic augmentation: append morphology recalls after the
+        # canonical BM25 results. Base ordering is preserved (promote, never
+        # demote); vector-only hits are appended.
+        if self._semantic is not None and query:
+            try:
+                return self._semantic.augment(base, query, self.list_skills())
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("BlenderMcpServer: semantic augment failed: %s", exc)
+        return base
 
     def find_skills(
         self,

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -32,7 +32,7 @@ def test_addon_entry_bl_info_version_is_static_tuple_literal():
     )
 
     assert isinstance(version_node, ast.Tuple)
-    assert ast.literal_eval(version_node) == (0, 1, 4)
+    assert ast.literal_eval(version_node) == (0, 1, 5)
 
 
 def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monkeypatch):
@@ -56,7 +56,7 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     assert "host.py" in names
     assert "skills/blender-scene/SKILL.md" in names
     assert not any(name.startswith("dcc_mcp_blender/") for name in names)
-    assert '"version": (0, 1, 4)' in addon_init
+    assert '"version": (0, 1, 5)' in addon_init
     assert "./wheels/dcc_mcp_core-0.17.47-cp38-abi3-win_amd64.whl" in manifest
     assert manifest.index("wheels = [") < manifest.index("[permissions]")
 

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -38,10 +38,10 @@ def test_addon_entry_bl_info_version_is_static_tuple_literal():
 def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monkeypatch):
     """The add-on package root must directly contain ``server.py`` and skills."""
     assemble_zip = _load_assemble_zip_module()
-    fake_wheel = tmp_path / "dcc_mcp_core-0.17.36-cp38-abi3-win_amd64.whl"
+    fake_wheel = tmp_path / "dcc_mcp_core-0.17.47-cp38-abi3-win_amd64.whl"
     fake_wheel.write_bytes(b"fake wheel")
 
-    monkeypatch.setattr(assemble_zip, "resolve_core_version", lambda min_version="0.17.36": "0.17.36")
+    monkeypatch.setattr(assemble_zip, "resolve_core_version", lambda min_version="0.17.47": "0.17.47")
     monkeypatch.setattr(assemble_zip, "download_core_wheel", lambda version, platform, dest_dir: fake_wheel)
 
     zip_path = assemble_zip.assemble(platform="win64", output_dir=tmp_path)
@@ -57,7 +57,7 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     assert "skills/blender-scene/SKILL.md" in names
     assert not any(name.startswith("dcc_mcp_blender/") for name in names)
     assert '"version": (0, 1, 4)' in addon_init
-    assert "./wheels/dcc_mcp_core-0.17.36-cp38-abi3-win_amd64.whl" in manifest
+    assert "./wheels/dcc_mcp_core-0.17.47-cp38-abi3-win_amd64.whl" in manifest
     assert manifest.index("wheels = [") < manifest.index("[permissions]")
 
 

--- a/tests/test_core_integrations.py
+++ b/tests/test_core_integrations.py
@@ -1,0 +1,465 @@
+"""Tests for the Blender adapter's dcc-mcp-core interface integrations.
+
+Mirrors the Maya adapter's coverage for the newly wired integrations:
+
+* three-state runtime readiness binder,
+* compact capability manifest builder + MCP tool,
+* project-tools integration with a fake scene resolver,
+* MCP resource binder (``scene://current``),
+* opt-in semantic skill-recall augmentation,
+* Blender context snapshot provider.
+
+None of these require a live Blender — every Blender access is faked or
+guarded so the suite runs in plain Python / ``mayapy``-style headless mode.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeInner:
+    """Fake inner Rust ``McpHttpServer`` exposing registry + handler + resources."""
+
+    def __init__(self) -> None:
+        self.registered: Dict[str, dict] = {}
+        self.handlers: Dict[str, Any] = {}
+        self.registry = MagicMock()
+        self.registry.register.side_effect = lambda name, **kw: self.registered.__setitem__(name, kw)
+        self._resources = _FakeResourceHandle()
+
+    def register_handler(self, name: str, handler: Any) -> None:
+        self.handlers[name] = handler
+
+    def resources(self) -> "_FakeResourceHandle":
+        return self._resources
+
+    def set_readiness_probe(self, probe: Any) -> None:
+        self.readiness_probe = probe
+
+
+class _FakeResourceHandle:
+    def __init__(self) -> None:
+        self.producers: Dict[str, Any] = {}
+        self.scene_payloads: List[dict] = []
+
+    def register_producer(self, scheme: str, producer: Any) -> None:
+        self.producers[scheme] = producer
+
+    def set_scene(self, payload: dict) -> None:
+        self.scene_payloads.append(payload)
+
+
+class _FakeServer:
+    """Minimal wrapper standing in for BlenderMcpServer."""
+
+    def __init__(self, *, dispatcher: Any = None) -> None:
+        self._server = _FakeInner()
+        self._blender_dispatcher = dispatcher
+        self._config = MagicMock()
+        self._config.scene = "/tmp/demo.blend"
+        self._config.dcc_version = "4.0.0"
+        self.instance_id = "abcd1234"
+
+
+# ---------------------------------------------------------------------------
+# Readiness binder
+# ---------------------------------------------------------------------------
+
+
+class TestReadinessBinder:
+    def test_no_dispatcher_marks_dcc_ready_immediately(self):
+        from dcc_mcp_blender._readiness import ReadinessBinder
+
+        server = _FakeServer(dispatcher=None)
+        binder = ReadinessBinder()
+        assert binder.bind(server) is True
+        report = binder.report()
+        assert report["dispatcher"] is True
+        assert report["dcc"] is True
+        assert binder.published_to_server is True
+        # Probe was published to the inner server.
+        assert server._server.readiness_probe is binder.probe
+
+    def test_async_dispatcher_schedules_then_marks_ready(self):
+        from dcc_mcp_blender._readiness import ReadinessBinder
+
+        captured = {}
+
+        class _AsyncDispatcher:
+            def submit_async_callable(self, *, request_id, task, affinity, timeout_ms, on_complete):
+                captured["request_id"] = request_id
+                captured["affinity"] = affinity
+                # Simulate the main-thread no-op completing.
+                on_complete(task())
+
+        server = _FakeServer(dispatcher=_AsyncDispatcher())
+        binder = ReadinessBinder()
+        assert binder.bind(server) is True
+        assert captured["affinity"] == "main"
+        assert binder.report()["dcc"] is True
+
+    def test_bind_idempotent(self):
+        from dcc_mcp_blender._readiness import ReadinessBinder
+
+        server = _FakeServer()
+        binder = ReadinessBinder()
+        binder.bind(server)
+        # Second bind on the same server is a no-op.
+        assert binder.bind(server) is True
+
+    def test_resolve_timeout_env(self, monkeypatch):
+        from dcc_mcp_blender._readiness import resolve_readiness_timeout_secs
+
+        monkeypatch.setenv("DCC_MCP_BLENDER_READINESS_TIMEOUT_SECS", "45")
+        assert resolve_readiness_timeout_secs() == 45
+        monkeypatch.setenv("DCC_MCP_BLENDER_READINESS_TIMEOUT_SECS", "-3")
+        assert resolve_readiness_timeout_secs() is None
+        monkeypatch.delenv("DCC_MCP_BLENDER_READINESS_TIMEOUT_SECS", raising=False)
+        assert resolve_readiness_timeout_secs(12) == 12
+
+
+# ---------------------------------------------------------------------------
+# Capability manifest
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityManifest:
+    def _builder(self, *, loaded: bool = False):
+        from dcc_mcp_blender._capability_manifest import BlenderCapabilityManifestBuilder
+
+        skills = [
+            {
+                "name": "blender-scene",
+                "tags": ["scene"],
+                "tools": [
+                    {
+                        "name": "get_scene_info",
+                        "description": "Return scene hierarchy",
+                        "input_schema": {"type": "object"},
+                    }
+                ],
+            }
+        ]
+        actions: List[dict] = []
+        if loaded:
+            actions = [
+                {
+                    "name": "blender_scene__get_scene_info",
+                    "skill": "blender-scene",
+                    "description": "Return scene hierarchy",
+                    "inputSchema": {"type": "object"},
+                }
+            ]
+        return BlenderCapabilityManifestBuilder(
+            skill_lister=lambda: skills,
+            action_lister=lambda: actions,
+            is_loaded=lambda name: loaded,
+        )
+
+    def test_unloaded_skill_yields_load_hint_record(self):
+        records = self._builder(loaded=False).build()
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.backend_tool == "blender_scene__get_scene_info"
+        assert rec.requires_load_skill is True
+        assert rec.load_hint == {"tool": "load_skill", "arguments": {"skill_name": "blender-scene"}}
+        assert rec.loaded is False
+
+    def test_loaded_action_record(self):
+        records = self._builder(loaded=True).build()
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.loaded is True
+        assert rec.has_schema is True
+        assert rec.tool_slug.startswith("blender.instance.")
+
+    def test_build_manifest_payload_totals(self):
+        from dcc_mcp_blender._capability_manifest import build_manifest_payload
+
+        records = self._builder(loaded=False).build()
+        payload = build_manifest_payload(records, dcc_name="blender", scene="/tmp/x.blend")
+        assert payload["dcc_type"] == "blender"
+        assert payload["totals"]["actions"] == 1
+        assert payload["totals"]["unloaded_actions"] == 1
+        assert payload["metadata"]["scene"] == "/tmp/x.blend"
+
+    def test_register_capability_mcp_tool(self):
+        from dcc_mcp_blender._capability_manifest import register_capability_mcp_tool
+
+        server = _FakeServer()
+        builder = self._builder(loaded=False)
+        assert register_capability_mcp_tool(server, builder=builder) is True
+        assert "dcc_capability_manifest" in server._server.registered
+        handler = server._server.handlers["dcc_capability_manifest"]
+        result = handler({"loaded_only": False})
+        assert result["success"] is True
+        assert result["context"]["dcc_type"] == "blender"
+
+    def test_register_returns_false_without_inner(self):
+        from dcc_mcp_blender._capability_manifest import register_capability_mcp_tool
+
+        class _NoInner:
+            _server = None
+
+        assert register_capability_mcp_tool(_NoInner(), builder=self._builder()) is False
+
+
+# ---------------------------------------------------------------------------
+# Project tools
+# ---------------------------------------------------------------------------
+
+
+class TestProjectTools:
+    def test_scene_resolver_returns_none_outside_blender(self):
+        from dcc_mcp_blender._project_tools import BlenderSceneResolver
+
+        # No bpy importable in the test interpreter.
+        assert BlenderSceneResolver().current_scene() is None
+
+    def test_resolve_enabled_env_opt_out(self, monkeypatch):
+        from dcc_mcp_blender._project_tools import resolve_enabled
+
+        monkeypatch.setenv("DCC_MCP_BLENDER_PROJECT_TOOLS", "0")
+        assert resolve_enabled() is False
+        monkeypatch.setenv("DCC_MCP_BLENDER_PROJECT_TOOLS", "1")
+        assert resolve_enabled() is True
+        monkeypatch.delenv("DCC_MCP_BLENDER_PROJECT_TOOLS", raising=False)
+        assert resolve_enabled() is True
+
+    def test_bind_with_fake_resolver(self, monkeypatch):
+        import dcc_mcp_core
+
+        from dcc_mcp_blender._project_tools import BlenderSceneResolver, ProjectToolsIntegration
+
+        calls = {}
+
+        def _fake_register(inner, *, dcc_name, project=None):
+            calls["inner"] = inner
+            calls["dcc_name"] = dcc_name
+            calls["project"] = project
+
+        monkeypatch.setattr(dcc_mcp_core, "register_project_tools", _fake_register)
+
+        class _Resolver(BlenderSceneResolver):
+            def current_scene(self) -> Optional[str]:
+                return "/projects/shot/shot.blend"
+
+        made = {}
+
+        def _factory(scene: str):
+            made["scene"] = scene
+            proj = MagicMock()
+            proj.state.scene_path = scene
+            return proj
+
+        server = _FakeServer()
+        integration = ProjectToolsIntegration(scene_resolver=_Resolver())
+        assert integration.bind(server, project_factory=_factory) is True
+        assert calls["dcc_name"] == "blender"
+        # The resolver path is normalised through ``pathlib.Path`` before
+        # reaching the factory, so compare the resolved form.
+        assert os.path.basename(made["scene"]) == "shot.blend"
+        assert integration.registered is True
+
+    def test_attach_to_server_disabled(self, monkeypatch):
+        from dcc_mcp_blender._project_tools import attach_to_server
+
+        monkeypatch.setenv("DCC_MCP_BLENDER_PROJECT_TOOLS", "0")
+        assert attach_to_server(_FakeServer()) is None
+
+
+# ---------------------------------------------------------------------------
+# Resources
+# ---------------------------------------------------------------------------
+
+
+class TestResources:
+    def test_bind_registers_producer_and_publishes_scene(self):
+        from dcc_mcp_blender._resources import SCHEME_BLENDER_DATA, BlenderResourceBinder
+
+        server = _FakeServer()
+        snapshots = [{"dcc": "blender", "scene": "/tmp/x.blend"}]
+        binder = BlenderResourceBinder(snapshot_provider=lambda: snapshots[0])
+        assert binder.bind(server) is True
+        assert SCHEME_BLENDER_DATA in binder.registered_producers
+        assert binder.scene_publish_count == 1
+        assert server._server.resources().scene_payloads == snapshots
+
+    def test_install_scene_events_uses_injected_installer(self):
+        from dcc_mcp_blender._resources import BlenderResourceBinder
+
+        recorded = {}
+
+        def _installer(callback, handlers):
+            recorded["handlers"] = handlers
+            return ["h1", "h2"]
+
+        server = _FakeServer()
+        binder = BlenderResourceBinder(snapshot_provider=lambda: {}, event_installer=_installer)
+        binder.bind(server)
+        handles = binder.install_scene_events()
+        assert handles == ["h1", "h2"]
+        assert "save_post" in recorded["handlers"]
+        # Idempotent.
+        assert binder.install_scene_events() == ["h1", "h2"]
+        binder.unbind()
+
+    def test_install_resources_env_opt_out(self, monkeypatch):
+        from dcc_mcp_blender._resources import install_resources
+
+        monkeypatch.setenv("DCC_MCP_BLENDER_RESOURCES", "0")
+        assert install_resources(_FakeServer(), snapshot_provider=lambda: {}) is None
+
+    def test_blender_data_producer_without_bpy(self):
+        from dcc_mcp_blender._resources import _blender_data_producer
+
+        result = _blender_data_producer("blender-data://current")
+        assert result["mimeType"] == "application/json"
+        assert "blender_unavailable" in result["text"]
+
+
+# ---------------------------------------------------------------------------
+# Semantic index
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticIndex:
+    def test_resolve_enabled_default_off(self, monkeypatch):
+        from dcc_mcp_blender._semantic_index import resolve_semantic_index_enabled
+
+        monkeypatch.delenv("DCC_MCP_BLENDER_SEMANTIC_INDEX", raising=False)
+        assert resolve_semantic_index_enabled() is False
+        monkeypatch.setenv("DCC_MCP_BLENDER_SEMANTIC_INDEX", "1")
+        assert resolve_semantic_index_enabled() is True
+
+    def test_build_returns_none_when_disabled(self, monkeypatch):
+        from dcc_mcp_blender._semantic_index import build_semantic_index
+
+        monkeypatch.delenv("DCC_MCP_BLENDER_SEMANTIC_INDEX", raising=False)
+        assert build_semantic_index() is None
+
+    def test_augment_appends_recall_preserving_base(self):
+        from dcc_mcp_blender._semantic_index import BlenderSemanticIndex
+
+        class _Hit:
+            def __init__(self, skill_id):
+                self.skill_id = skill_id
+
+        class _FakeFusion:
+            def clear(self):
+                pass
+
+            def index(self, docs):
+                self._docs = docs
+
+            def search(self, query, k=16):
+                return [_Hit("blender-render")]
+
+        index = BlenderSemanticIndex(_FakeFusion(), "hashed")
+        base = [{"name": "blender-scene"}]
+        all_summaries = [{"name": "blender-scene"}, {"name": "blender-render", "description": "render"}]
+        result = index.augment(base, "rendering", all_summaries)
+        names = [r["name"] for r in result]
+        assert names[0] == "blender-scene"  # base order preserved
+        assert "blender-render" in names  # recall appended
+
+    def test_augment_empty_query_returns_base(self):
+        from dcc_mcp_blender._semantic_index import BlenderSemanticIndex
+
+        index = BlenderSemanticIndex(MagicMock(), "hashed")
+        base = [{"name": "blender-scene"}]
+        assert index.augment(base, "", [{"name": "blender-scene"}]) == base
+
+
+# ---------------------------------------------------------------------------
+# Context snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestContextSnapshot:
+    def test_unavailable_outside_blender(self):
+        from dcc_mcp_blender.context_snapshot import BlenderContextSnapshotProvider
+
+        provider = BlenderContextSnapshotProvider(bpy_provider=lambda: None)
+        snap = provider.collect()
+        assert snap["dcc"] == "blender"
+        assert snap["available"] is False
+
+    def test_collect_with_fake_bpy(self):
+        from dcc_mcp_blender.context_snapshot import BlenderContextSnapshotProvider, collect_gateway_metadata
+
+        fake = MagicMock()
+        fake.data.filepath = "/projects/shot/shot.blend"
+        fake.data.is_dirty = True
+        fake.app.version_string = "4.0.0"
+        scene = MagicMock()
+        scene.name = "Scene"
+        scene.frame_current = 7
+        scene.frame_start = 1
+        scene.frame_end = 250
+        fake.context.scene = scene
+        obj = MagicMock()
+        obj.name = "Cube"
+        fake.context.selected_objects = [obj]
+
+        provider = BlenderContextSnapshotProvider(bpy_provider=lambda: fake)
+        snap = provider.collect()
+        assert snap["available"] is True
+        assert snap["scene"] == "/projects/shot/shot.blend"
+        assert snap["scene_modified"] is True
+        assert snap["version"] == "4.0.0"
+        assert snap["scene_name"] == "Scene"
+        assert snap["frame"] == 7
+        assert snap["frame_range"] == [1, 250]
+        assert snap["selection"] == ["Cube"]
+        assert "shot.blend" in snap["display_name"]
+
+        meta = collect_gateway_metadata(provider)
+        assert meta["scene"] == "/projects/shot/shot.blend"
+        assert meta["documents"] == ["/projects/shot/shot.blend"]
+        assert meta["version"] == "4.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Server wiring smoke
+# ---------------------------------------------------------------------------
+
+
+class TestServerWiring:
+    def test_server_exposes_readiness_and_manifest(self):
+        from dcc_mcp_blender.server import BlenderMcpServer
+
+        server = BlenderMcpServer(port=0)
+        report = server.readiness_report()
+        assert "dcc" in report
+        manifest = server.build_capability_manifest()
+        assert manifest["dcc_type"] == "blender"
+        assert "capabilities" in manifest
+
+    def test_public_exports(self):
+        import dcc_mcp_blender as b
+
+        for symbol in (
+            "ReadinessBinder",
+            "BlenderCapabilityManifestBuilder",
+            "ProjectToolsIntegration",
+            "BlenderResourceBinder",
+            "BlenderSemanticIndex",
+            "BlenderContextSnapshotProvider",
+            "attach_project_tools",
+            "install_readiness",
+        ):
+            assert hasattr(b, symbol), symbol
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([os.path.abspath(__file__), "-v"]))

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -17,10 +17,10 @@ def _load_assemble_zip_module():
     return mod
 
 
-def test_core_dependency_floor_is_01736():
+def test_core_dependency_floor_is_01747():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert '"dcc-mcp-core>=0.17.36,<1.0.0"' in pyproject
+    assert '"dcc-mcp-core>=0.17.47,<1.0.0"' in pyproject
 
 
 def test_packaging_core_floor_matches_pyproject():


### PR DESCRIPTION
## Summary

Brings the Blender adapter to parity with the Maya adapter's latest `dcc-mcp-core` interface wiring, and adds an agent-facing install path. Blender has no Qt UI, so the Qt UI inspector is intentionally omitted.

> Note: this branch also includes the prerequisite commit `refactor: simplify blender dispatcher with core interfaces` (not yet on `main`).

### Server wiring
Wired in `BlenderMcpServer.register_builtin_actions` after `super()`, each guarded by `try/except`; every surface has a `DCC_MCP_BLENDER_*` opt-out.

- Three-state runtime readiness probe (`install_readiness` in `__init__`)
- Per-action capability manifest + `dcc_capability_manifest` MCP tool + `build_capability_manifest()`
- Context snapshot provider (gateway metadata, driven by `bpy.data.filepath`)
- MCP resources: `scene://current` + `blender-data://` (scene events via `bpy.app.handlers`)
- Project tools: `project_save/load/resume/status`
- Opt-in morphology-aware semantic skill recall augmenting `search_skills`
- `introspect` / `feedback` / `recipes` / `skill-reference-docs` core tools

### Agent install
- `install.md` + `skills/dcc-mcp-blender-setup/` (SKILL.md + `setup_dcc_mcp_blender.py`)
- README "Agent install (recommended)" section (trigger: `帮我参考 loonghao/dcc-mcp-blender/install.md 去安装`)

## Test plan
- [x] `python -m pytest tests -q` → 343 passed, 18 skipped (live-Blender e2e)
- [x] New `test_core_integrations.py` → 25 passed
- [x] `setup_dcc_mcp_blender.py` compiles; `--help` works; clean SystemExit when Blender python is absent
