### PR TITLE
fix: sync bl_info version to 0.1.6 in addon entry and tests

### DIFF
--- a/packaging/addon_entry/__init__.py
+++ b/packaging/addon_entry/__init__.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 bl_info = {
     "name": "DCC MCP Blender",
     "author": "Long Hao",
-    "version": (0, 1, 5),
+    "version": (0, 1, 6),
     "blender": (4, 2, 0),
     "location": "Top Bar > DCC MCP",
     "description": "Embeds an MCP HTTP server inside Blender for AI-driven 3D workflows",

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -32,7 +32,7 @@ def test_addon_entry_bl_info_version_is_static_tuple_literal():
     )
 
     assert isinstance(version_node, ast.Tuple)
-    assert ast.literal_eval(version_node) == (0, 1, 5)
+    assert ast.literal_eval(version_node) == (0, 1, 6)
 
 
 def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monkeypatch):
@@ -56,7 +56,7 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     assert "host.py" in names
     assert "skills/blender-scene/SKILL.md" in names
     assert not any(name.startswith("dcc_mcp_blender/") for name in names)
-    assert '"version": (0, 1, 5)' in addon_init
+    assert '"version": (0, 1, 6)' in addon_init
     assert "./wheels/dcc_mcp_core-0.17.47-cp38-abi3-win_amd64.whl" in manifest
     assert manifest.index("wheels = [") < manifest.index("[permissions]")
 


### PR DESCRIPTION
## Summary
The release-please commit `b9598bf` bumped pyproject.toml to 0.1.6 but missed updating `packaging/addon_entry/__init__.py` `bl_info.version` and the test assertions.

Since `assemble_zip.py` dynamically patches the version from `pyproject.toml` into the staged `__init__.py`, the ZIP always contains `(0, 1, 6)`, causing `test_assembled_addon_zip_uses_flat_importable_package_layout` to fail with: `assert '"version": (0, 1, 5)' in addon_init`.

This fix updates:
- `packaging/addon_entry/__init__.py`: `bl_info["version"]` from `(0, 1, 5)` → `(0, 1, 6)`
- `tests/test_addon_packaging.py`: both assertions synced to `(0, 1, 6)`