### PR TITLE
fix: add release-please version marker to packaging entry for auto-sync

### DIFF
--- a/packaging/addon_entry/__init__.py
+++ b/packaging/addon_entry/__init__.py
@@ -340,3 +340,5 @@ def unregister() -> None:
         print("[DCC MCP Blender] Server stopped")
     except Exception as exc:  # noqa: BLE001
         print(f"[DCC MCP Blender] Failed to stop server: {exc}")
+
+__addon_version__ = "0.1.6"  # x-release-please-version

--- a/packaging/addon_entry/__init__.py
+++ b/packaging/addon_entry/__init__.py
@@ -341,4 +341,5 @@ def unregister() -> None:
     except Exception as exc:  # noqa: BLE001
         print(f"[DCC MCP Blender] Failed to stop server: {exc}")
 
+
 __addon_version__ = "0.1.6"  # x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,6 +24,10 @@
           "type": "toml",
           "path": "packaging/addon_entry/blender_manifest.toml",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "generic",
+          "path": "packaging/addon_entry/__init__.py"
         }
       ]
     }

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -5,12 +5,25 @@ from __future__ import annotations
 import ast
 import importlib.util
 import pathlib
+import re
 import sys
 import zipfile
 from types import SimpleNamespace
 
 ROOT = pathlib.Path(__file__).parent.parent
 ADDON_ENTRY = ROOT / "packaging" / "addon_entry" / "__init__.py"
+
+
+def _get_addon_version():
+    """Extract the addon version from the __addon_version__ variable."""
+    src = ADDON_ENTRY.read_text(encoding="utf-8")
+    m = re.search(r'__addon_version__\s*=\s*"(\d+\.\d+\.\d+)"', src)
+    assert m, "could not find __addon_version__ in packaging/addon_entry/__init__.py"
+    return m.group(1)
+
+
+def _parse_version_tuple(version_str: str):
+    return tuple(int(x) for x in version_str.split("."))
 
 
 def _load_assemble_zip_module():
@@ -32,7 +45,7 @@ def test_addon_entry_bl_info_version_is_static_tuple_literal():
     )
 
     assert isinstance(version_node, ast.Tuple)
-    assert ast.literal_eval(version_node) == (0, 1, 6)
+    assert ast.literal_eval(version_node) == _parse_version_tuple(_get_addon_version())
 
 
 def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monkeypatch):
@@ -56,7 +69,7 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     assert "host.py" in names
     assert "skills/blender-scene/SKILL.md" in names
     assert not any(name.startswith("dcc_mcp_blender/") for name in names)
-    assert '"version": (0, 1, 6)' in addon_init
+    assert '"version": (%s)' % ", ".join(_get_addon_version().split(".")) in addon_init
     assert "./wheels/dcc_mcp_core-0.17.47-cp38-abi3-win_amd64.whl" in manifest
     assert manifest.index("wheels = [") < manifest.index("[permissions]")
 


### PR DESCRIPTION
## Problem

`packaging/addon_entry/__init__.py` (the Blender add-on entry point that ships in the ZIP) was not managed by release-please. Every time release-please bumped the version in `pyproject.toml` / `__version__.py`, the `bl_info["version"]` tuple in this file stayed behind, causing test failures like `assert (0, 1, 5) == (0, 1, 6)`.

## Solution

1. Add `__addon_version__ = "0.1.6"  # x-release-please-version` at the end of `packaging/addon_entry/__init__.py`. The `x-release-please-version` annotation lets release-please's generic updater find and replace the SemVer string.
2. Register the file as a generic extra-file in `release-please-config.json`.
3. Refactor tests to read from `__addon_version__` via regex instead of hardcoding the version tuple, so they stay green after future bumps.

## How it works

On each release, release-please scans `packaging/addon_entry/__init__.py` for the `x-release-please-version` annotation and replaces `0.1.6` with the bumped version. The `bl_info["version"]` tuple still needs manual sync, but tests will now verify the two are consistent.