### PR TITLE
fix: reorder imports in test_agent_instruction_files.py for Ruff I001

### DIFF
--- a/tests/test_agent_instruction_files.py
+++ b/tests/test_agent_instruction_files.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import subprocess
-
+from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 AGENT_ENTRYPOINTS = (
@@ -53,9 +52,6 @@ def test_multica_runtime_artifacts_are_not_tracked() -> None:
     offenders = [
         path
         for path in tracked
-        if any(
-            path == prefix.rstrip("/") or path.startswith(prefix)
-            for prefix in FORBIDDEN_TRACKED_PREFIXES
-        )
+        if any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in FORBIDDEN_TRACKED_PREFIXES)
     ]
     assert offenders == []


### PR DESCRIPTION
## Summary

Fix Ruff I001 lint failure on Renovate PRs #14 and #11.

The `from pathlib import Path` import was placed before `import subprocess`,
violating stdlib import ordering (Ruff I001).  The issue existed in main
but went undetected until a newer Ruff version was installed during CI on
Renovate's refreshed branches.

## Changes

- Swap `from pathlib import Path` and `import subprocess` to correct order
- Collapse multiline `any()` inside comprehension (automatic ruff format)

## After this merges

Renovate PRs #14 and #11 will need to rebase onto main to pick up the fix
and pass the Lint check.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean