### PR TITLE
fix(ci): pre-install mcporter globally to avoid intermittent npx exit 127 on Windows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -262,6 +262,12 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Install mcporter globally
+        # Pre-install mcporter to avoid intermittent npx PATH/cache resolution
+        # failures on Windows runners (exit code 127).
+        shell: bash
+        run: npm install -g mcporter
+
       - name: Test MCP connectivity and progressive loading
         # Blender 4.2.0 on Windows: Blender's bundled libuv triggers
         # UV_HANDLE_CLOSING assertion failure in the MCP HTTP server;
@@ -304,14 +310,14 @@ jobs:
           "
 
           # ── 2. List all registered tools via mcporter ───────────────────────
-          npx --yes mcporter list \
+          mcporter list \
             --http-url http://127.0.0.1:8765/mcp \
             --name blender-ci \
             --allow-http
 
           call_tool() {
             set +e
-            output=$(npx mcporter call \
+            output=$(mcporter call \
               --http-url http://127.0.0.1:8765/mcp \
               --allow-http \
               "$@" 2>&1)


### PR DESCRIPTION
## Problem

E2E (Blender) Windows CI jobs intermittently fail with exit code 127 in the "Test MCP connectivity and progressive loading" step. The MCP server starts and responds correctly to all tool calls — the exit 127 occurs after all tests pass.

## Root Cause

The `call_tool()` function uses `npx mcporter call` without the `--yes` flag. When npm cache resolution fails intermittently on Windows 2025 runners, `npx` returns exit code 127 (command not found), which propagates through `call_tool`'s return value and causes the CI step to fail due to `set -e`.

Evidence from two failing runs:
- **#27132511573** (4.2.0 windows): all MCP calls succeed, libuv assertion fires, then exit 127 from subsequent npx call within 5 seconds
- **#27135401653** (4.4.3 windows): same pattern — MCP server responds correctly, npx resolution fails after assertion

## Fix

Three changes in `.github/workflows/e2e.yml`:

1. **Add global mcporter install step** after setup-node: `npm install -g mcporter`
2. **Replace `npx --yes mcporter list`** → `mcporter list`  
3. **Replace `npx mcporter call`** → `mcporter call` in `call_tool()`

By pre-installing mcporter globally, we bypass npx resolution entirely and use the binary directly.

## Testing

- The fix eliminates the npx PATH/cache resolution step entirely
- No functional change to the test — mcporter is the same binary
- The libuv assertion (UV_HANDLE_CLOSING) is a known Blender runtime issue that does not affect test correctness