### PR TITLE
fix: add custom release-please updater for bl_info version tuple

### DIFF
--- a/.release-please/update-blender-addon-version.cjs
+++ b/.release-please/update-blender-addon-version.cjs
@@ -1,0 +1,16 @@
+class BlenderAddonVersionUpdater {
+  updateContent(content, version) {
+    const [major, minor, patch] = version.split('.');
+    content = content.replace(
+      /(__addon_version__\s*=\s*")\d+\.\d+\.\d+(")/,
+      `$1${version}$2`,
+    );
+    content = content.replace(
+      /("version":\s*\()\d+,\s*\d+,\s*\d+(\))/,
+      `$1${major}, ${minor}, ${patch}$2`,
+    );
+    return content;
+  }
+}
+
+module.exports = BlenderAddonVersionUpdater;

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -27,7 +27,8 @@
         },
         {
           "type": "generic",
-          "path": "packaging/addon_entry/__init__.py"
+          "path": "packaging/addon_entry/__init__.py",
+          "updater": ".release-please/update-blender-addon-version.cjs"
         }
       ]
     }


### PR DESCRIPTION
## Summary

release-please generic updater only handles dotted X.Y.Z version strings, not Python tuple format used in bl_info. This causes every release-please PR to fail the bl_info version test because the tuple is never updated.

## Changes

- **`.release-please/update-blender-addon-version.cjs`** (new) — custom release-please updater that updates both `__addon_version__` string and `bl_info["version"]` tuple in `packaging/addon_entry/__init__.py`
- **`release-please-config.json`** — reference the custom updater for the addon entry file

## Verification

- Custom updater correctly transforms both version formats (string "0.1.8" and tuple (0, 1, 8) to "0.1.9" and (0, 1, 9))
- All 3 tests in `tests/test_addon_packaging.py` pass
