### PR TITLE
docs: add AGENTS.md, CLAUDE.md, GEMINI.md, and llms.txt for AI agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+# AGENTS.md — dcc-mcp-blender Agent Navigation Map
+
+> Progressive disclosure: this file is a **map**, not an encyclopedia.
+> Follow the links for depth. Stay here for breadth.
+
+---
+
+## 30-Second Summary
+
+`dcc-mcp-blender` embeds a standards-compliant MCP Streamable HTTP server directly inside Blender. It exposes 200+ Blender operations as MCP tools that any AI agent (Claude, Gemini, Cursor, etc.) can call over HTTP — no external gateway, no subprocess bridge.
+
+**Current version:** 0.1.20 <!-- x-release-please-version -->
+**Core dependency:** `dcc-mcp-core>=0.18.34,<1.0.0`
+**Python:** 3.10+ (bundled with Blender)
+**Blender:** 3.6 LTS, 4.2 LTS, 4.3, 4.4
+
+---
+
+## Quick Start (3 Lines)
+
+```python
+import dcc_mcp_blender
+handle = dcc_mcp_blender.start_server(port=8765)
+# MCP client connects to http://127.0.0.1:8765/mcp
+```
+
+Or install the Blender extension (ZIP) and the server starts automatically.
+
+---
+
+## Information Layers — Pick Your Depth
+
+### Layer 1 — You Are a User / Operator
+*Goal: Install, configure, and connect an MCP host.*
+
+- **README.md** — Installation, quick start, environment variables, bundled tools list.
+- **install.md** — Agent-facing setup entry: install pip dependencies, guide Blender add-on loading, and run a first smoke prompt.
+- **skills/dcc-mcp-blender-setup/SKILL.md** — Setup skill reference, one-command install script.
+- **src/dcc_mcp_blender/skills/SKILLS_INDEX.md** — Staged loading guidance, task-to-skill chains, side-effect profiles for all bundled skills.
+
+### Layer 2 — You Are a Skill Author
+*Goal: Write new Blender automation skills and register them as MCP tools.*
+
+- **src/dcc_mcp_blender/api.py** — `@with_main_thread` decorator, `blender_success` / `blender_error` helpers, context snapshot wrappers.
+- **src/dcc_mcp_blender/capabilities.py** — Capability manifest builder; each skill registers its action list so agents can discover tools without loading the full catalog.
+- **src/dcc_mcp_blender/_scene_ops.py**, **src/dcc_mcp_blender/_mesh_ops.py**, etc. — Reference implementations for each domain skill.
+- **pyproject.toml** — `[project.entry-points."dcc_mcp.adapters"]` declares `blender = "dcc_mcp_blender:BlenderMcpServer"`.
+
+Create a new skill package under `src/dcc_mcp_blender/skills/<your-skill>/` with:
+1. `SKILL.md` — metadata, dependencies, tools yaml path
+2. `tools.yaml` — tool definitions (name, description, inputSchema)
+3. `scripts/*.py` — implementation scripts (one file per tool or group)
+
+### Layer 3 — You Are a Core Developer
+*Goal: Understand the server lifecycle, dispatcher architecture, and integration points.*
+
+- **src/dcc_mcp_blender/server.py** — `BlenderMcpServer`, builtin action registration, metrics, jobs
+- **src/dcc_mcp_blender/dispatcher/** — `BlenderUiDispatcher` (GUI mode) and `BlenderHost` (headless) dispatcher implementations
+- **src/dcc_mcp_blender/host.py** — Host adapter that abstracts Blender's main thread from MCP request threads
+- **src/dcc_mcp_blender/blender_bootstrap.py** — Headless CI/automation bootstrap entry point
+- **src/dcc_mcp_blender/context_snapshot.py** — Scene context provider (selection, frame, scene name, version)
+- **src/dcc_mcp_blender/_readiness.py** — Three-state readiness probe (process, dispatcher, dcc)
+
+---
+
+## Key Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DCC_MCP_BLENDER_SEMANTIC_INDEX` | `0` | Enable hybrid BM25 + vector skill search (opt-in) |
+| `DCC_MCP_BLENDER_METRICS` | `false` | Enable Prometheus `/metrics` |
+| `DCC_MCP_BLENDER_DISABLE_EXECUTE_PYTHON` | `false` | Restrict arbitrary Python execution |
+| `DCC_MCP_BLENDER_SKILL_PATHS` | — | Additional skill search paths |
+| `DCC_MCP_BLENDER_PROJECT_TOOLS` | — | Set to `0` to opt out of project tools |
+| `DCC_MCP_BLENDER_RESOURCES` | — | Set to `0` to opt out of MCP resource publishing |
+
+See **README.md** for the full env var table.
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/dcc_mcp_blender/server.py` | `BlenderMcpServer`, builtin skill discovery, metrics, jobs |
+| `src/dcc_mcp_blender/dispatcher/__init__.py` | Thread-affinity dispatchers for GUI and headless modes |
+| `src/dcc_mcp_blender/host.py` | Host adapter (abstracts Blender main thread) |
+| `src/dcc_mcp_blender/api.py` | Skill authoring helpers |
+| `src/dcc_mcp_blender/context_snapshot.py` | Scene / selection / frame context provider |
+| `src/dcc_mcp_blender/skills/` | 25+ built-in skill packages (200+ typed MCP tools) |
+| `src/dcc_mcp_blender/skills/SKILLS_INDEX.md` | Staged loading guide and task-to-skill maps |
+| `README.md` | Human overview |
+| `llms.txt` | One-page core reference for AI agents |
+
+---
+
+## See Also
+
+- [README.md](README.md) — Installation, features, all env vars
+- [CLAUDE.md](CLAUDE.md) — Claude Desktop-specific integration
+- [GEMINI.md](GEMINI.md) — Gemini-specific integration
+- [llms.txt](llms.txt) — One-page core reference for AI agents
+- [install.md](install.md) — Agent-facing setup workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md — Claude Desktop / Anthropic API Integration Guide
+
+> Claude-specific integration notes for `dcc-mcp-blender`.
+> For the full project map, see [AGENTS.md](AGENTS.md).
+
+---
+
+## What This Project Does
+
+`dcc-mcp-blender` embeds an MCP Streamable HTTP server directly inside Blender. Claude Desktop (or any Anthropic API client using MCP) can call 200+ Blender tools over HTTP without any external gateway process.
+
+---
+
+## Claude Desktop Configuration
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "blender": {
+      "url": "http://127.0.0.1:8765/mcp"
+    }
+  }
+}
+```
+
+**File locations:**
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Restart Claude Desktop after editing.
+
+---
+
+## Progressive Loading — Important for Claude
+
+By default, `dcc-mcp-blender` starts with a minimal set of built-in tools active:
+- `execute_python`, `execute_script_file`, `get_blender_info`
+- `get_scene_info`, `get_session_info`, `list_objects`
+- `search_tools`, `list_skills`, `load_skill`
+
+**All other skills appear as `__skill__<name>` stubs.** When Claude needs a tool from an unloaded skill, it should:
+
+1. Call `load_skill("blender-animation")` to expand the skill.
+2. Then call the desired tool (e.g., `blender_animation__set_keyframe`).
+
+This keeps the initial `tools/list` small and fast for Claude to parse.
+
+---
+
+## Claude-Specific Tips
+
+- **Viewport feedback:** Ask Claude to call `capture_viewport` after geometry changes. The result is a base64-encoded PNG that Claude can "see" in the conversation.
+- **Cancellation:** Claude can send `notifications/cancelled` for long renders. Skill scripts that poll `check_blender_cancelled()` will exit cleanly.
+- **Code execution:** Prefer `search_skills` → `load_skill` → typed tools with `inputSchema`. Use `execute_python` only when no skill covers the task (bulk in-Blender loops, bpy API gaps, one-offs). Operators can refuse it with `DCC_MCP_BLENDER_DISABLE_EXECUTE_PYTHON=1` or `DCC_MCP_BLENDER_DISABLE_ARBITRARY_SCRIPT=1`.
+
+---
+
+## Quick Test Prompts
+
+> "Create a red sphere in Blender"
+> "List all cameras in the scene and set the active camera to Camera.001"
+> "Capture the viewport so I can see the current state"
+> "Load the blender-animation skill and set a keyframe on the sphere's location Z at frame 10"
+
+---
+
+## See Also
+
+- [AGENTS.md](AGENTS.md) — Shared agent navigation map; keep common guidance single-sourced there
+- [llms.txt](llms.txt) — One-page core reference
+- [README.md](README.md) — Human-facing installation and overview

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,78 @@
+# GEMINI.md — Google Gemini / Vertex AI Integration Guide
+
+> Gemini-specific integration notes for `dcc-mcp-blender`.
+> For the full project map, see [AGENTS.md](AGENTS.md).
+
+---
+
+## What This Project Does
+
+`dcc-mcp-blender` embeds an MCP Streamable HTTP server directly inside Blender. Gemini (via an MCP-compatible client or custom integration) can discover and invoke 200+ Blender tools over HTTP.
+
+---
+
+## Gemini-Specific Strengths
+
+Gemini excels at **code generation** and **structured output parsing**. Leverage these when working with `dcc-mcp-blender`:
+
+### 1. Skill Script Generation
+Ask Gemini to generate new Blender skill scripts using the `dcc_mcp_blender.api` helpers:
+
+```python
+from dcc_mcp_blender.api import blender_success, blender_error
+
+def batch_rename(prefix: str) -> dict:
+    """Rename selected objects with prefix."""
+    import bpy
+    selected = bpy.context.selected_objects or []
+    renamed = []
+    for obj in selected:
+        obj.name = f"{prefix}{obj.name}"
+        renamed.append(obj.name)
+    return blender_success("Renamed objects", renamed=renamed, count=len(renamed))
+```
+
+### 2. Structured Tool Results
+Gemini handles nested JSON well. Parse `blender_success` / `blender_error` results directly:
+
+```json
+{
+  "success": true,
+  "message": "Created sphere",
+  "context": {
+    "object_name": "Sphere",
+    "radius": 1.0
+  }
+}
+```
+
+### 3. Skill Search & Discovery
+Use Gemini's search capability with the built-in discovery tools:
+- `search_skills("render batch")` → returns matching skills with descriptions
+- `search_tools(query="bake", tags=["texture"])` → filtered search
+
+---
+
+## Integration Setup
+
+If your Gemini client supports MCP over HTTP, configure:
+
+```
+Endpoint: http://127.0.0.1:8765/mcp
+Protocol: MCP Streamable HTTP (2025-03-26 spec)
+```
+
+---
+
+## Gemini-Specific Tips
+
+- **Code-first workflows:** Gemini can write complete skill packages. Generate `SKILL.md`, `tools.yaml`, and `scripts/*.py` in one shot, then place them in a directory listed in `DCC_MCP_BLENDER_SKILL_PATHS`.
+- **Image understanding:** Feed `capture_viewport` base64 PNGs back to Gemini for visual state verification.
+
+---
+
+## See Also
+
+- [AGENTS.md](AGENTS.md) — Shared agent navigation map; keep common guidance single-sourced there
+- [llms.txt](llms.txt) — One-page core reference
+- [README.md](README.md) — Human-facing installation and overview

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,152 @@
+# llms.txt — dcc-mcp-blender Core Reference for AI Agents
+
+> One-page cheat sheet.
+
+---
+
+## Project
+
+**dcc-mcp-blender** — Embed a standards-compliant MCP Streamable HTTP server directly inside Blender.
+**Version:** 0.1.20 <!-- x-release-please-version -->
+**License:** MIT
+**Repo:** https://github.com/dcc-mcp/dcc-mcp-blender
+**Python:** >=3.10 (bundled with Blender)
+**Blender:** 3.6 LTS, 4.2 LTS, 4.3, 4.4
+**Core dep:** `dcc-mcp-core>=0.18.34,<1.0.0`
+
+---
+
+## Quick Start
+
+```python
+import dcc_mcp_blender
+handle = dcc_mcp_blender.start_server(port=8765)
+# MCP host → http://127.0.0.1:8765/mcp
+handle.shutdown()
+```
+
+Headless bootstrap:
+```bash
+blender --background --python src/dcc_mcp_blender/blender_bootstrap.py
+```
+
+---
+
+## Core API
+
+### Module-Level Functions
+
+```python
+start_server(
+    port: int = 8765,
+    server_name: str = "blender-mcp",
+    register_builtins: bool = True,
+    extra_skill_paths: Optional[List[str]] = None,
+    include_bundled: bool = True,
+    enable_gateway_failover: bool = True,
+) -> McpServerHandle
+
+stop_server() -> None
+```
+
+### BlenderMcpServer Constructor
+
+```python
+BlenderMcpServer(
+    port: int = 8765,
+    server_name: str = "blender-mcp",
+    server_version: str = "0.1.20",  # x-release-please-version
+    enable_gateway_failover: bool = True,
+    metrics_enabled: Optional[bool] = None,     # env: DCC_MCP_BLENDER_METRICS=1
+    job_storage_path: Optional[str] = None,     # env: DCC_MCP_BLENDER_JOB_STORAGE
+)
+```
+
+Key methods: `register_builtin_actions()`, `start()`, `stop()`, `build_capability_manifest(loaded_only=False)`.
+
+---
+
+## Skill Discovery & Loading
+
+Agent workflow (skills-first — **default**):
+1. `search_skills` / `search_tools` — find the domain skill.
+2. `load_skill("blender-animation")` — activate tools with `inputSchema` + annotations.
+3. Call the concrete tool (e.g. `blender_animation__set_keyframe`).
+
+Reserve `blender_scripting__execute_python` for **escape hatches** (no skill yet, bulk in-Blender loops, bpy-only API). Operators can block arbitrary execution with `DCC_MCP_BLENDER_DISABLE_EXECUTE_PYTHON=1` or `DCC_MCP_BLENDER_DISABLE_ARBITRARY_SCRIPT=1`.
+
+Tool naming: `{skill_name.replace("-","_")}__{script_stem}` (e.g. `blender_scene__new_scene`).
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/dcc_mcp_blender/server.py` | `BlenderMcpServer`, builtin skill discovery, metrics, jobs |
+| `src/dcc_mcp_blender/dispatcher/` | Thread-affinity dispatchers + cancellation |
+| `src/dcc_mcp_blender/api.py` | Skill authoring helpers (`blender_success`, `blender_error`, `with_main_thread`) |
+| `src/dcc_mcp_blender/host.py` | Host adapter (GUI vs headless mode) |
+| `src/dcc_mcp_blender/context_snapshot.py` | Scene context provider |
+| `src/dcc_mcp_blender/skills/` | 25+ built-in skill packages (200+ typed MCP tools) |
+| `src/dcc_mcp_blender/skills/SKILLS_INDEX.md` | Staged loading guide and task-to-skill chains |
+| `README.md` | Human overview |
+| `AGENTS.md` | Progressive disclosure map |
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DCC_MCP_BLENDER_PORT` | `8765` | TCP port |
+| `DCC_MCP_BLENDER_SERVER_NAME` | `blender-mcp` | MCP init name |
+| `DCC_MCP_BLENDER_SKILL_PATHS` | — | Blender skill search roots |
+| `DCC_MCP_SKILL_PATHS` | — | Global fallback skill search roots |
+| `DCC_MCP_BLENDER_SEMANTIC_INDEX` | `0` | `1`=hybrid BM25+vector skill search |
+| `DCC_MCP_BLENDER_SEMANTIC_EMBEDDER` | `hashed` | `onnx` for dense embeddings |
+| `DCC_MCP_BLENDER_METRICS` | `false` | `true`=Prometheus `/metrics` |
+| `DCC_MCP_BLENDER_JOB_STORAGE` | *(auto)* | Render-job SQLite persistence dir |
+| `DCC_MCP_BLENDER_READINESS_TIMEOUT_SECS` | — | Advisory timeout for readiness probe |
+| `DCC_MCP_BLENDER_DISABLE_EXECUTE_PYTHON` | `false` | `1`/`true`/`yes`/`on` — refuse `execute_python` |
+| `DCC_MCP_BLENDER_DISABLE_ARBITRARY_SCRIPT` | `false` | Same tokens — refuse all arbitrary script execution |
+| `DCC_MCP_BLENDER_PROJECT_TOOLS` | — | `0` to opt out of project tools |
+| `DCC_MCP_BLENDER_RESOURCES` | — | `0` to opt out of MCP resource publishing |
+| `DCC_MCP_BLENDER_STRICT_SKILL_SCAN` | `false` | Raise on invalid skill YAML |
+| `DCC_MCP_BLENDER_ENABLE_WORKFLOWS` | `true` | Enable workflow orchestration surface |
+| `DCC_MCP_BLENDER_ENABLE_GATEWAY_FAILOVER` | `true` | Enable gateway failover |
+
+---
+
+## Available Tool Categories
+
+| Skill Package | Key Tools |
+|---------------|-----------|
+| blender-scene | `new_scene`, `open_scene`, `save_scene`, `list_objects`, `get_scene_info` |
+| blender-objects | `create_object`, `delete_object`, `move/rotate/scale`, `get_selection`, `set_selection` |
+| blender-mesh / blender-mesh-ops | `add_modifier`, `apply_modifier`, `triangulate_mesh`, `combine_meshes`, `merge_vertices` |
+| blender-uv-ops | `create_uv_map`, `unwrap_uvs`, `pack_uvs`, `project_uvs` |
+| blender-rigging | `create_armature`, `create_bone`, `add_constraint`, `bind_mesh_to_armature`, `retarget_animation` |
+| blender-pose-library | `list_poses`, `save_pose`, `load_pose` |
+| blender-interchange | `import_fbx/obj/usd`, `export_gltf/usd/alembic`, `batch_export` |
+| blender-materials / blender-shader-nodes | `create_material`, `create_node`, `connect_nodes`, `set_principled_input` |
+| blender-material-library | `save/load/delete_material_preset`, `assign_texture`, `list_images` |
+| blender-texture-bake | `bake_textures`, `bake_ambient_occlusion`, `transfer_maps` |
+| blender-render | `render_scene`, `set_render_settings`, `capture_viewport` |
+| blender-render-farm | `submit_render_job`, `get_render_job_status`, `cancel_render_job` |
+| blender-animation | `set_keyframe`, `set_frame_range`, `bake_animation` |
+| blender-lighting / blender-light-rig | `create_light`, `create_three_point_light_rig`, `create_hdri_world` |
+| blender-camera | `create_camera`, `set_active_camera`, `set_camera_properties` |
+| blender-physics | `add_rigid_body`, `add_cloth_modifier`, `add_force_field`, `bake_simulation` |
+| blender-geometry-nodes | `create_geometry_node_group`, `set_geometry_node_modifier_input` |
+| blender-scripting | `execute_python`, `execute_script_file`, `get_blender_info` |
+| blender-dev | `reload_modules`, `capture_ui_snapshot`, `start_debug_server`, `get_python_environment` |
+| blender-validation | `run_scene_checks`, `validate_mesh/materials/animation`, `get_validation_report` |
+| blender-pipeline | `get/tag/clear_asset_metadata`, `set_project_context`, `create_publish_manifest` |
+| blender-shot-export | `get_shot_info`, `export_camera` |
+| blender-export-preset | `list/save/load/delete_export_preset` |
+| blender-collection | `create_collection`, `link_to_collection`, `list_collections` |
+| blender-node-graph | `list_all_node_graphs`, `list_compositor_nodes`, `get_compositor_node_tree` |
+| blender-import-to-scene | `import_to_scene` |
+
+See `src/dcc_mcp_blender/skills/SKILLS_INDEX.md` for staged loading guidance, task-to-skill chains, and side-effect profiles.


### PR DESCRIPTION
## Summary

Add standard AI agent documentation files to align `dcc-mcp-blender` with the other DCC-MCP repositories (maya, 3dsmax, houdini, core).

### Files added

- **AGENTS.md** — progressive-disclosure navigation map for AI agents, covering installation, skill authoring, and core development layers with key file references and environment variables
- **CLAUDE.md** — Claude Desktop integration guide with configuration snippets, progressive loading explanation, viewport feedback tips, and quick test prompts
- **GEMINI.md** — Gemini/Vertex AI integration guide highlighting code generation and structured output parsing strengths
- **llms.txt** — one-page core reference summarizing project metadata, Quick Start, Core API, skill discovery workflow, environment variables table, and the full tool category inventory

### Motivation

Every other DCC-MCP host adapter (maya, 3dsmax, houdini) provides these files. Adding them makes the blender repo discoverable and usable by AI agents out of the box, with no manual documentation lookup needed.

### Context

All content was derived from the existing `README.md`, `pyproject.toml`, and source tree of `dcc-mcp-blender` v0.1.20.