### PR TITLE
fix: package Blender addon in installable directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,23 +132,23 @@ jobs:
           assert zips, f"expected dist_addon/dcc_mcp_blender_addon_{platform}_v*.zip"
           with zipfile.ZipFile(zips[-1]) as zf:
               names = zf.namelist()
-          wheels = [n for n in names if n.startswith("wheels/") and n.endswith(".whl")]
+          prefix = "dcc_mcp_blender/"
+          wheels = [n for n in names if n.startswith(prefix + "wheels/") and n.endswith(".whl")]
           assert wheels, f"expected bundled .whl under wheels/, sample: {names[:30]}"
           assert not any(
-              n.startswith("dcc_mcp_core/") for n in names
+              n.startswith(prefix + "dcc_mcp_core/") for n in names
           ), "unexpected extracted dcc_mcp_core tree — use manifest wheels instead"
-          assert "__init__.py" in names, names[:25]
-          assert "server.py" in names, names[:25]
-          assert "host.py" in names, names[:25]
-          assert "blender_manifest.toml" in names, names[:25]
-          nested = [n for n in names if n.startswith("dcc_mcp_blender/")]
-          assert not nested, f"unexpected nested adapter package paths: {nested[:5]}"
-          skill_md = [n for n in names if n.startswith("skills/") and n.endswith("/SKILL.md")]
+          assert "__init__.py" not in names, names[:25]
+          assert prefix + "__init__.py" in names, names[:25]
+          assert prefix + "server.py" in names, names[:25]
+          assert prefix + "host.py" in names, names[:25]
+          assert prefix + "blender_manifest.toml" in names, names[:25]
+          skill_md = [n for n in names if n.startswith(prefix + "skills/") and n.endswith("/SKILL.md")]
           assert len(skill_md) >= 13, f"expected >=13 SKILL.md under skills/, got {len(skill_md)}"
-          tools_yaml = [n for n in names if n.startswith("skills/") and n.endswith("/tools.yaml")]
+          tools_yaml = [n for n in names if n.startswith(prefix + "skills/") and n.endswith("/tools.yaml")]
           assert len(tools_yaml) >= 13, f"expected >=13 tools.yaml under skills/, got {len(tools_yaml)}"
           with zipfile.ZipFile(zips[-1]) as zf:
-              raw = zf.read("blender_manifest.toml").decode("utf-8")
+              raw = zf.read(prefix + "blender_manifest.toml").decode("utf-8")
           assert "wheels = [" in raw and "./wheels/" in raw, raw[:400]
           assert raw.index("wheels = [") < raw.index("[permissions]"), raw
           PY

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -285,13 +285,13 @@ def assemble(platform: str, output_dir: pathlib.Path) -> pathlib.Path:
         _stage_addon_entry(addon_dir, version=version)
         _inject_wheels_into_manifest(addon_dir / "blender_manifest.toml", [wheel.name])
 
-        # 4) Zip the extension package contents at archive root. Blender's
-        # extension installer expects ``blender_manifest.toml`` at ZIP root.
+        # 4) Zip the add-on as a top-level package directory. Blender's legacy
+        # add-on installer rejects ZIPs with ``__init__.py`` directly at root.
         print(f"Creating {zip_name}...")
         with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
             for file in addon_dir.rglob("*"):
                 if file.is_file() and "__pycache__" not in str(file):
-                    arcname = file.relative_to(addon_dir)
+                    arcname = file.relative_to(tmp_dir)
                     zf.write(file, arcname)
 
     print(f"Created: {zip_path}")

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -48,8 +48,8 @@ def test_addon_entry_bl_info_version_is_static_tuple_literal():
     assert ast.literal_eval(version_node) == _parse_version_tuple(_get_addon_version())
 
 
-def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monkeypatch):
-    """The add-on package root must directly contain ``server.py`` and skills."""
+def test_assembled_addon_zip_uses_installable_package_directory_layout(tmp_path, monkeypatch):
+    """The ZIP root must contain the add-on package directory, not raw package files."""
     assemble_zip = _load_assemble_zip_module()
     fake_wheel = tmp_path / "dcc_mcp_core-0.18.9-cp38-abi3-win_amd64.whl"
     fake_wheel.write_bytes(b"fake wheel")
@@ -61,14 +61,14 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
 
     with zipfile.ZipFile(zip_path) as zf:
         names = set(zf.namelist())
-        addon_init = zf.read("__init__.py").decode("utf-8")
-        manifest = zf.read("blender_manifest.toml").decode("utf-8")
+        addon_init = zf.read("dcc_mcp_blender/__init__.py").decode("utf-8")
+        manifest = zf.read("dcc_mcp_blender/blender_manifest.toml").decode("utf-8")
 
-    assert "__init__.py" in names
-    assert "server.py" in names
-    assert "host.py" in names
-    assert "skills/blender-scene/SKILL.md" in names
-    assert not any(name.startswith("dcc_mcp_blender/") for name in names)
+    assert "__init__.py" not in names
+    assert "dcc_mcp_blender/__init__.py" in names
+    assert "dcc_mcp_blender/server.py" in names
+    assert "dcc_mcp_blender/host.py" in names
+    assert "dcc_mcp_blender/skills/blender-scene/SKILL.md" in names
     addon_tree = ast.parse(addon_init)
     addon_bl_info = next(
         node for node in addon_tree.body if isinstance(node, ast.Assign) and node.targets[0].id == "bl_info"


### PR DESCRIPTION
Packages the Blender addon ZIP with a top-level dcc_mcp_blender directory so Blender's legacy addon installer accepts the release artifact.\n\nValidation:\n- uv run pytest tests/test_addon_packaging.py -q