### PR TITLE
chore: bump dcc-mcp-core to >=0.18.34

### DIFF
--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -44,7 +44,7 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.18.14"
+MIN_CORE_VERSION = "0.18.34"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,8 @@ classifiers = [
 ]
 
 dependencies = [
-    # v0.18.14: DccServerBase split into 4 seam controllers (PIP-688),
-    # shared registration phase pipeline (PIP-689), gateway discovery fixes.
-    "dcc-mcp-core>=0.18.14,<1.0.0",
+    # v0.18.34: bump dcc-mcp-core minimum version.
+    "dcc-mcp-core>=0.18.34,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -17,10 +17,10 @@ def _load_assemble_zip_module():
     return mod
 
 
-def test_core_dependency_floor_is_01814():
+def test_core_dependency_floor_is_01834():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert '"dcc-mcp-core>=0.18.14,<1.0.0"' in pyproject
+    assert '"dcc-mcp-core>=0.18.34,<1.0.0"' in pyproject
 
 
 def test_packaging_core_floor_matches_pyproject():


### PR DESCRIPTION
Bump dcc-mcp-core minimum version from >=0.18.14 to >=0.18.34. No breaking changes. Part of PIP-1820.