### PR TITLE
feat: add blender-render-farm skill with Deadline and Flamenco support

### DIFF
--- a/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_blender/skills/SKILLS_INDEX.md
@@ -31,6 +31,7 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | `blender-lighting` | lookdev, render | Create lights, edit light properties, list lights, and set world background. | Load when visibility or render quality depends on lighting. | Mutating except light listing. | light, world background, sun, area light, exposure |
 | `blender-light-rig` | lookdev, render, environment | Create reusable light rigs, softboxes, HDRI worlds, grouped light collections, and view-transform settings. | Load after basic lighting when scenes need repeatable studio or environment lighting. | Mutating except rig listing and summary. | three point light, softbox, hdri world, light rig, view transform, lighting summary |
 | `blender-render` | render, diagnostics, delivery | Configure renders, render scenes, inspect render settings, and capture viewport images. | Load after scene/camera/lighting setup when output is needed. | Disk/output producing; read-only for render info. | render, viewport capture, image output, resolution |
+| `blender-render-farm` | render, pipeline | Validate scenes, write job configs, submit to Deadline or Flamenco, and query farm job status. | Load after blender-render when distributed / farm rendering is needed. | Read-only for status/listing; network calls for submission/cancellation. | render farm, deadline, flamenco, distributed render, farm submission, job status |
 | `blender-dev` | diagnostics, development | Inspect add-ons, Python environment, structured UI metadata, module reloads, debug listeners, and development entrypoints. | Load for adapter/add-on debugging before falling back to arbitrary scripting; avoid for normal scene authoring. | Mixed: read-only diagnostics plus explicit development code execution, path mutation, module reload, and add-on enable/disable. | addon diagnostics, reload modules, run check, debug server, UI snapshot, Python environment |
 | `blender-scripting` | diagnostics, escape hatch | Execute Python snippets or script files and inspect Blender runtime info. | Load last, after checking typed skills and only when custom logic is required. | Potentially arbitrary; use with explicit user intent. | python, script, custom, escape hatch, blender info |
 
@@ -51,6 +52,7 @@ This index helps agents choose typed Blender skills before falling back to raw P
 | Procedural node setup | `blender-objects` -> `blender-geometry-nodes` -> `blender-shader-nodes` for low-level graph edits -> `blender-render` |
 | Physics setup | `blender-objects` -> `blender-mesh` -> `blender-physics` |
 | Shot and render delivery | `blender-camera` -> `blender-lighting` or `blender-light-rig` -> `blender-render` |
+| Distributed render farm | `blender-render` -> `blender-render-farm` (validate, write job, submit, monitor) |
 | Studio lookdev setup | `blender-materials` -> `blender-material-library` -> `blender-light-rig` -> `blender-render` |
 | File interchange | `blender-scene` -> `blender-interchange` -> `blender-export-preset` when settings repeat |
 | Export validation | `blender-validation` -> `blender-interchange` -> `blender-export-preset` |

--- a/src/dcc_mcp_blender/skills/blender-render-farm/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: blender-render-farm
+description: |-
+  Pipeline stage — render farm integration: validate scenes, write job
+  configs, submit to Deadline or Flamenco, and query job status. Use for
+  distributed render submission. Not for local renders (blender-render).
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: blender
+    layer: domain
+    stage: pipeline
+    version: 1.0.0
+    tags:
+    - blender
+    - render
+    - farm
+    - deadline
+    - flamenco
+    - pipeline
+    - submission
+    search-hint: |-
+      submit render job, distributed render, deadline queue, farm submission,
+      validate scene for farm, render job spec, render job status, flamenco,
+      cancel render, render farm status, list render jobs
+    depends:
+    - blender-render
+    tools: tools.yaml
+    groups: groups.yaml
+---
+# blender-render-farm (Pipeline stage)
+
+Render farm submission. Layered on top of `blender-render` (which handles
+*local* renders): this skill validates the scene for farm readiness, writes
+a JSON job spec, and submits to Deadline (via ``deadlinecommand``) or
+Flamenco (via REST API). Supports cooperative cancellation.
+
+## Scripts
+
+- `validate_scene_for_farm` — Check scene for missing files, render settings, camera
+- `write_render_job` — Write a JSON render job spec for a render farm dispatcher
+- `submit_render_job` — Submit the current scene to Deadline, Flamenco, or a generic farm
+- `get_render_job_status` — Query the status of a submitted render job by job ID
+- `list_render_jobs` — List recent render jobs from the farm manager
+- `cancel_render_job` — Cancel a specific render job on the farm
+- `cooperative_cancel` — Cancel the currently running farm operation cooperatively
+- `render_farm_status` — Report the connected render farm health and worker status

--- a/src/dcc_mcp_blender/skills/blender-render-farm/groups.yaml
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/groups.yaml
@@ -1,0 +1,13 @@
+groups:
+  - name: rendering
+    description: Render farm submission, status, and management tools
+    default_active: false
+    tools:
+    - validate_scene_for_farm
+    - write_render_job
+    - submit_render_job
+    - get_render_job_status
+    - list_render_jobs
+    - cancel_render_job
+    - cooperative_cancel
+    - render_farm_status

--- a/src/dcc_mcp_blender/skills/blender-render-farm/metadata/depends.md
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/metadata/depends.md
@@ -1,0 +1,4 @@
+# Dependencies
+# Skills that should be loaded before this skill for the full workflow.
+
+- blender-render

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/cancel_render_job.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/cancel_render_job.py
@@ -1,0 +1,146 @@
+"""Cancel a specific render job on the render farm.
+
+Supports Deadline and Flamenco backends.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import json
+import os
+import subprocess
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def cancel_render_job(
+    job_id: str,
+    farm: str = "flamenco",
+    deadline_command: Optional[str] = None,
+    flamenco_server_url: Optional[str] = None,
+) -> dict:
+    """Cancel a specific render job on the render farm.
+
+    Args:
+        job_id: The job ID returned by ``submit_render_job``.
+        farm: Render farm backend (``"flamenco"`` or ``"deadline"``).
+        deadline_command: Path to ``deadlinecommand`` binary (Deadline only).
+        flamenco_server_url: Flamenco Manager URL (Flamenco only).
+
+    Returns:
+        ToolResult dict confirming cancellation.
+    """
+
+    try:
+        if farm == "deadline":
+            return _cancel_deadline_job(job_id, deadline_command)
+        elif farm == "flamenco":
+            return _cancel_flamenco_job(job_id, flamenco_server_url)
+        else:
+            return skill_error(
+                "Unknown farm type: '{}'".format(farm),
+                "Supported farms: flamenco, deadline",
+            )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to cancel render job")
+
+
+def _cancel_deadline_job(job_id: str, deadline_command: Optional[str]) -> dict:
+    """Cancel a Deadline job via deadlinecommand."""
+    cmd = deadline_command
+    if not cmd:
+        for candidate in ["deadlinecommand", "deadlinecommand.exe"]:
+            result = subprocess.run(
+                ["where", candidate] if os.name == "nt" else ["which", candidate],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                cmd = candidate
+                break
+    if not cmd:
+        return skill_error(
+            "deadlinecommand not found",
+            "Install Thinkbox Deadline client and ensure it is on PATH",
+        )
+
+    proc = subprocess.run(
+        [cmd, "-DeleteJob", job_id],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    if proc.returncode != 0:
+        return skill_error(
+            "Failed to cancel Deadline job '{}'".format(job_id),
+            proc.stderr.strip() or proc.stdout.strip(),
+        )
+
+    return skill_success(
+        "Cancelled Deadline job '{}'".format(job_id),
+        prompt="Use list_render_jobs to verify the job was removed.",
+        job_id=job_id,
+        farm="deadline",
+        cancelled=True,
+    )
+
+
+def _cancel_flamenco_job(job_id: str, flamenco_server_url: Optional[str]) -> dict:
+    """Cancel a Flamenco job via REST API."""
+    try:
+        import urllib.error  # noqa: PLC0415
+        import urllib.request  # noqa: PLC0415
+
+        server_url = flamenco_server_url or os.environ.get("FLAMENCO_SERVER_URL", "http://localhost:8080")
+        server_url = server_url.rstrip("/")
+
+        api_url = "{}/api/v3/jobs/{}/status".format(server_url, job_id)
+        payload = json.dumps({"status": "cancel-requested"}).encode("utf-8")
+        req = urllib.request.Request(
+            api_url,
+            data=payload,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            method="POST",
+        )
+
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            _result = json.loads(resp.read().decode("utf-8"))
+
+        return skill_success(
+            "Cancelled Flamenco job '{}'".format(job_id),
+            prompt="Use get_render_job_status to confirm the cancellation.",
+            job_id=job_id,
+            farm="flamenco",
+            cancelled=True,
+            server_url=server_url,
+        )
+    except ImportError:
+        return skill_error(
+            "urllib not available",
+            "Python standard library was stripped; install python or use deadline farm",
+        )
+    except urllib.error.HTTPError as exc:
+        if exc.code == 409:
+            return skill_error(
+                "Cannot cancel Flamenco job '{}': job is in a non-cancellable state".format(job_id),
+                "The job may already be completed or cancelled. HTTP 409: {}".format(str(exc)),
+            )
+        return skill_error(
+            "Flamenco API error (HTTP {})".format(exc.code),
+            str(exc),
+        )
+
+
+@skill_entry
+def main(**kwargs):
+    return cancel_render_job(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/cancel_render_job.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/cancel_render_job.py
@@ -50,6 +50,10 @@ def cancel_render_job(
 
 def _cancel_deadline_job(job_id: str, deadline_command: Optional[str]) -> dict:
     """Cancel a Deadline job via deadlinecommand."""
+    from dcc_mcp_core import check_dcc_cancelled  # noqa: PLC0415
+
+    check_dcc_cancelled()
+
     cmd = deadline_command
     if not cmd:
         for candidate in ["deadlinecommand", "deadlinecommand.exe"]:
@@ -66,6 +70,8 @@ def _cancel_deadline_job(job_id: str, deadline_command: Optional[str]) -> dict:
             "deadlinecommand not found",
             "Install Thinkbox Deadline client and ensure it is on PATH",
         )
+
+    check_dcc_cancelled()
 
     proc = subprocess.run(
         [cmd, "-DeleteJob", job_id],

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/cancel_render_job.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/cancel_render_job.py
@@ -90,15 +90,23 @@ def _cancel_deadline_job(job_id: str, deadline_command: Optional[str]) -> dict:
 
 
 def _cancel_flamenco_job(job_id: str, flamenco_server_url: Optional[str]) -> dict:
-    """Cancel a Flamenco job via REST API."""
+    """Cancel a Flamenco job via REST API.
+
+    Uses the official Flamenco v3 API endpoint:
+    ``POST /api/v3/jobs/{job_id}/setstatus`` with body ``{"status": "cancel-requested"}``.
+    """
     try:
         import urllib.error  # noqa: PLC0415
         import urllib.request  # noqa: PLC0415
 
+        from dcc_mcp_core import check_dcc_cancelled  # noqa: PLC0415
+
         server_url = flamenco_server_url or os.environ.get("FLAMENCO_SERVER_URL", "http://localhost:8080")
         server_url = server_url.rstrip("/")
 
-        api_url = "{}/api/v3/jobs/{}/status".format(server_url, job_id)
+        check_dcc_cancelled()
+
+        api_url = "{}/api/v3/jobs/{}/setstatus".format(server_url, job_id)
         payload = json.dumps({"status": "cancel-requested"}).encode("utf-8")
         req = urllib.request.Request(
             api_url,

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/cooperative_cancel.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/cooperative_cancel.py
@@ -16,9 +16,19 @@ from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_
 def cooperative_cancel() -> dict:
     """Signal cooperative cancellation for the currently running farm operation.
 
