### PR TITLE
feat(blender): bump dcc-mcp-core floor to >=0.18.2 (PIP-571)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![GitHub release downloads](https://img.shields.io/github/downloads/dcc-mcp/dcc-mcp-blender/total.svg?label=release%20downloads)](https://github.com/dcc-mcp/dcc-mcp-blender/releases)
 [![GitHub Release](https://img.shields.io/github/v/release/dcc-mcp/dcc-mcp-blender.svg)](https://github.com/dcc-mcp/dcc-mcp-blender/releases)
 [![Coverage](https://img.shields.io/badge/coverage-pytest--cov-blue.svg)](https://github.com/dcc-mcp/dcc-mcp-blender/blob/main/pyproject.toml)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.17.47-blue.svg)](https://github.com/loonghao/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.18.2-blue.svg)](https://github.com/loonghao/dcc-mcp-core)
 [![Blender](https://img.shields.io/badge/Blender-3.6%20LTS%20%7C%204.2%20LTS%20%7C%204.3%20%7C%204.4-orange.svg)](https://www.blender.org/download/releases/)
 [![MCP](https://img.shields.io/badge/MCP-2025--03--26-purple.svg)](https://modelcontextprotocol.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -44,7 +44,7 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.17.47"
+MIN_CORE_VERSION = "0.18.2"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ classifiers = [
 ]
 
 dependencies = [
-    # 0.17.43+: builtin registration passes skills to recipes; 0.17.47 semantic
-    # wheel fixes; AdapterReadinessBinder (0.17.32+) and
-    # register_metadata_driven_tools (0.17.34+) for unified sidecar registration.
-    "dcc-mcp-core>=0.17.47,<1.0.0",
+    # 0.18.2+: Release Train anchor — adapter_version / adapter_dcc gateway
+    # election support, HostUiDispatcherBase, AdapterReadinessBinder, and
+    # register_metadata_driven_tools for unified sidecar registration.
+    "dcc-mcp-core>=0.18.2,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -51,10 +51,10 @@ def test_addon_entry_bl_info_version_is_static_tuple_literal():
 def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monkeypatch):
     """The add-on package root must directly contain ``server.py`` and skills."""
     assemble_zip = _load_assemble_zip_module()
-    fake_wheel = tmp_path / "dcc_mcp_core-0.17.47-cp38-abi3-win_amd64.whl"
+    fake_wheel = tmp_path / "dcc_mcp_core-0.18.2-cp38-abi3-win_amd64.whl"
     fake_wheel.write_bytes(b"fake wheel")
 
-    monkeypatch.setattr(assemble_zip, "resolve_core_version", lambda min_version="0.17.47": "0.17.47")
+    monkeypatch.setattr(assemble_zip, "resolve_core_version", lambda min_version="0.18.2": "0.18.2")
     monkeypatch.setattr(assemble_zip, "download_core_wheel", lambda version, platform, dest_dir: fake_wheel)
 
     zip_path = assemble_zip.assemble(platform="win64", output_dir=tmp_path)
@@ -70,7 +70,7 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     assert "skills/blender-scene/SKILL.md" in names
     assert not any(name.startswith("dcc_mcp_blender/") for name in names)
     assert '"version": (%s)' % ", ".join(_get_addon_version().split(".")) in addon_init
-    assert "./wheels/dcc_mcp_core-0.17.47-cp38-abi3-win_amd64.whl" in manifest
+    assert "./wheels/dcc_mcp_core-0.18.2-cp38-abi3-win_amd64.whl" in manifest
     assert manifest.index("wheels = [") < manifest.index("[permissions]")
 
 

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -17,10 +17,10 @@ def _load_assemble_zip_module():
     return mod
 
 
-def test_core_dependency_floor_is_01747():
+def test_core_dependency_floor_is_0182():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert '"dcc-mcp-core>=0.17.47,<1.0.0"' in pyproject
+    assert '"dcc-mcp-core>=0.18.2,<1.0.0"' in pyproject
 
 
 def test_packaging_core_floor_matches_pyproject():


### PR DESCRIPTION
## Summary

Align `dcc-mcp-blender` with the Release Train anchor `dcc-mcp-core v0.18.2`.

## Changes

- **pyproject.toml**: bump `dcc-mcp-core` dependency constraint from `>=0.17.47` to `>=0.18.2`
- **packaging/assemble_zip.py**: sync `MIN_CORE_VERSION` to `0.18.2`
- **tests/test_core_version.py**: update floor assertion to `0.18.2`

## Validation

- `dcc-mcp-core==0.18.2` installed and verified
- ruff lint: **All checks passed**
- pytest: **351 passed, 18 skipped** (e2e/packaging tests excluded)

## Related

- Parent: PIP-552 (Release Train)
- Issue: PIP-571