### PR TITLE
chore(deps): bump dcc-mcp-core to >=0.18.9

### DIFF
--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -44,7 +44,7 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.18.7"
+MIN_CORE_VERSION = "0.18.9"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ classifiers = [
 ]
 
 dependencies = [
-    # v0.18.7: marketplace icon + schema validation, gateway discovery optimizations,
-    # call_examples in model descriptions, SSE notification budget increase.
-    "dcc-mcp-core>=0.18.7,<1.0.0",
+    # v0.18.9: marketplace extracted as shared crate, gateway election disabled for
+    # probe server, ADR-010 dual-protocol migration docs.
+    "dcc-mcp-core>=0.18.9,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -51,10 +51,10 @@ def test_addon_entry_bl_info_version_is_static_tuple_literal():
 def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monkeypatch):
     """The add-on package root must directly contain ``server.py`` and skills."""
     assemble_zip = _load_assemble_zip_module()
-    fake_wheel = tmp_path / "dcc_mcp_core-0.18.7-cp38-abi3-win_amd64.whl"
+    fake_wheel = tmp_path / "dcc_mcp_core-0.18.9-cp38-abi3-win_amd64.whl"
     fake_wheel.write_bytes(b"fake wheel")
 
-    monkeypatch.setattr(assemble_zip, "resolve_core_version", lambda min_version="0.18.7": "0.18.7")
+    monkeypatch.setattr(assemble_zip, "resolve_core_version", lambda min_version="0.18.9": "0.18.9")
     monkeypatch.setattr(assemble_zip, "download_core_wheel", lambda version, platform, dest_dir: fake_wheel)
 
     zip_path = assemble_zip.assemble(platform="win64", output_dir=tmp_path)
@@ -80,7 +80,7 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     )
     assert isinstance(addon_version_node, ast.Tuple)
     assert ast.literal_eval(addon_version_node) == _parse_version_tuple(_get_addon_version())
-    assert "./wheels/dcc_mcp_core-0.18.7-cp38-abi3-win_amd64.whl" in manifest
+    assert "./wheels/dcc_mcp_core-0.18.9-cp38-abi3-win_amd64.whl" in manifest
     assert manifest.index("wheels = [") < manifest.index("[permissions]")
 
 

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -17,10 +17,10 @@ def _load_assemble_zip_module():
     return mod
 
 
-def test_core_dependency_floor_is_0187():
+def test_core_dependency_floor_is_0189():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert '"dcc-mcp-core>=0.18.7,<1.0.0"' in pyproject
+    assert '"dcc-mcp-core>=0.18.9,<1.0.0"' in pyproject
 
 
 def test_packaging_core_floor_matches_pyproject():


### PR DESCRIPTION
## Summary
- Bump `dcc-mcp-core` dependency from `>=0.18.7,<1.0.0` to `>=0.18.9,<1.0.0`
- Release Train v0.18.0..v0.18.9: marketplace shared crate, gateway election disabled for probe server, ADR-010 dual-protocol migration docs

## Related
- Core release: https://github.com/dcc-mcp/dcc-mcp-core/releases/tag/v0.18.9