-    This sets a cancellation flag that the running validation or submission
-    operation checks periodically.  The running operation will raise
-    ``CancelledError`` and abort promptly instead of continuing.
+    This sets a cancellation flag that the running farm operation checks
+    via ``check_dcc_cancelled()`` at key checkpoints:
+
+    - ``validate_scene_for_farm``: at start and inside image/library loops.
+    - ``write_render_job``: before scene inspection.
+    - ``submit_render_job``: before farm submission.
+    - ``get_render_job_status``: before API calls.
+    - ``list_render_jobs``: before API calls.
+    - ``cancel_render_job``: before API calls.
+    - ``render_farm_status``: before each API call.
+
+    When the flag is set, the checkpoint raises ``CancelledError`` and the
+    operation aborts promptly instead of continuing.
 
     Outside an MCP request context (e.g. standalone scripting), the
     cancellation flag has no effect.

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/cooperative_cancel.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/cooperative_cancel.py
@@ -17,15 +17,16 @@ def cooperative_cancel() -> dict:
     """Signal cooperative cancellation for the currently running farm operation.
 
     This sets a cancellation flag that the running farm operation checks
-    via ``check_dcc_cancelled()`` at key checkpoints:
+    via ``check_dcc_cancelled()`` at key checkpoints.  **All supported farm
+    backends are covered** (Deadline, Flamenco, and Generic):
 
     - ``validate_scene_for_farm``: at start and inside image/library loops.
     - ``write_render_job``: before scene inspection.
-    - ``submit_render_job``: before farm submission.
-    - ``get_render_job_status``: before API calls.
-    - ``list_render_jobs``: before API calls.
-    - ``cancel_render_job``: before API calls.
-    - ``render_farm_status``: before each API call.
+    - ``submit_render_job``: before Deadline/Flamenco/Generic submission.
+    - ``get_render_job_status``: before Deadline CLI or Flamenco API calls.
+    - ``list_render_jobs``: before Deadline CLI or Flamenco API calls.
+    - ``cancel_render_job``: before Deadline CLI or Flamenco API calls.
+    - ``render_farm_status``: before Deadline CLI or Flamenco API calls.
 
     When the flag is set, the checkpoint raises ``CancelledError`` and the
     operation aborts promptly instead of continuing.

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/cooperative_cancel.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/cooperative_cancel.py
@@ -1,0 +1,57 @@
+"""Cooperatively cancel the currently running farm operation.
+
+Unlike ``cancel_render_job`` which targets a specific job on the farm
+manager, this tool tells the *local* DCC process to abort a long-running
+farm operation (e.g. validate_scene_for_farm or submit_render_job) that
+is still in progress.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def cooperative_cancel() -> dict:
+    """Signal cooperative cancellation for the currently running farm operation.
+
+    This sets a cancellation flag that the running validation or submission
+    operation checks periodically.  The running operation will raise
+    ``CancelledError`` and abort promptly instead of continuing.
+
+    Outside an MCP request context (e.g. standalone scripting), the
+    cancellation flag has no effect.
+
+    Returns:
+        ToolResult dict confirming the cancellation was signaled.
+    """
+
+    try:
+        from dcc_mcp_core import set_cancelled  # noqa: PLC0415
+
+        set_cancelled()
+        return skill_success(
+            "Cooperative cancellation signaled",
+            prompt="The currently running farm operation will abort at its next checkpoint.",
+            cancelled=True,
+        )
+    except ImportError:
+        return skill_error(
+            "Cancellation not available",
+            "dcc_mcp_core.set_cancelled could not be imported; "
+            "ensure the adapter is running inside a valid MCP session",
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to signal cooperative cancellation")
+
+
+@skill_entry
+def main(**kwargs):
+    return cooperative_cancel(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/get_render_job_status.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/get_render_job_status.py
@@ -50,6 +50,10 @@ def get_render_job_status(
 
 def _query_deadline(job_id: str, deadline_command: Optional[str]) -> dict:
     """Query Deadline for job status via deadlinecommand."""
+    from dcc_mcp_core import check_dcc_cancelled  # noqa: PLC0415
+
+    check_dcc_cancelled()
+
     cmd = deadline_command
     if not cmd:
         for candidate in ["deadlinecommand", "deadlinecommand.exe"]:
@@ -66,6 +70,8 @@ def _query_deadline(job_id: str, deadline_command: Optional[str]) -> dict:
             "deadlinecommand not found",
             "Install Thinkbox Deadline client and ensure it is on PATH",
         )
+
+    check_dcc_cancelled()
 
     proc = subprocess.run(
         [cmd, "-GetJobDetails", job_id],

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/get_render_job_status.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/get_render_job_status.py
@@ -1,0 +1,166 @@
+"""Query the status of a submitted render job by job ID.
+
+Supports Deadline, Flamenco, and generic farm backends.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import json
+import os
+import subprocess
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def get_render_job_status(
+    job_id: str,
+    farm: str = "flamenco",
+    deadline_command: Optional[str] = None,
+    flamenco_server_url: Optional[str] = None,
+) -> dict:
+    """Query the render farm for the status of a render job.
+
+    Args:
+        job_id: The job ID returned by ``submit_render_job``.
+        farm: Render farm backend (``"flamenco"`` or ``"deadline"``).
+        deadline_command: Path to ``deadlinecommand`` binary (Deadline only).
+        flamenco_server_url: Flamenco Manager URL (Flamenco only).
+
+    Returns:
+        ToolResult dict with job status, progress, and task summary.
+    """
+
+    try:
+        if farm == "deadline":
+            return _query_deadline(job_id, deadline_command)
+        elif farm == "flamenco":
+            return _query_flamenco(job_id, flamenco_server_url)
+        else:
+            return skill_error(
+                "Unknown farm type: '{}'".format(farm),
+                "Supported farms: flamenco, deadline",
+            )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to query job status")
+
+
+def _query_deadline(job_id: str, deadline_command: Optional[str]) -> dict:
+    """Query Deadline for job status via deadlinecommand."""
+    cmd = deadline_command
+    if not cmd:
+        for candidate in ["deadlinecommand", "deadlinecommand.exe"]:
+            result = subprocess.run(
+                ["where", candidate] if os.name == "nt" else ["which", candidate],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                cmd = candidate
+                break
+    if not cmd:
+        return skill_error(
+            "deadlinecommand not found",
+            "Install Thinkbox Deadline client and ensure it is on PATH",
+        )
+
+    proc = subprocess.run(
+        [cmd, "-GetJobDetails", job_id],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    if proc.returncode != 0:
+        return skill_error(
+            "Failed to query job '{}'".format(job_id),
+            proc.stderr.strip() or proc.stdout.strip(),
+        )
+
+    # Parse key=value output
+    status_info = {}  # type: dict
+    for line in proc.stdout.splitlines():
+        if "=" in line:
+            k, _, v = line.partition("=")
+            status_info[k.strip()] = v.strip()
+
+    job_status = status_info.get("Status", "Unknown")
+    completed = status_info.get("CompletedChunks", "0")
+    total = status_info.get("TaskCount", "0")
+    errors = status_info.get("FailedChunks", "0")
+
+    return skill_success(
+        "Job '{}' status: {} ({}/{} tasks)".format(job_id, job_status, completed, total),
+        prompt="Check again later or use submit_render_job to resubmit if failed.",
+        job_id=job_id,
+        farm="deadline",
+        status=job_status,
+        completed_tasks=completed,
+        total_tasks=total,
+        failed_tasks=errors,
+        raw=status_info,
+    )
+
+
+def _query_flamenco(job_id: str, flamenco_server_url: Optional[str]) -> dict:
+    """Query Flamenco Manager API for job status."""
+    try:
+        import urllib.error  # noqa: PLC0415
+        import urllib.request  # noqa: PLC0415
+
+        server_url = flamenco_server_url or os.environ.get("FLAMENCO_SERVER_URL", "http://localhost:8080")
+        server_url = server_url.rstrip("/")
+
+        api_url = "{}/api/v3/jobs/{}".format(server_url, job_id)
+        req = urllib.request.Request(api_url, headers={"Accept": "application/json"}, method="GET")
+
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+
+        job_status = result.get("status", "unknown")
+        task_summary = result.get("task_summary", {})
+        completed = task_summary.get("completed", 0)
+        total = task_summary.get("total", 0)
+        failed = task_summary.get("failed", 0)
+
+        return skill_success(
+            "Job '{}' status: {} ({}/{} tasks)".format(job_id, job_status, completed, total),
+            prompt="Check again later or use submit_render_job to resubmit if failed.",
+            job_id=job_id,
+            farm="flamenco",
+            status=job_status,
+            completed_tasks=completed,
+            total_tasks=total,
+            failed_tasks=failed,
+            name=result.get("name", ""),
+            server_url=server_url,
+        )
+    except ImportError:
+        return skill_error(
+            "urllib not available",
+            "Python standard library was stripped; install python or use deadline farm",
+        )
+    except urllib.error.HTTPError as exc:
+        return skill_error(
+            "Flamenco API error (HTTP {})".format(exc.code),
+            str(exc),
+        )
+    except Exception as exc:
+        return skill_error(
+            "Failed to query Flamenco job '{}'".format(job_id),
+            str(exc),
+        )
+
+
+@skill_entry
+def main(**kwargs):
+    return get_render_job_status(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/get_render_job_status.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/get_render_job_status.py
@@ -111,8 +111,12 @@ def _query_flamenco(job_id: str, flamenco_server_url: Optional[str]) -> dict:
         import urllib.error  # noqa: PLC0415
         import urllib.request  # noqa: PLC0415
 
+        from dcc_mcp_core import check_dcc_cancelled  # noqa: PLC0415
+
         server_url = flamenco_server_url or os.environ.get("FLAMENCO_SERVER_URL", "http://localhost:8080")
         server_url = server_url.rstrip("/")
+
+        check_dcc_cancelled()
 
         api_url = "{}/api/v3/jobs/{}".format(server_url, job_id)
         req = urllib.request.Request(api_url, headers={"Accept": "application/json"}, method="GET")

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/list_render_jobs.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/list_render_jobs.py
@@ -56,6 +56,10 @@ def _list_deadline_jobs(
     deadline_command: Optional[str],
 ) -> dict:
     """List Deadline jobs via deadlinecommand."""
+    from dcc_mcp_core import check_dcc_cancelled  # noqa: PLC0415
+
+    check_dcc_cancelled()
+
     cmd = deadline_command
     if not cmd:
         for candidate in ["deadlinecommand", "deadlinecommand.exe"]:
@@ -72,6 +76,8 @@ def _list_deadline_jobs(
             "deadlinecommand not found",
             "Install Thinkbox Deadline client and ensure it is on PATH",
         )
+
+    check_dcc_cancelled()
 
     args = [cmd, "-GetJobs"]
     if status_filter:

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/list_render_jobs.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/list_render_jobs.py
@@ -126,8 +126,12 @@ def _list_flamenco_jobs(
         import urllib.error  # noqa: PLC0415
         import urllib.request  # noqa: PLC0415
 
+        from dcc_mcp_core import check_dcc_cancelled  # noqa: PLC0415
+
         server_url = flamenco_server_url or os.environ.get("FLAMENCO_SERVER_URL", "http://localhost:8080")
         server_url = server_url.rstrip("/")
+
+        check_dcc_cancelled()
 
         api_url = "{}/api/v3/jobs?limit={}".format(server_url, limit)
         if status_filter:

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/list_render_jobs.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/list_render_jobs.py
@@ -1,0 +1,176 @@
+"""List recent render jobs from the farm manager.
+
+Supports Deadline and Flamenco backends.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import json
+import os
+import subprocess
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def list_render_jobs(
+    farm: str = "flamenco",
+    limit: int = 20,
+    status_filter: Optional[str] = None,
+    deadline_command: Optional[str] = None,
+    flamenco_server_url: Optional[str] = None,
+) -> dict:
+    """List recent render jobs from the farm manager.
+
+    Args:
+        farm: Render farm backend (``"flamenco"`` or ``"deadline"``).
+        limit: Maximum number of jobs to return.  Default: 20.
+        status_filter: Optional filter by job status (e.g. ``"queued"``, ``"active"``, ``"completed"``).
+        deadline_command: Path to ``deadlinecommand`` binary (Deadline only).
+        flamenco_server_url: Flamenco Manager URL (Flamenco only).
+
+    Returns:
+        ToolResult dict with ``context.jobs`` list and ``context.count``.
+    """
+
+    try:
+        if farm == "deadline":
+            return _list_deadline_jobs(limit, status_filter, deadline_command)
+        elif farm == "flamenco":
+            return _list_flamenco_jobs(limit, status_filter, flamenco_server_url)
+        else:
+            return skill_error(
+                "Unknown farm type: '{}'".format(farm),
+                "Supported farms: flamenco, deadline",
+            )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list render jobs")
+
+
+def _list_deadline_jobs(
+    limit: int,
+    status_filter: Optional[str],
+    deadline_command: Optional[str],
+) -> dict:
+    """List Deadline jobs via deadlinecommand."""
+    cmd = deadline_command
+    if not cmd:
+        for candidate in ["deadlinecommand", "deadlinecommand.exe"]:
+            result = subprocess.run(
+                ["where", candidate] if os.name == "nt" else ["which", candidate],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                cmd = candidate
+                break
+    if not cmd:
+        return skill_error(
+            "deadlinecommand not found",
+            "Install Thinkbox Deadline client and ensure it is on PATH",
+        )
+
+    args = [cmd, "-GetJobs"]
+    if status_filter:
+        args.extend(["-Status", status_filter])
+    args.extend(["-Limit", str(limit)])
+
+    proc = subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    if proc.returncode != 0:
+        return skill_error(
+            "Failed to list Deadline jobs",
+            proc.stderr.strip() or proc.stdout.strip(),
+        )
+
+    # Parse multi-line output — each job is separated by an empty line
+    jobs = []
+    current_job = {}  # type: dict
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            if current_job:
+                jobs.append(current_job)
+                current_job = {}
+            continue
+        if "=" in line:
+            k, _, v = line.partition("=")
+            current_job[k.strip()] = v.strip()
+    if current_job:
+        jobs.append(current_job)
+
+    return skill_success(
+        "Found {} Deadline job(s)".format(len(jobs)),
+        prompt="Use get_render_job_status with a specific job_id to get details.",
+        farm="deadline",
+        count=len(jobs),
+        jobs=jobs,
+    )
+
+
+def _list_flamenco_jobs(
+    limit: int,
+    status_filter: Optional[str],
+    flamenco_server_url: Optional[str],
+) -> dict:
+    """List Flamenco jobs via REST API."""
+    try:
+        import urllib.error  # noqa: PLC0415
+        import urllib.request  # noqa: PLC0415
+
+        server_url = flamenco_server_url or os.environ.get("FLAMENCO_SERVER_URL", "http://localhost:8080")
+        server_url = server_url.rstrip("/")
+
+        api_url = "{}/api/v3/jobs?limit={}".format(server_url, limit)
+        if status_filter:
+            api_url += "&status={}".format(status_filter)
+
+        req = urllib.request.Request(api_url, headers={"Accept": "application/json"}, method="GET")
+
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+
+        jobs = result.get("jobs", result if isinstance(result, list) else [])
+
+        return skill_success(
+            "Found {} Flamenco job(s)".format(len(jobs)),
+            prompt="Use get_render_job_status with a specific job_id to get details.",
+            farm="flamenco",
+            count=len(jobs),
+            jobs=jobs,
+            server_url=server_url,
+        )
+    except ImportError:
+        return skill_error(
+            "urllib not available",
+            "Python standard library was stripped; install python or use deadline farm",
+        )
+    except urllib.error.HTTPError as exc:
+        return skill_error(
+            "Flamenco API error (HTTP {})".format(exc.code),
+            str(exc),
+        )
+    except Exception as exc:
+        return skill_error(
+            "Failed to list Flamenco jobs",
+            str(exc),
+        )
+
+
+@skill_entry
+def main(**kwargs):
+    return list_render_jobs(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/render_farm_status.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/render_farm_status.py
@@ -111,24 +111,45 @@ def _query_deadline_status(deadline_command: Optional[str]) -> dict:
 
 
 def _query_flamenco_status(flamenco_server_url: Optional[str]) -> dict:
-    """Query Flamenco Manager health and worker status via REST API."""
+    """Query Flamenco Manager health and worker status via REST API.
+
+    Uses the official Flamenco v3 API endpoints:
+    - ``GET /api/v3/status`` — manager version and health.
+    - ``GET /api/v3/worker-mgt/workers`` — registered worker list.
+    - ``GET /api/v3/jobs?status=queued`` — queued job count.
+    """
     try:
         import urllib.error  # noqa: PLC0415
         import urllib.request  # noqa: PLC0415
 
+        from dcc_mcp_core import check_dcc_cancelled  # noqa: PLC0415
+
         server_url = flamenco_server_url or os.environ.get("FLAMENCO_SERVER_URL", "http://localhost:8080")
         server_url = server_url.rstrip("/")
 
-        # Query manager config/health
-        workers_url = "{}/api/v3/workers".format(server_url)
-        req = urllib.request.Request(workers_url, headers={"Accept": "application/json"}, method="GET")
+        # 1. Manager health via GET /api/v3/status
+        healthy = True
+        manager_name = ""
+        try:
+            check_dcc_cancelled()
+            status_url = "{}/api/v3/status".format(server_url)
+            status_req = urllib.request.Request(status_url, headers={"Accept": "application/json"}, method="GET")
+            with urllib.request.urlopen(status_req, timeout=30) as resp:
+                status_data = json.loads(resp.read().decode("utf-8"))
+                manager_name = status_data.get("name", "")
+        except urllib.error.HTTPError:
+            healthy = False
+        except Exception:
+            healthy = False
 
+        # 2. Worker list via GET /api/v3/worker-mgt/workers
         workers = []
         worker_count = 0
-        healthy = True
-
         try:
-            with urllib.request.urlopen(req, timeout=30) as resp:
+            check_dcc_cancelled()
+            workers_url = "{}/api/v3/worker-mgt/workers".format(server_url)
+            workers_req = urllib.request.Request(workers_url, headers={"Accept": "application/json"}, method="GET")
+            with urllib.request.urlopen(workers_req, timeout=30) as resp:
                 workers_data = json.loads(resp.read().decode("utf-8"))
                 workers = workers_data.get("workers", workers_data if isinstance(workers_data, list) else [])
                 worker_count = len(workers)
@@ -139,21 +160,23 @@ def _query_flamenco_status(flamenco_server_url: Optional[str]) -> dict:
             healthy = False
             workers = [{"error": str(exc)}]
 
-        # Query job queue summary
+        # 3. Queue statistics via GET /api/v3/jobs?status=queued
         queue_stats = {}
         try:
-            queue_url = "{}/api/v3/jobs/queue".format(server_url)
+            check_dcc_cancelled()
+            queue_url = "{}/api/v3/jobs?status=queued&limit=0".format(server_url)
             queue_req = urllib.request.Request(queue_url, headers={"Accept": "application/json"}, method="GET")
             with urllib.request.urlopen(queue_req, timeout=30) as resp:
                 queue_data = json.loads(resp.read().decode("utf-8"))
                 queue_stats = {
-                    "queued": queue_data.get("length", 0) if isinstance(queue_data, dict) else len(queue_data),
+                    "queued": queue_data.get("total", 0) if isinstance(queue_data, dict) else len(queue_data),
                 }
         except Exception:
             pass
 
         return skill_success(
-            "Flamenco farm status: {} worker(s), {} queued job(s)".format(
+            "Flamenco {} status: {} worker(s), {} queued job(s)".format(
+                manager_name or "Manager",
                 worker_count,
                 queue_stats.get("queued", 0),
             ),

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/render_farm_status.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/render_farm_status.py
@@ -49,6 +49,10 @@ def render_farm_status(
 
 def _query_deadline_status(deadline_command: Optional[str]) -> dict:
     """Query Deadline farm status via deadlinecommand."""
+    from dcc_mcp_core import check_dcc_cancelled  # noqa: PLC0415
+
+    check_dcc_cancelled()
+
     cmd = deadline_command
     if not cmd:
         for candidate in ["deadlinecommand", "deadlinecommand.exe"]:
@@ -65,6 +69,8 @@ def _query_deadline_status(deadline_command: Optional[str]) -> dict:
             "deadlinecommand not found",
             "Install Thinkbox Deadline client and ensure it is on PATH",
         )
+
+    check_dcc_cancelled()
 
     # Query slave list for worker availability
     proc = subprocess.run(

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/render_farm_status.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/render_farm_status.py
@@ -1,0 +1,188 @@
+"""Report the connected render farm health and worker status.
+
+Queries Deadline or Flamenco for current farm health, available workers,
+and queue statistics.
+"""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import json
+import os
+import subprocess
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def render_farm_status(
+    farm: str = "flamenco",
+    deadline_command: Optional[str] = None,
+    flamenco_server_url: Optional[str] = None,
+) -> dict:
+    """Report the connected render farm health and worker status.
+
+    Args:
+        farm: Render farm backend (``"flamenco"`` or ``"deadline"``).
+        deadline_command: Path to ``deadlinecommand`` binary (Deadline only).
+        flamenco_server_url: Flamenco Manager URL (Flamenco only).
+
+    Returns:
+        ToolResult dict with farm status, workers, and queue summary.
+    """
+
+    try:
+        if farm == "deadline":
+            return _query_deadline_status(deadline_command)
+        elif farm == "flamenco":
+            return _query_flamenco_status(flamenco_server_url)
+        else:
+            return skill_error(
+                "Unknown farm type: '{}'".format(farm),
+                "Supported farms: flamenco, deadline",
+            )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to query render farm status")
+
+
+def _query_deadline_status(deadline_command: Optional[str]) -> dict:
+    """Query Deadline farm status via deadlinecommand."""
+    cmd = deadline_command
+    if not cmd:
+        for candidate in ["deadlinecommand", "deadlinecommand.exe"]:
+            result = subprocess.run(
+                ["where", candidate] if os.name == "nt" else ["which", candidate],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                cmd = candidate
+                break
+    if not cmd:
+        return skill_error(
+            "deadlinecommand not found",
+            "Install Thinkbox Deadline client and ensure it is on PATH",
+        )
+
+    # Query slave list for worker availability
+    proc = subprocess.run(
+        [cmd, "-GetSlaveNames"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    workers = []
+    if proc.returncode == 0:
+        for line in proc.stdout.splitlines():
+            line = line.strip()
+            if line:
+                workers.append({"name": line, "status": "online"})
+
+    # Query pulse stats for queue info
+    pulse_proc = subprocess.run(
+        [cmd, "-GetPulseStats"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    pulse_info = {}  # type: dict
+    if pulse_proc.returncode == 0:
+        for line in pulse_proc.stdout.splitlines():
+            if "=" in line:
+                k, _, v = line.partition("=")
+                pulse_info[k.strip()] = v.strip()
+
+    return skill_success(
+        "Deadline farm status: {} worker(s), {} queued job(s)".format(
+            len(workers),
+            pulse_info.get("QueuedJobsCount", "0"),
+        ),
+        prompt="Use list_render_jobs to see job details.",
+        farm="deadline",
+        workers=workers,
+        worker_count=len(workers),
+        queue_stats=pulse_info,
+        healthy=proc.returncode == 0,
+    )
+
+
+def _query_flamenco_status(flamenco_server_url: Optional[str]) -> dict:
+    """Query Flamenco Manager health and worker status via REST API."""
+    try:
+        import urllib.error  # noqa: PLC0415
+        import urllib.request  # noqa: PLC0415
+
+        server_url = flamenco_server_url or os.environ.get("FLAMENCO_SERVER_URL", "http://localhost:8080")
+        server_url = server_url.rstrip("/")
+
+        # Query manager config/health
+        workers_url = "{}/api/v3/workers".format(server_url)
+        req = urllib.request.Request(workers_url, headers={"Accept": "application/json"}, method="GET")
+
+        workers = []
+        worker_count = 0
+        healthy = True
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                workers_data = json.loads(resp.read().decode("utf-8"))
+                workers = workers_data.get("workers", workers_data if isinstance(workers_data, list) else [])
+                worker_count = len(workers)
+        except urllib.error.HTTPError as exc:
+            healthy = False
+            workers = [{"error": "HTTP {}: {}".format(exc.code, str(exc))}]
+        except Exception as exc:
+            healthy = False
+            workers = [{"error": str(exc)}]
+
+        # Query job queue summary
+        queue_stats = {}
+        try:
+            queue_url = "{}/api/v3/jobs/queue".format(server_url)
+            queue_req = urllib.request.Request(queue_url, headers={"Accept": "application/json"}, method="GET")
+            with urllib.request.urlopen(queue_req, timeout=30) as resp:
+                queue_data = json.loads(resp.read().decode("utf-8"))
+                queue_stats = {
+                    "queued": queue_data.get("length", 0) if isinstance(queue_data, dict) else len(queue_data),
+                }
+        except Exception:
+            pass
+
+        return skill_success(
+            "Flamenco farm status: {} worker(s), {} queued job(s)".format(
+                worker_count,
+                queue_stats.get("queued", 0),
+            ),
+            prompt="Use list_render_jobs to see job details.",
+            farm="flamenco",
+            workers=workers,
+            worker_count=worker_count,
+            queue_stats=queue_stats,
+            healthy=healthy,
+            server_url=server_url,
+        )
+    except ImportError:
+        return skill_error(
+            "urllib not available",
+            "Python standard library was stripped; install python or use deadline farm",
+        )
+    except Exception as exc:
+        return skill_error(
+            "Failed to query Flamenco farm status",
+            str(exc),
+        )
+
+
+@skill_entry
+def main(**kwargs):
+    return render_farm_status(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/submit_render_job.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/submit_render_job.py
@@ -317,6 +317,10 @@ def _submit_generic(
     file_format: str,
 ) -> dict:
     """Write a generic render job spec and return the file path."""
+    from dcc_mcp_core import check_dcc_cancelled  # noqa: PLC0415
+
+    check_dcc_cancelled()
+
     job_spec = {
         "name": name,
         "scene_file": scene_path,

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/submit_render_job.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/submit_render_job.py
@@ -1,0 +1,343 @@
+"""Submit the current Blender scene to a render farm (Flamenco, Deadline, or generic)."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import json
+import os
+import subprocess
+import tempfile
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def submit_render_job(
+    farm: str = "flamenco",
+    job_name: Optional[str] = None,
+    pool: str = "blender",
+    priority: int = 50,
+    start_frame: Optional[int] = None,
+    end_frame: Optional[int] = None,
+    chunk_size: int = 10,
+    deadline_command: Optional[str] = None,
+    flamenco_server_url: Optional[str] = None,
+    flamenco_project_id: Optional[str] = None,
+) -> dict:
+    """Submit the current Blender scene to a render farm.
+
+    Supports three farm backends:
+
+    - ``"flamenco"``: Submit to a Flamenco Manager via the REST API.
+    - ``"deadline"``: Submit to Thinkbox Deadline via ``deadlinecommand`` CLI.
+    - ``"generic"``: Write a JSON job spec to a directory for a custom dispatcher.
+
+    Args:
+        farm: Render farm backend (``"flamenco"``, ``"deadline"``, or ``"generic"``).
+        job_name: Display name for the job.  Defaults to scene stem.
+        pool: Worker pool / farm name.  Default: ``"blender"``.
+        priority: Job priority 0-100.  Default: 50.
+        start_frame: Override start frame.
+        end_frame: Override end frame.
+        chunk_size: Frames per task.  Default: 10.
+        deadline_command: Path to ``deadlinecommand`` binary (Deadline only).
+        flamenco_server_url: Flamenco Manager URL (Flamenco only).
+        flamenco_project_id: Flamenco project UUID (Flamenco only).
+
+    Returns:
+        ToolResult dict with the job ID on success.
+    """
+
+    try:
+        import bpy  # noqa: PLC0415
+
+        scene_path = bpy.data.filepath or ""
+        if not scene_path:
+            return skill_error(
+                "Scene must be saved before submitting",
+                "Save the scene first with save_scene",
+            )
+
+        scene_stem = os.path.splitext(os.path.basename(scene_path))[0]
+        name = job_name or scene_stem
+
+        scene = bpy.context.scene
+        render = scene.render
+
+        sf = start_frame if start_frame is not None else scene.frame_start
+        ef = end_frame if end_frame is not None else scene.frame_end
+
+        if farm == "deadline":
+            return _submit_to_deadline(
+                name=name,
+                scene_path=scene_path,
+                pool=pool,
+                priority=priority,
+                sf=sf,
+                ef=ef,
+                chunk_size=chunk_size,
+                render_engine=render.engine,
+                output_path=render.filepath,
+                deadline_command=deadline_command,
+            )
+        elif farm == "flamenco":
+            return _submit_to_flamenco(
+                name=name,
+                scene_path=scene_path,
+                sf=sf,
+                ef=ef,
+                chunk_size=chunk_size,
+                render_engine=render.engine,
+                output_path=render.filepath,
+                flamenco_server_url=flamenco_server_url,
+                flamenco_project_id=flamenco_project_id,
+            )
+        elif farm == "generic":
+            return _submit_generic(
+                name=name,
+                scene_path=scene_path,
+                sf=sf,
+                ef=ef,
+                chunk_size=chunk_size,
+                render_engine=render.engine,
+                output_path=render.filepath,
+                resolution_x=render.resolution_x,
+                resolution_y=render.resolution_y,
+                file_format=render.image_settings.file_format,
+            )
+        else:
+            return skill_error(
+                "Unknown farm type: '{}'".format(farm),
+                "Supported farms: flamenco, deadline, generic",
+            )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to submit render job")
+
+
+def _submit_to_deadline(
+    name: str,
+    scene_path: str,
+    pool: str,
+    priority: int,
+    sf: int,
+    ef: int,
+    chunk_size: int,
+    render_engine: str,
+    output_path: str,
+    deadline_command: Optional[str],
+) -> dict:
+    """Submit to Thinkbox Deadline via deadlinecommand CLI."""
+    # Locate deadlinecommand
+    cmd = deadline_command
+    if not cmd:
+        for candidate in ["deadlinecommand", "deadlinecommand.exe"]:
+            result = subprocess.run(
+                ["where", candidate] if os.name == "nt" else ["which", candidate],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                cmd = candidate
+                break
+    if not cmd:
+        return skill_error(
+            "deadlinecommand not found",
+            "Install Thinkbox Deadline client and ensure it is on PATH",
+        )
+
+    # Build minimal job info files
+    job_info = {
+        "Plugin": "Blender",
+        "Name": name,
+        "Pool": pool,
+        "Priority": str(priority),
+        "Frames": "{}-{}".format(sf, ef),
+        "ChunkSize": str(chunk_size),
+        "OutputDirectory0": output_path,
+    }
+    import bpy as _bpy  # noqa: PLC0415
+
+    plugin_info = {
+        "SceneFile": scene_path,
+        "Version": _bpy.app.version_string if hasattr(_bpy.app, "version_string") else "4.0",
+        "Renderer": render_engine,
+    }
+
+    with tempfile.TemporaryDirectory() as tmp:
+        job_file = os.path.join(tmp, "job_info.job")
+        plugin_file = os.path.join(tmp, "plugin_info.job")
+
+        with open(job_file, "w") as fh:
+            for k, v in job_info.items():
+                fh.write("{}={}\n".format(k, v))
+        with open(plugin_file, "w") as fh:
+            for k, v in plugin_info.items():
+                fh.write("{}={}\n".format(k, v))
+
+        proc = subprocess.run(
+            [cmd, job_file, plugin_file],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    if proc.returncode != 0:
+        return skill_error(
+            "Deadline submission failed",
+            proc.stderr.strip() or proc.stdout.strip(),
+        )
+
+    # Parse job ID from output
+    job_id = ""
+    for line in proc.stdout.splitlines():
+        if "JobID" in line or "Job ID" in line:
+            parts = line.split("=", 1) if "=" in line else line.split(":", 1)
+            if len(parts) == 2:
+                job_id = parts[1].strip()
+                break
+
+    return skill_success(
+        "Submitted '{}' to Deadline (job ID: {})".format(name, job_id or "unknown"),
+        prompt="Use get_render_job_status with farm='deadline' and the job ID to monitor progress.",
+        job_id=job_id,
+        name=name,
+        farm="deadline",
+        pool=pool,
+        frame_range="{}-{}".format(sf, ef),
+    )
+
+
+def _submit_to_flamenco(
+    name: str,
+    scene_path: str,
+    sf: int,
+    ef: int,
+    chunk_size: int,
+    render_engine: str,
+    output_path: str,
+    flamenco_server_url: Optional[str],
+    flamenco_project_id: Optional[str],
+) -> dict:
+    """Submit to Flamenco Manager via its REST API."""
+    try:
+        import urllib.request  # noqa: PLC0415
+
+        server_url = flamenco_server_url or os.environ.get("FLAMENCO_SERVER_URL", "http://localhost:8080")
+        server_url = server_url.rstrip("/")
+
+        # Build job payload for Flamenco API
+        job_payload = {
+            "name": name,
+            "type": "blender-render",
+            "description": "Submitted from dcc-mcp-blender",
+            "settings": {
+                "blender_cmd": "blender",
+                "filepath": scene_path,
+                "render_engine": render_engine,
+                "render_output": output_path,
+                "frames": "{}-{}".format(sf, ef),
+                "chunk_size": chunk_size,
+            },
+            "priority": 50,
+        }
+        if flamenco_project_id:
+            job_payload["project_id"] = flamenco_project_id
+
+        # Submit job via Flamenco REST API
+        api_url = "{}/api/v3/jobs".format(server_url)
+        data = json.dumps(job_payload).encode("utf-8")
+        req = urllib.request.Request(
+            api_url,
+            data=data,
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+            job_id = result.get("id", "")
+
+        return skill_success(
+            "Submitted '{}' to Flamenco (job ID: {})".format(name, job_id),
+            prompt="Use get_render_job_status with farm='flamenco' and the job ID to monitor progress.",
+            job_id=job_id,
+            name=name,
+            farm="flamenco",
+            server_url=server_url,
+            frame_range="{}-{}".format(sf, ef),
+        )
+    except ImportError:
+        return skill_error(
+            "urllib not available",
+            "Python standard library was stripped; install python or use deadline farm",
+        )
+    except Exception as exc:
+        return skill_error(
+            "Flamenco submission failed",
+            str(exc),
+        )
+
+
+def _submit_generic(
+    name: str,
+    scene_path: str,
+    sf: int,
+    ef: int,
+    chunk_size: int,
+    render_engine: str,
+    output_path: str,
+    resolution_x: int,
+    resolution_y: int,
+    file_format: str,
+) -> dict:
+    """Write a generic render job spec and return the file path."""
+    job_spec = {
+        "name": name,
+        "scene_file": scene_path,
+        "renderer": render_engine,
+        "start_frame": sf,
+        "end_frame": ef,
+        "chunk_size": chunk_size,
+        "output_dir": output_path,
+        "resolution_x": resolution_x,
+        "resolution_y": resolution_y,
+        "file_format": file_format,
+    }
+
+    output_dir = os.path.join(tempfile.gettempdir(), "render_jobs")
+    os.makedirs(output_dir, exist_ok=True)
+    job_file = os.path.join(output_dir, "{}.json".format(name))
+
+    with open(job_file, "w") as fh:
+        json.dump(job_spec, fh, indent=2)
+
+    frame_count = max(0, (ef - sf) + 1)
+    task_count = max(1, (frame_count + chunk_size - 1) // chunk_size)
+
+    return skill_success(
+        "Wrote generic render job spec '{}'".format(name),
+        prompt=("The job spec was written to {}. Use a custom dispatcher to pick up and run the job.".format(job_file)),
+        job_file=job_file,
+        name=name,
+        farm="generic",
+        frame_range="{}-{}".format(sf, ef),
+        frame_count=frame_count,
+        task_count=task_count,
+    )
+
+
+@skill_entry
+def main(**kwargs):
+    return submit_render_job(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/submit_render_job.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/submit_render_job.py
@@ -89,6 +89,7 @@ def submit_render_job(
                 sf=sf,
                 ef=ef,
                 chunk_size=chunk_size,
+                priority=priority,
                 render_engine=render.engine,
                 output_path=render.filepath,
                 flamenco_server_url=flamenco_server_url,
@@ -217,19 +218,30 @@ def _submit_to_flamenco(
     sf: int,
     ef: int,
     chunk_size: int,
+    priority: int,
     render_engine: str,
     output_path: str,
     flamenco_server_url: Optional[str],
     flamenco_project_id: Optional[str],
 ) -> dict:
-    """Submit to Flamenco Manager via its REST API."""
+    """Submit to Flamenco Manager via its REST API.
+
+    Aligns with the Flamenco \"Simple Blender Render\" job type schema
+    (v3 API).  Required settings: ``blender_cmd``, ``filepath``,
+    ``frames``, ``chunk_size``, ``render_output``, ``render_engine``,
+    ``add_path_components``.
+    """
     try:
         import urllib.request  # noqa: PLC0415
+
+        from dcc_mcp_core import check_dcc_cancelled  # noqa: PLC0415
 
         server_url = flamenco_server_url or os.environ.get("FLAMENCO_SERVER_URL", "http://localhost:8080")
         server_url = server_url.rstrip("/")
 
-        # Build job payload for Flamenco API
+        check_dcc_cancelled()
+
+        # Build job payload matching Flamenco "blender-render" job type
         job_payload = {
             "name": name,
             "type": "blender-render",
@@ -241,8 +253,9 @@ def _submit_to_flamenco(
                 "render_output": output_path,
                 "frames": "{}-{}".format(sf, ef),
                 "chunk_size": chunk_size,
+                "add_path_components": True,
             },
-            "priority": 50,
+            "priority": priority,
         }
         if flamenco_project_id:
             job_payload["project_id"] = flamenco_project_id
@@ -271,6 +284,7 @@ def _submit_to_flamenco(
             farm="flamenco",
             server_url=server_url,
             frame_range="{}-{}".format(sf, ef),
+            priority=priority,
         )
     except ImportError:
         return skill_error(

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/submit_render_job.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/submit_render_job.py
@@ -132,6 +132,10 @@ def _submit_to_deadline(
     deadline_command: Optional[str],
 ) -> dict:
     """Submit to Thinkbox Deadline via deadlinecommand CLI."""
+    from dcc_mcp_core import check_dcc_cancelled  # noqa: PLC0415
+
+    check_dcc_cancelled()
+
     # Locate deadlinecommand
     cmd = deadline_command
     if not cmd:
@@ -149,6 +153,8 @@ def _submit_to_deadline(
             "deadlinecommand not found",
             "Install Thinkbox Deadline client and ensure it is on PATH",
         )
+
+    check_dcc_cancelled()
 
     # Build minimal job info files
     job_info = {

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/validate_scene_for_farm.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/validate_scene_for_farm.py
@@ -1,0 +1,98 @@
+"""Validate a Blender scene for render farm submission."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import os
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def validate_scene_for_farm() -> dict:
+    """Check the open Blender scene for common farm-submission issues.
+
+    Checks performed:
+    - Scene is saved (not untitled)
+    - Active camera exists
+    - Render frame range is valid (start < end)
+    - Output path is set
+    - No missing external files (textures, linked libraries, etc.)
+
+    Returns:
+        ToolResult dict with ``context.issues`` list and ``context.valid`` flag.
+    """
+
+    try:
+        import bpy  # noqa: PLC0415
+
+        issues = []  # type: List[str]
+
+        # 1. Scene is saved
+        scene_path = bpy.data.filepath or ""
+        if not scene_path:
+            issues.append("Scene is unsaved (untitled) — save before submitting")
+
+        # 2. Active camera
+        scene = bpy.context.scene
+        if not scene.camera:
+            issues.append("No active camera found — set a camera before submitting")
+
+        # 3. Render frame range
+        start = scene.frame_start
+        end = scene.frame_end
+        if end <= start:
+            issues.append("Render frame range invalid: frame_start={} frame_end={}".format(start, end))
+
+        # 4. Output path
+        output_path = scene.render.filepath or ""
+        if not output_path:
+            issues.append("No render output path set")
+
+        # 5. Missing external files
+        if hasattr(bpy.data, "images"):
+            for img in bpy.data.images:
+                if img.filepath and not img.packed_file:
+                    abs_path = img.filepath_from_user()
+                    if abs_path and not os.path.isfile(abs_path):
+                        issues.append("Missing image file: '{}' on image '{}'".format(img.filepath, img.name))
+
+        # 6. Missing linked libraries
+        if hasattr(bpy.data, "libraries"):
+            for lib in bpy.data.libraries:
+                if lib.filepath and not os.path.isfile(lib.filepath):
+                    issues.append("Missing library: '{}' (name: {})".format(lib.filepath, lib.name))
+
+        valid = len(issues) == 0
+        if valid:
+            return skill_success(
+                "Scene is valid for farm submission",
+                prompt="Use write_render_job to create a job spec for the render farm.",
+                valid=True,
+                issues=[],
+                scene_path=scene_path,
+            )
+        else:
+            return skill_success(
+                "Scene has {} issue(s) that should be resolved before submission".format(len(issues)),
+                prompt="Fix the listed issues, then re-run validate_scene_for_farm.",
+                valid=False,
+                issues=issues,
+                scene_path=scene_path,
+            )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to validate scene")
+
+
+@skill_entry
+def main(**kwargs):
+    return validate_scene_for_farm(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/validate_scene_for_farm.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/validate_scene_for_farm.py
@@ -26,6 +26,9 @@ def validate_scene_for_farm() -> dict:
 
     try:
         import bpy  # noqa: PLC0415
+        from dcc_mcp_core import check_dcc_cancelled  # noqa: PLC0415
+
+        check_dcc_cancelled()
 
         issues = []  # type: List[str]
 
@@ -42,7 +45,7 @@ def validate_scene_for_farm() -> dict:
         # 3. Render frame range
         start = scene.frame_start
         end = scene.frame_end
-        if end <= start:
+        if end < start:
             issues.append("Render frame range invalid: frame_start={} frame_end={}".format(start, end))
 
         # 4. Output path
@@ -53,6 +56,7 @@ def validate_scene_for_farm() -> dict:
         # 5. Missing external files
         if hasattr(bpy.data, "images"):
             for img in bpy.data.images:
+                check_dcc_cancelled()
                 if img.filepath and not img.packed_file:
                     abs_path = img.filepath_from_user()
                     if abs_path and not os.path.isfile(abs_path):
@@ -61,6 +65,7 @@ def validate_scene_for_farm() -> dict:
         # 6. Missing linked libraries
         if hasattr(bpy.data, "libraries"):
             for lib in bpy.data.libraries:
+                check_dcc_cancelled()
                 if lib.filepath and not os.path.isfile(lib.filepath):
                     issues.append("Missing library: '{}' (name: {})".format(lib.filepath, lib.name))
 

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/write_render_job.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/write_render_job.py
@@ -41,6 +41,9 @@ def write_render_job(
 
     try:
         import bpy  # noqa: PLC0415
+        from dcc_mcp_core import check_dcc_cancelled  # noqa: PLC0415
+
+        check_dcc_cancelled()
 
         scene_path = bpy.data.filepath or ""
         scene_stem = os.path.splitext(os.path.basename(scene_path))[0] or "untitled"

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/write_render_job.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/write_render_job.py
@@ -1,0 +1,122 @@
+"""Write a JSON render job specification for a render farm dispatcher."""
+
+# Import future modules
+from __future__ import annotations
+
+# Import built-in modules
+import json
+import os
+from typing import Optional
+
+# Import local modules
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def write_render_job(
+    output_dir: str,
+    job_name: Optional[str] = None,
+    renderer: Optional[str] = None,
+    start_frame: Optional[int] = None,
+    end_frame: Optional[int] = None,
+    step: int = 1,
+    chunk_size: int = 10,
+    priority: int = 50,
+) -> dict:
+    """Write a render job JSON spec from the current scene settings.
+
+    Args:
+        output_dir: Directory where the ``.json`` job file is written.
+        job_name: Job display name.  Defaults to the scene file stem.
+        renderer: Override render engine name (e.g. ``"CYCLES"``, ``"BLENDER_EEVEE"``).
+            Defaults to the scene's active render engine.
+        start_frame: Override start frame.  Defaults to scene render frame_start.
+        end_frame: Override end frame.  Defaults to scene render frame_end.
+        step: Frame step / increment.  Default: 1.
+        chunk_size: Frames per render task.  Default: 10.
+        priority: Job priority (0=low, 100=high).  Default: 50.
+
+    Returns:
+        ToolResult dict with ``context.job_file`` path and job spec summary.
+    """
+
+    try:
+        import bpy  # noqa: PLC0415
+
+        scene_path = bpy.data.filepath or ""
+        scene_stem = os.path.splitext(os.path.basename(scene_path))[0] or "untitled"
+
+        name = job_name or scene_stem
+
+        scene = bpy.context.scene
+        render = scene.render
+
+        sf = start_frame if start_frame is not None else scene.frame_start
+        ef = end_frame if end_frame is not None else scene.frame_end
+
+        active_renderer = renderer
+        if not active_renderer:
+            active_renderer = render.engine
+
+        render_output = render.filepath or ""
+
+        # Collect extra render settings for the job spec
+        cycles_samples = None
+        eevee_samples = None
+        if active_renderer == "CYCLES" and hasattr(scene, "cycles"):
+            cycles_samples = scene.cycles.samples
+        elif "EEVEE" in active_renderer and hasattr(scene, "eevee"):
+            eevee_samples = scene.eevee.taa_render_samples
+
+        job_spec = {
+            "name": name,
+            "scene_file": scene_path,
+            "renderer": active_renderer,
+            "start_frame": sf,
+            "end_frame": ef,
+            "step": step,
+            "chunk_size": chunk_size,
+            "priority": priority,
+            "output_dir": render_output,
+            "resolution_x": render.resolution_x,
+            "resolution_y": render.resolution_y,
+            "resolution_percentage": render.resolution_percentage,
+            "file_format": render.image_settings.file_format,
+        }
+        if cycles_samples is not None:
+            job_spec["samples"] = cycles_samples
+        if eevee_samples is not None:
+            job_spec["samples"] = eevee_samples
+
+        os.makedirs(output_dir, exist_ok=True)
+        job_file = os.path.join(output_dir, "{}.json".format(name))
+        with open(job_file, "w") as fh:
+            json.dump(job_spec, fh, indent=2)
+
+        frame_count = max(0, (ef - sf) // step + 1)
+        task_count = max(1, (frame_count + chunk_size - 1) // chunk_size)
+
+        return skill_success(
+            "Wrote render job spec '{}' to '{}'".format(name, job_file),
+            prompt="Use submit_render_job to send this job to the render farm.",
+            job_file=job_file,
+            name=name,
+            renderer=active_renderer,
+            frame_range="{}-{}".format(sf, ef),
+            frame_count=frame_count,
+            task_count=task_count,
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to write render job")
+
+
+@skill_entry
+def main(**kwargs):
+    return write_render_job(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-render-farm/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/tools.yaml
@@ -1,0 +1,68 @@
+tools:
+  - name: validate_scene_for_farm
+    description: "Validate the current Blender scene for render farm readiness"
+    source_file: scripts/validate_scene_for_farm.py
+    execution: sync
+    affinity: main
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: write_render_job
+    description: "Write a JSON render job spec from the current scene settings for a render farm"
+    source_file: scripts/write_render_job.py
+    execution: sync
+    affinity: main
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: submit_render_job
+    description: "Submit the current scene to a render farm (Flamenco, Deadline, or generic)"
+    source_file: scripts/submit_render_job.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 900
+    read_only: false
+    destructive: false
+    idempotent: false
+  - name: get_render_job_status
+    description: "Query the status of a submitted render job by job ID"
+    source_file: scripts/get_render_job_status.py
+    execution: sync
+    affinity: any
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: list_render_jobs
+    description: "List recent render jobs from the farm manager"
+    source_file: scripts/list_render_jobs.py
+    execution: sync
+    affinity: any
+    read_only: true
+    destructive: false
+    idempotent: true
+  - name: cancel_render_job
+    description: "Cancel a specific render job on the render farm"
+    source_file: scripts/cancel_render_job.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 300
+    read_only: false
+    destructive: true
+    idempotent: false
+  - name: cooperative_cancel
+    description: "Cooperatively cancel the currently running farm operation"
+    source_file: scripts/cooperative_cancel.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 60
+    read_only: false
+    destructive: true
+    idempotent: true
+  - name: render_farm_status
+    description: "Report the connected render farm health and worker status"
+    source_file: scripts/render_farm_status.py
+    execution: sync
+    affinity: any
+    read_only: true
+    destructive: false
+    idempotent: true

--- a/tests/test_skills_render_farm.py
+++ b/tests/test_skills_render_farm.py
@@ -1,0 +1,550 @@
+"""Unit tests for blender-render-farm skill scripts.
+
+Covers behavioral contracts that structural/lint tests cannot catch:
+- Flamenco v3 API endpoint correctness and HTTP verbs
+- Single-frame validation acceptance
+- Priority passthrough in submission
+- Cooperative cancel checkpoints
+"""
+
+from __future__ import annotations
+
+import json
+import types
+import urllib.error
+import urllib.request
+from unittest.mock import MagicMock, patch
+
+from tests.conftest import _LOAD_COUNTER, SKILLS_ROOT, load_and_call, make_mock_bpy
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_urllib_patch(urllib_request_mock: MagicMock) -> dict:
+    """Build a sys.modules patch dict for scripts that ``import urllib.request``.
+
+    Scripts do ``import urllib.request`` which requires ``urllib`` to be a
+    real module/proxy whose ``request`` attribute resolves to our mock.
+    """
+
+    class _UrllibProxy(types.ModuleType):
+        request = urllib_request_mock
+        error = urllib.error
+
+    _UrllibProxy.__name__ = "urllib"
+    return {
+        "urllib": _UrllibProxy("urllib"),
+        "urllib.request": urllib_request_mock,
+        "urllib.error": urllib.error,
+    }
+
+
+def _load_with_urllib_mock(
+    rel_path: str,
+    urllib_request_mock: MagicMock,
+    dcc_mcp_core_mock: MagicMock | None = None,
+    bpy_mock: MagicMock | None = None,
+    **kwargs,
+):
+    """Load a skill script with urllib.request and optionally dcc_mcp_core mocked.
+
+    Args:
+        rel_path: Script path relative to ``skills/``.
+        urllib_request_mock: MagicMock replacing ``urllib.request``.
+        dcc_mcp_core_mock: If given, replaces ``dcc_mcp_core`` in sys.modules
+            so that ``from dcc_mcp_core import ...`` resolves to this mock.
+        bpy_mock: If given, uses this as ``bpy`` instead of auto-creating one.
+        **kwargs: Keyword arguments forwarded to ``main()``.
+    """
+    _LOAD_COUNTER[0] += 1
+    fpath = SKILLS_ROOT / rel_path
+    mod_name = f"skill_rf_{fpath.stem}_{_LOAD_COUNTER[0]}"
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(mod_name, str(fpath))
+    mod = importlib.util.module_from_spec(spec)
+    patches = _make_urllib_patch(urllib_request_mock)
+    patches.update(
+        {
+            "bpy": bpy_mock or make_mock_bpy(),
+            "mathutils": MagicMock(),
+        }
+    )
+    if dcc_mcp_core_mock is not None:
+        patches["dcc_mcp_core"] = dcc_mcp_core_mock
+    with patch.dict("sys.modules", patches):
+        spec.loader.exec_module(mod)
+        return mod.main(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Flamenco API endpoint correctness
+# ---------------------------------------------------------------------------
+
+
+class TestFlamencoEndpoints:
+    """Verify that the right Flamenco v3 API URLs and HTTP verbs are used."""
+
+    def test_render_farm_status_hits_status_and_workers_endpoints(self):
+        """GET /api/v3/status and GET /api/v3/worker-mgt/workers (not /workers)."""
+        urllib_mock = MagicMock()
+        # Simulate successful responses
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = b'{"version":"3.5","name":"Flamenco Manager"}'
+        resp_mock.__enter__.return_value = resp_mock
+        urllib_mock.Request.return_value = MagicMock()
+        urllib_mock.urlopen.return_value = resp_mock
+
+        result = _load_with_urllib_mock(
+            "blender-render-farm/scripts/render_farm_status.py",
+            urllib_mock,
+        )
+
+        assert result["success"] is True
+        # Collect all Request calls and their args
+        requests = urllib_mock.Request.call_args_list
+        urls = [c[0][0] if c[0] else "" for c in requests]
+
+        # Must hit /api/v3/status (not /api/v3/workers)
+        assert any("/api/v3/status" in u for u in urls), "Expected GET /api/v3/status but got: {}".format(urls)
+        # Must hit /api/v3/worker-mgt/workers
+        assert any("/api/v3/worker-mgt/workers" in u for u in urls), (
+            "Expected GET /api/v3/worker-mgt/workers but got: {}".format(urls)
+        )
+        # Must NOT hit the old /api/v3/workers (without worker-mgt prefix)
+        assert not any(
+            "/api/v3/workers" == u.rstrip("/").split("?")[0].rsplit("/", 1)[-1] and "worker-mgt" not in u for u in urls
+        ), "Must not call deprecated /api/v3/workers, use /api/v3/worker-mgt/workers. Got: {}".format(urls)
+        # Must NOT hit the old /api/v3/jobs/queue
+        assert not any("/api/v3/jobs/queue" in u for u in urls), (
+            "Must not call deprecated /api/v3/jobs/queue. Got: {}".format(urls)
+        )
+
+    def test_cancel_render_job_hits_setstatus_endpoint(self):
+        """POST /api/v3/jobs/{job_id}/setstatus (not /status)."""
+        urllib_mock = MagicMock()
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = b'{"id":"job-123"}'
+        resp_mock.__enter__.return_value = resp_mock
+        urllib_mock.Request.return_value = MagicMock()
+        urllib_mock.urlopen.return_value = resp_mock
+
+        result = _load_with_urllib_mock(
+            "blender-render-farm/scripts/cancel_render_job.py",
+            urllib_mock,
+            job_id="job-abc",
+            farm="flamenco",
+        )
+
+        assert result["success"] is True
+        # Check that the Request URL includes /setstatus
+        req_call = urllib_mock.Request.call_args
+        url = req_call[0][0] if req_call[0] else ""
+        assert "/api/v3/jobs/job-abc/setstatus" in url, (
+            "Expected POST /api/v3/jobs/job-abc/setstatus but got: {}".format(url)
+        )
+        assert "/status" not in url.split("/setstatus")[0] if "/setstatus" in url else True, (
+            "Must not call deprecated /api/v3/jobs/.../status. Got: {}".format(url)
+        )
+
+    def test_cancel_render_job_sends_correct_method(self):
+        """The setstatus call must use POST with cancel-requested body."""
+        urllib_mock = MagicMock()
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = b'{"id":"job-xyz"}'
+        resp_mock.__enter__.return_value = resp_mock
+        urllib_mock.Request.return_value = MagicMock()
+        urllib_mock.urlopen.return_value = resp_mock
+
+        _load_with_urllib_mock(
+            "blender-render-farm/scripts/cancel_render_job.py",
+            urllib_mock,
+            job_id="job-xyz",
+            farm="flamenco",
+        )
+
+        # Verify POST method
+        req_call = urllib_mock.Request.call_args
+        kwargs = req_call[1] if len(req_call) > 1 else {}
+        method = kwargs.get("method", "GET")
+        assert method == "POST", "Cancel must use POST, got: {}".format(method)
+
+        # Verify payload includes cancel-requested
+        data = kwargs.get("data")
+        if data is not None:
+            body = json.loads(data.decode("utf-8") if isinstance(data, bytes) else data)
+            assert body.get("status") == "cancel-requested", "Expected cancel-requested status, got: {}".format(body)
+
+
+# ---------------------------------------------------------------------------
+# Single-frame validation
+# ---------------------------------------------------------------------------
+
+
+class TestSingleFrameValidation:
+    """validate_scene_for_farm must accept single-frame renders."""
+
+    def test_single_frame_is_valid(self):
+        """Frame start == end (single frame) should NOT produce an issue."""
+        bpy = make_mock_bpy()
+        bpy.data.filepath = "/tmp/scene.blend"
+        bpy.context.scene.camera = MagicMock()
+        bpy.context.scene.frame_start = 47
+        bpy.context.scene.frame_end = 47
+        bpy.context.scene.render.filepath = "/tmp/output/"
+        bpy.data.images = []
+        bpy.data.libraries = []
+
+        result = load_and_call("blender-render-farm/scripts/validate_scene_for_farm.py", bpy)
+
+        assert result["success"] is True
+        assert result["context"]["valid"] is True, "Single-frame render (47-47) should be valid, got issues: {}".format(
+            result["context"].get("issues", [])
+        )
+        assert len(result["context"]["issues"]) == 0
+
+    def test_multi_frame_is_valid(self):
+        """Frame start < end should still be valid."""
+        bpy = make_mock_bpy()
+        bpy.data.filepath = "/tmp/scene.blend"
+        bpy.context.scene.camera = MagicMock()
+        bpy.context.scene.frame_start = 1
+        bpy.context.scene.frame_end = 250
+        bpy.context.scene.render.filepath = "/tmp/output/"
+        bpy.data.images = []
+        bpy.data.libraries = []
+
+        result = load_and_call("blender-render-farm/scripts/validate_scene_for_farm.py", bpy)
+
+        assert result["success"] is True
+        assert result["context"]["valid"] is True
+
+    def test_end_before_start_is_invalid(self):
+        """Frame end < start should still be flagged as invalid."""
+        bpy = make_mock_bpy()
+        bpy.data.filepath = "/tmp/scene.blend"
+        bpy.context.scene.camera = MagicMock()
+        bpy.context.scene.frame_start = 250
+        bpy.context.scene.frame_end = 1
+        bpy.context.scene.render.filepath = "/tmp/output/"
+        bpy.data.images = []
+        bpy.data.libraries = []
+
+        result = load_and_call("blender-render-farm/scripts/validate_scene_for_farm.py", bpy)
+
+        assert result["context"]["valid"] is False
+        assert any("frame range invalid" in i.lower() for i in result["context"]["issues"])
+
+
+# ---------------------------------------------------------------------------
+# Priority passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestPriorityPassthrough:
+    """submit_render_job must pass priority through to Flamenco, not hardcode."""
+
+    def test_flamenco_submit_respects_priority_parameter(self):
+        """The priority kwarg should appear in the Flamenco job payload."""
+        bpy = make_mock_bpy()
+        bpy.data.filepath = "/tmp/scene.blend"
+        bpy.context.scene.frame_start = 1
+        bpy.context.scene.frame_end = 100
+        bpy.context.scene.render.filepath = "/tmp/output/"
+        bpy.context.scene.render.engine = "CYCLES"
+
+        urllib_mock = MagicMock()
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = b'{"id":"flam-job-99"}'
+        resp_mock.__enter__.return_value = resp_mock
+        urllib_mock.Request.return_value = MagicMock()
+        urllib_mock.urlopen.return_value = resp_mock
+
+        # Submit with a non-default priority
+        result = _load_with_urllib_mock(
+            "blender-render-farm/scripts/submit_render_job.py",
+            urllib_mock,
+            bpy_mock=bpy,
+            farm="flamenco",
+            priority=77,
+        )
+
+        assert result["success"] is True
+
+        # Extract the payload sent to Flamenco
+        req_call = urllib_mock.Request.call_args
+        kwargs = req_call[1] if len(req_call) > 1 else {}
+        data = kwargs.get("data")
+        assert data is not None, "Expected Request with data payload"
+        body = json.loads(data.decode("utf-8") if isinstance(data, bytes) else data)
+
+        assert body.get("priority") == 77, "Expected priority=77 in payload, got priority={}".format(
+            body.get("priority")
+        )
+        assert body["priority"] != 50, "Priority must not be hardcoded to 50; should use the passed kwarg"
+
+    def test_flamenco_submit_includes_add_path_components(self):
+        """The Flamenco payload must include add_path_components setting."""
+        bpy = make_mock_bpy()
+        bpy.data.filepath = "/tmp/scene.blend"
+        bpy.context.scene.frame_start = 1
+        bpy.context.scene.frame_end = 10
+        bpy.context.scene.render.filepath = "/tmp/output/"
+        bpy.context.scene.render.engine = "CYCLES"
+
+        urllib_mock = MagicMock()
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = b'{"id":"flam-job-add"}'
+        resp_mock.__enter__.return_value = resp_mock
+        urllib_mock.Request.return_value = MagicMock()
+        urllib_mock.urlopen.return_value = resp_mock
+
+        _load_with_urllib_mock(
+            "blender-render-farm/scripts/submit_render_job.py",
+            urllib_mock,
+            bpy_mock=bpy,
+            farm="flamenco",
+        )
+
+        req_call = urllib_mock.Request.call_args
+        kwargs = req_call[1] if len(req_call) > 1 else {}
+        data = kwargs.get("data")
+        body = json.loads(data.decode("utf-8") if isinstance(data, bytes) else data)
+
+        settings = body.get("settings", {})
+        assert "add_path_components" in settings, "Flamenco Simple Blender Render requires add_path_components setting"
+        assert settings["add_path_components"] is True
+
+    def test_flamenco_payload_includes_required_settings(self):
+        """Verify all Flamenco Simple Blender Render required settings."""
+        bpy = make_mock_bpy()
+        bpy.data.filepath = "/tmp/scene.blend"
+        bpy.context.scene.frame_start = 1
+        bpy.context.scene.frame_end = 24
+        bpy.context.scene.render.filepath = "/tmp/output/"
+        bpy.context.scene.render.engine = "BLENDER_EEVEE"
+
+        urllib_mock = MagicMock()
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = b'{"id":"flam-job-req"}'
+        resp_mock.__enter__.return_value = resp_mock
+        urllib_mock.Request.return_value = MagicMock()
+        urllib_mock.urlopen.return_value = resp_mock
+
+        _load_with_urllib_mock(
+            "blender-render-farm/scripts/submit_render_job.py",
+            urllib_mock,
+            bpy_mock=bpy,
+            farm="flamenco",
+            chunk_size=5,
+        )
+
+        req_call = urllib_mock.Request.call_args
+        kwargs = req_call[1] if len(req_call) > 1 else {}
+        data = kwargs.get("data")
+        body = json.loads(data.decode("utf-8") if isinstance(data, bytes) else data)
+
+        assert body.get("type") == "blender-render"
+        settings = body["settings"]
+        assert settings.get("blender_cmd") == "blender"
+        assert settings.get("filepath") == "/tmp/scene.blend"
+        assert settings.get("frames") == "1-24"
+        assert settings.get("chunk_size") == 5
+        assert settings.get("render_engine") == "BLENDER_EEVEE"
+        assert settings.get("render_output") == "/tmp/output/"
+        assert settings.get("add_path_components") is True
+
+
+# ---------------------------------------------------------------------------
+# Cooperative cancel checkpoints
+# ---------------------------------------------------------------------------
+
+
+def _make_dcc_mcp_core_mock(check_cancelled: MagicMock | None = None) -> MagicMock:
+    """Build a dcc_mcp_core mock with real skill helpers and a mock checkpoint.
+
+    Scripts import ``from dcc_mcp_core.skill import ...`` and
+    ``from dcc_mcp_core import check_dcc_cancelled``.  We wire up the real
+    skill module but replace the cancellation entry-point.
+    """
+    import dcc_mcp_core.skill as real_skill  # noqa: PLC0415
+
+    mock = MagicMock()
+    mock.check_dcc_cancelled = check_cancelled or MagicMock()
+    mock.skill = real_skill
+    # Forward common attributes that scripts may import at module level
+    mock.skill_entry = real_skill.skill_entry
+    mock.skill_error = real_skill.skill_error
+    mock.skill_success = real_skill.skill_success
+    mock.skill_exception = real_skill.skill_exception
+    return mock
+
+
+class TestCooperativeCancelCheckpoint:
+    """Scripts must call check_dcc_cancelled() at appropriate checkpoints."""
+
+    def test_validate_scene_calls_check_dcc_cancelled(self):
+        """validate_scene_for_farm should call check_dcc_cancelled()."""
+        bpy = make_mock_bpy()
+        bpy.data.filepath = "/tmp/scene.blend"
+        bpy.context.scene.camera = MagicMock()
+        bpy.context.scene.frame_start = 1
+        bpy.context.scene.frame_end = 250
+        bpy.context.scene.render.filepath = "/tmp/output/"
+        bpy.data.images = []
+        bpy.data.libraries = []
+
+        mock_check = MagicMock()
+        dcc_mock = _make_dcc_mcp_core_mock(mock_check)
+
+        _LOAD_COUNTER[0] += 1
+        fpath = SKILLS_ROOT / "blender-render-farm/scripts/validate_scene_for_farm.py"
+        mod_name = f"skill_rf_v_{_LOAD_COUNTER[0]}"
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(mod_name, str(fpath))
+        mod = importlib.util.module_from_spec(spec)
+        with patch.dict(
+            "sys.modules",
+            {
+                "bpy": bpy,
+                "mathutils": MagicMock(),
+                "dcc_mcp_core": dcc_mock,
+            },
+        ):
+            spec.loader.exec_module(mod)
+            result = mod.main()
+
+        assert result["success"] is True
+        assert mock_check.call_count >= 1, (
+            "validate_scene_for_farm must call check_dcc_cancelled() at checkpoints, got {} calls".format(
+                mock_check.call_count
+            )
+        )
+
+    def test_submit_flamenco_calls_check_dcc_cancelled(self):
+        """submit_render_job Flamenco path should call check_dcc_cancelled()."""
+        bpy = make_mock_bpy()
+        bpy.data.filepath = "/tmp/scene.blend"
+        bpy.context.scene.frame_start = 1
+        bpy.context.scene.frame_end = 10
+        bpy.context.scene.render.filepath = "/tmp/output/"
+        bpy.context.scene.render.engine = "CYCLES"
+
+        urllib_mock = MagicMock()
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = b'{"id":"job-ck"}'
+        resp_mock.__enter__.return_value = resp_mock
+        urllib_mock.Request.return_value = MagicMock()
+        urllib_mock.urlopen.return_value = resp_mock
+
+        mock_check = MagicMock()
+        dcc_mock = _make_dcc_mcp_core_mock(mock_check)
+
+        result = _load_with_urllib_mock(
+            "blender-render-farm/scripts/submit_render_job.py",
+            urllib_mock,
+            bpy_mock=bpy,
+            dcc_mcp_core_mock=dcc_mock,
+            farm="flamenco",
+        )
+
+        assert result["success"] is True
+        assert mock_check.call_count >= 1, "submit_render_job Flamenco path must call check_dcc_cancelled()"
+
+    def test_get_render_job_status_calls_check_dcc_cancelled(self):
+        """get_render_job_status Flamenco path should call check_dcc_cancelled()."""
+        urllib_mock = MagicMock()
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = (
+            b'{"id":"job-1","status":"completed","task_summary":{"completed":10,"total":10,"failed":0},"name":"Test"}'
+        )
+        resp_mock.__enter__.return_value = resp_mock
+        urllib_mock.Request.return_value = MagicMock()
+        urllib_mock.urlopen.return_value = resp_mock
+
+        mock_check = MagicMock()
+        dcc_mock = _make_dcc_mcp_core_mock(mock_check)
+
+        result = _load_with_urllib_mock(
+            "blender-render-farm/scripts/get_render_job_status.py",
+            urllib_mock,
+            dcc_mcp_core_mock=dcc_mock,
+            job_id="job-1",
+            farm="flamenco",
+        )
+
+        assert result["success"] is True
+        assert mock_check.call_count >= 1, "get_render_job_status must call check_dcc_cancelled()"
+
+    def test_list_render_jobs_calls_check_dcc_cancelled(self):
+        """list_render_jobs Flamenco path should call check_dcc_cancelled()."""
+        urllib_mock = MagicMock()
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = b'{"jobs":[{"id":"job-1","name":"Test"}]}'
+        resp_mock.__enter__.return_value = resp_mock
+        urllib_mock.Request.return_value = MagicMock()
+        urllib_mock.urlopen.return_value = resp_mock
+
+        mock_check = MagicMock()
+        dcc_mock = _make_dcc_mcp_core_mock(mock_check)
+
+        result = _load_with_urllib_mock(
+            "blender-render-farm/scripts/list_render_jobs.py",
+            urllib_mock,
+            dcc_mcp_core_mock=dcc_mock,
+            farm="flamenco",
+        )
+
+        assert result["success"] is True
+        assert mock_check.call_count >= 1, "list_render_jobs must call check_dcc_cancelled()"
+
+    def test_cancel_render_job_calls_check_dcc_cancelled(self):
+        """cancel_render_job Flamenco path should call check_dcc_cancelled()."""
+        urllib_mock = MagicMock()
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = b'{"id":"job-c"}'
+        resp_mock.__enter__.return_value = resp_mock
+        urllib_mock.Request.return_value = MagicMock()
+        urllib_mock.urlopen.return_value = resp_mock
+
+        mock_check = MagicMock()
+        dcc_mock = _make_dcc_mcp_core_mock(mock_check)
+
+        result = _load_with_urllib_mock(
+            "blender-render-farm/scripts/cancel_render_job.py",
+            urllib_mock,
+            dcc_mcp_core_mock=dcc_mock,
+            job_id="job-c",
+            farm="flamenco",
+        )
+
+        assert result["success"] is True
+        assert mock_check.call_count >= 1, "cancel_render_job Flamenco path must call check_dcc_cancelled()"
+
+    def test_render_farm_status_calls_check_dcc_cancelled(self):
+        """render_farm_status Flamenco path should call check_dcc_cancelled()."""
+        urllib_mock = MagicMock()
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = b'{"version":"3.5","name":"Manager"}'
+        resp_mock.__enter__.return_value = resp_mock
+        urllib_mock.Request.return_value = MagicMock()
+        urllib_mock.urlopen.return_value = resp_mock
+
+        mock_check = MagicMock()
+        dcc_mock = _make_dcc_mcp_core_mock(mock_check)
+
+        result = _load_with_urllib_mock(
+            "blender-render-farm/scripts/render_farm_status.py",
+            urllib_mock,
+            dcc_mcp_core_mock=dcc_mock,
+        )
+
+        assert result["success"] is True
+        assert mock_check.call_count >= 1, (
+            "render_farm_status Flamenco path must call check_dcc_cancelled(). Got {} calls".format(
+                mock_check.call_count
+            )
+        )

--- a/tests/test_skills_render_farm.py
+++ b/tests/test_skills_render_farm.py
@@ -721,3 +721,36 @@ class TestDeadlineCancelCheckpoint:
                 mock_check.call_count
             )
         )
+
+
+# ---------------------------------------------------------------------------
+# Generic cooperative cancel checkpoint
+# ---------------------------------------------------------------------------
+
+
+class TestGenericCancelCheckpoint:
+    """Generic path in submit_render_job must also call check_dcc_cancelled()."""
+
+    def test_submit_generic_calls_check_dcc_cancelled(self):
+        """submit_render_job Generic path should call check_dcc_cancelled()."""
+        mock_check = MagicMock()
+        dcc_mock = _make_dcc_mcp_core_mock(mock_check)
+
+        bpy = make_mock_bpy()
+        bpy.data.filepath = "/tmp/scene.blend"
+        bpy.context.scene.frame_start = 1
+        bpy.context.scene.frame_end = 100
+        bpy.context.scene.render.filepath = "/tmp/output/"
+        bpy.context.scene.render.engine = "CYCLES"
+
+        result = _load_deadline_script(
+            "blender-render-farm/scripts/submit_render_job.py",
+            dcc_mock,
+            bpy_mock=bpy,
+            farm="generic",
+        )
+
+        assert result["success"] is True
+        assert mock_check.call_count >= 1, (
+            "submit_render_job Generic path must call check_dcc_cancelled(), got {} calls".format(mock_check.call_count)
+        )

--- a/tests/test_skills_render_farm.py
+++ b/tests/test_skills_render_farm.py
@@ -548,3 +548,176 @@ class TestCooperativeCancelCheckpoint:
                 mock_check.call_count
             )
         )
+
+
+# ---------------------------------------------------------------------------
+# Deadline cooperative cancel checkpoints
+# ---------------------------------------------------------------------------
+
+
+def _load_deadline_script(
+    rel_path: str,
+    dcc_mock: MagicMock,
+    bpy_mock: MagicMock | None = None,
+    subprocess_mock: MagicMock | None = None,
+    **kwargs,
+):
+    """Load a farm script with Deadline path mocked (subprocess + dcc_mcp_core)."""
+    _LOAD_COUNTER[0] += 1
+    fpath = SKILLS_ROOT / rel_path
+    mod_name = f"skill_rf_dl_{fpath.stem}_{_LOAD_COUNTER[0]}"
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(mod_name, str(fpath))
+    mod = importlib.util.module_from_spec(spec)
+    patches = {"dcc_mcp_core": dcc_mock}
+    if bpy_mock is not None:
+        patches["bpy"] = bpy_mock
+        patches["mathutils"] = MagicMock()
+    if subprocess_mock is not None:
+        patches["subprocess"] = subprocess_mock
+    with patch.dict("sys.modules", patches):
+        spec.loader.exec_module(mod)
+        return mod.main(**kwargs)
+
+
+class TestDeadlineCancelCheckpoint:
+    """Deadline paths must call check_dcc_cancelled() before subprocess calls."""
+
+    def test_cancel_deadline_job_calls_check_dcc_cancelled(self):
+        """cancel_render_job Deadline path should call check_dcc_cancelled()."""
+        mock_check = MagicMock()
+        dcc_mock = _make_dcc_mcp_core_mock(mock_check)
+
+        subp_mock = MagicMock()
+        proc_mock = MagicMock()
+        proc_mock.returncode = 0
+        proc_mock.stdout = ""
+        proc_mock.stderr = ""
+        subp_mock.run.return_value = proc_mock
+
+        result = _load_deadline_script(
+            "blender-render-farm/scripts/cancel_render_job.py",
+            dcc_mock,
+            subprocess_mock=subp_mock,
+            job_id="deadline-job-1",
+            farm="deadline",
+        )
+
+        assert result["success"] is True
+        assert mock_check.call_count >= 1, (
+            "cancel_render_job Deadline path must call check_dcc_cancelled(), got {} calls".format(
+                mock_check.call_count
+            )
+        )
+
+    def test_get_render_job_status_deadline_calls_check_dcc_cancelled(self):
+        """get_render_job_status Deadline path should call check_dcc_cancelled()."""
+        mock_check = MagicMock()
+        dcc_mock = _make_dcc_mcp_core_mock(mock_check)
+
+        subp_mock = MagicMock()
+        proc_mock = MagicMock()
+        proc_mock.returncode = 0
+        proc_mock.stdout = "Status=Completed\n"
+        proc_mock.stderr = ""
+        subp_mock.run.return_value = proc_mock
+
+        result = _load_deadline_script(
+            "blender-render-farm/scripts/get_render_job_status.py",
+            dcc_mock,
+            subprocess_mock=subp_mock,
+            job_id="deadline-job-1",
+            farm="deadline",
+        )
+
+        assert result["success"] is True
+        assert mock_check.call_count >= 1, (
+            "get_render_job_status Deadline path must call check_dcc_cancelled(), got {} calls".format(
+                mock_check.call_count
+            )
+        )
+
+    def test_list_render_jobs_deadline_calls_check_dcc_cancelled(self):
+        """list_render_jobs Deadline path should call check_dcc_cancelled()."""
+        mock_check = MagicMock()
+        dcc_mock = _make_dcc_mcp_core_mock(mock_check)
+
+        subp_mock = MagicMock()
+        proc_mock = MagicMock()
+        proc_mock.returncode = 0
+        proc_mock.stdout = "JobID=job-1\nStatus=Active\n"
+        proc_mock.stderr = ""
+        subp_mock.run.return_value = proc_mock
+
+        result = _load_deadline_script(
+            "blender-render-farm/scripts/list_render_jobs.py",
+            dcc_mock,
+            subprocess_mock=subp_mock,
+            farm="deadline",
+        )
+
+        assert result["success"] is True
+        assert mock_check.call_count >= 1, (
+            "list_render_jobs Deadline path must call check_dcc_cancelled(), got {} calls".format(mock_check.call_count)
+        )
+
+    def test_render_farm_status_deadline_calls_check_dcc_cancelled(self):
+        """render_farm_status Deadline path should call check_dcc_cancelled()."""
+        mock_check = MagicMock()
+        dcc_mock = _make_dcc_mcp_core_mock(mock_check)
+
+        subp_mock = MagicMock()
+        proc_mock = MagicMock()
+        proc_mock.returncode = 0
+        proc_mock.stdout = "worker-1\nworker-2\n"
+        proc_mock.stderr = ""
+        subp_mock.run.return_value = proc_mock
+
+        result = _load_deadline_script(
+            "blender-render-farm/scripts/render_farm_status.py",
+            dcc_mock,
+            subprocess_mock=subp_mock,
+            farm="deadline",
+        )
+
+        assert result["success"] is True
+        assert mock_check.call_count >= 1, (
+            "render_farm_status Deadline path must call check_dcc_cancelled(), got {} calls".format(
+                mock_check.call_count
+            )
+        )
+
+    def test_submit_deadline_calls_check_dcc_cancelled(self):
+        """submit_render_job Deadline path should call check_dcc_cancelled()."""
+        mock_check = MagicMock()
+        dcc_mock = _make_dcc_mcp_core_mock(mock_check)
+
+        subp_mock = MagicMock()
+        proc_mock = MagicMock()
+        proc_mock.returncode = 0
+        proc_mock.stdout = "JobID=dl-123\n"
+        proc_mock.stderr = ""
+        subp_mock.run.return_value = proc_mock
+
+        bpy = make_mock_bpy()
+        bpy.data.filepath = "/tmp/scene.blend"
+        bpy.context.scene.frame_start = 1
+        bpy.context.scene.frame_end = 100
+        bpy.context.scene.render.filepath = "/tmp/output/"
+        bpy.context.scene.render.engine = "CYCLES"
+
+        result = _load_deadline_script(
+            "blender-render-farm/scripts/submit_render_job.py",
+            dcc_mock,
+            bpy_mock=bpy,
+            subprocess_mock=subp_mock,
+            farm="deadline",
+        )
+
+        assert result["success"] is True
+        assert mock_check.call_count >= 1, (
+            "submit_render_job Deadline path must call check_dcc_cancelled(), got {} calls".format(
+                mock_check.call_count
+            )
+        )

--- a/tests/test_skills_structure.py
+++ b/tests/test_skills_structure.py
@@ -14,6 +14,7 @@ EXPECTED_SKILLS = [
     "blender-mesh",
     "blender-materials",
     "blender-render",
+    "blender-render-farm",
     "blender-scripting",
     "blender-animation",
     "blender-lighting",


### PR DESCRIPTION
## Summary

Add a new pipeline-stage skill that enables distributed render farm submission for Blender through multiple backends.

### New Skill: `blender-render-farm`

**Backends supported:**
- **Deadline** — via `deadlinecommand` CLI (Thinkbox Deadline render farm)
- **Flamenco** — via REST API (Blender's native render farm manager)
- **Generic** — JSON job spec for custom dispatchers

**Tools (8 total):**
| Tool | Description |
|------|-------------|
| `validate_scene_for_farm` | Check scene for render farm readiness (saved, camera, frame range, output, missing files) |
| `write_render_job` | Write a portable JSON render job spec from scene settings |
| `submit_render_job` | Submit to Deadline, Flamenco, or generic farm |
| `get_render_job_status` | Query job status by job ID |
| `list_render_jobs` | List recent jobs from the farm manager |
| `cancel_render_job` | Cancel a specific render job |
| `cooperative_cancel` | Abort a locally running farm operation |
| `render_farm_status` | Report farm health and worker availability |

### Structure
Follows the same layout as `maya-render-farm` and existing Blender skills:
- `SKILL.md` with YAML frontmatter metadata
- `tools.yaml` with execution mode, affinity, and safety flags
- `groups.yaml` for tool grouping
- `metadata/depends.md` declaring `blender-render` dependency
- 8 Python scripts in `scripts/`

### Related Files Updated
- `SKILLS_INDEX.md` — added `blender-render-farm` to stage map and task chains
- `tests/test_skills_structure.py` — added to expected skills list

### Verification
- `ruff check` — all clear
- `ruff format` — all 8 files formatted
- `pytest tests/test_lint_skills.py` — 3 passed
- `pytest tests/test_skills_structure.py` — 6 passed