### PR TITLE
fix(ci): remove github.token fallback from release-please token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: googleapis/release-please-action@v5
         id: release
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Problem

release-please uses `secrets.PERSONAL_ACCESS_TOKEN || github.token` as the token. When `PERSONAL_ACCESS_TOKEN` is not configured, it falls back to `GITHUB_TOKEN`. GitHub Actions suppresses CI workflow triggers for pushes made with `GITHUB_TOKEN` to prevent recursive chains, so release-please PRs and branches never get CI checks.

This causes:
- `dcc-mcp-blender#75` - mergeStateStatus=BLOCKED (required checks never run)
- No CI on `release-please--branches--*` pushes

## Fix

Remove `|| github.token` fallback so release-please fails explicitly when PAT is missing, rather than silently breaking CI.

## ⚠️ Blocker

**`PERSONAL_ACCESS_TOKEN` secret must be configured in this repo before merging.** This repo currently has no repo-level secrets. The PAT should be the same one used in dcc-mcp-core and dcc-mcp-maya (loonghao's PAT).

Ref: dcc-mcp-core release.yml uses `secrets.PERSONAL_ACCESS_TOKEN` without fallback.