### PR TITLE
docs: fix architecture diagram — SSE Streaming -> Streamable HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 │  dcc-mcp-core                   │
 │  ├─ McpHttpServer               │
 │  ├─ JSON-RPC 2.0                │
-│  └─ SSE Streaming               │
+│  └─ Streamable HTTP             │
 └─────────────────────────────────┘
          ↓ http://127.0.0.1:8765/mcp
 ┌─────────────────────────────────┐


### PR DESCRIPTION
The README architecture diagram still referenced "SSE Streaming" in the
dcc-mcp-core block, but the protocol was migrated to Streamable HTTP
(MCP 2025-03-26). This brings the diagram in line with the text
description (line 3 and line 55) which already correctly say
"Streamable HTTP".