### PR TITLE
fix(host): wire real main-thread dispatcher and manage its lifecycle

### DIFF
--- a/src/dcc_mcp_blender/dispatcher/standalone.py
+++ b/src/dcc_mcp_blender/dispatcher/standalone.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 import uuid
 from typing import Any, Callable, Dict, Optional
 
-from dcc_mcp_core import InProcessCallableDispatcher, JobOutcome
+from dcc_mcp_core import JobOutcome
+from dcc_mcp_core.host import BlockingDispatcher
 
 
 class BlenderStandaloneDispatcher:
@@ -18,37 +19,31 @@ class BlenderStandaloneDispatcher:
 
     def __init__(self, timeout_ms: int = 30000) -> None:
         self.timeout_ms = timeout_ms
-        self._dispatcher = InProcessCallableDispatcher()
+        self._host_dispatcher = BlockingDispatcher()
         self._results: Dict[str, Any] = {}
         self._errors: Dict[str, str] = {}
 
+    @property
+    def host_dispatcher(self) -> BlockingDispatcher:
+        """Expose the core dispatcher that backs HTTP main-thread routing."""
+        return self._host_dispatcher
+
     def dispatch(self, func: Callable, *args: Any, **kwargs: Any) -> Any:
         """Dispatch a call inline through core's in-process dispatcher."""
-        outcome = self._dispatcher.submit_callable(
-            self._request_id(func),
-            lambda: func(*args, **kwargs),
-            affinity="main",
-            timeout_ms=self.timeout_ms,
-        )
-        return self._value_or_raise(outcome)
+        handle = self._host_dispatcher.post(lambda: func(*args, **kwargs))
+        return handle.wait(self.timeout_ms / 1000.0)
 
     def dispatch_async(self, func: Callable, *args: Any, **kwargs: Any) -> str:
         """Dispatch a call asynchronously and return a pollable request id."""
         job_id = self._request_id(func)
 
-        def _complete(outcome: JobOutcome) -> None:
-            if outcome.ok:
-                self._results[job_id] = outcome.value
-            else:
-                self._errors[job_id] = outcome.error or "Blender standalone dispatch failed"
+        def _invoke():
+            try:
+                self._results[job_id] = func(*args, **kwargs)
+            except Exception as exc:
+                self._errors[job_id] = str(exc)
 
-        self._dispatcher.submit_async_callable(
-            job_id,
-            lambda: func(*args, **kwargs),
-            affinity="main",
-            timeout_ms=self.timeout_ms,
-            on_complete=_complete,
-        )
+        self._host_dispatcher.post(_invoke)
         return job_id
 
     def get_result(self, job_id: str) -> Optional[Any]:

--- a/src/dcc_mcp_blender/host.py
+++ b/src/dcc_mcp_blender/host.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
 from dcc_mcp_core import HostUiDispatcherBase
-from dcc_mcp_core.host import BlockingDispatcher, HostAdapter
+from dcc_mcp_core.host import BlockingDispatcher, HostAdapter, QueueDispatcher
 
 TickFn = Callable[[], Optional[float]]
 
@@ -129,7 +129,13 @@ class BlenderUiDispatcher(HostUiDispatcherBase):
         self.active_interval_secs = float(active_interval_secs)
         self.idle_interval_secs = float(idle_interval_secs)
         self._pump = pump or BlenderTimerPump(budget_ms=budget_ms)
+        self._host_dispatcher = QueueDispatcher()
         self._owner_thread_ident = threading.get_ident()
+
+    @property
+    def host_dispatcher(self) -> QueueDispatcher:
+        """Expose the core dispatcher that backs HTTP main-thread routing."""
+        return self._host_dispatcher
 
     @property
     def pump(self) -> BlenderTimerPump:
@@ -161,6 +167,11 @@ class BlenderUiDispatcher(HostUiDispatcherBase):
         """Return the number of currently executing main-thread jobs."""
         with self._lock:
             return len(self._active)
+
+    def shutdown(self, reason: str = "Interrupted") -> int:
+        """Shutdown queued work and the underlying core dispatcher."""
+        self._host_dispatcher.shutdown()
+        return super().shutdown(reason)
 
     def dispatch_callable(
         self,
@@ -194,6 +205,7 @@ class BlenderUiDispatcher(HostUiDispatcherBase):
     def _timer_tick(self) -> Optional[float]:
         if self.is_shutdown:
             return None
+        self._host_dispatcher.tick(16)
         _executed, remaining = self.drain_queue(self.budget_ms)
         return self.active_interval_secs if remaining else self.idle_interval_secs
 

--- a/src/dcc_mcp_blender/host.py
+++ b/src/dcc_mcp_blender/host.py
@@ -276,8 +276,20 @@ class BlenderInlineCallableDispatcher:
     def __init__(self, host_dispatcher: Any) -> None:
         self._host_dispatcher = host_dispatcher
 
-    def dispatch_callable(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    def dispatch_callable(
+        self,
+        func: Callable[..., Any],
+        *args: Any,
+        affinity: str = "main",
+        context: Any = None,
+        action_name: str = "",
+        skill_name: Optional[str] = None,
+        execution: str = "sync",
+        timeout_hint_secs: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Any:
         """Execute ``func`` inline once HTTP has dispatched onto Blender's thread."""
+        _ = (affinity, context, action_name, skill_name, execution, timeout_hint_secs)
         return func(*args, **kwargs)
 
     def shutdown(self, reason: str = "Interrupted") -> Any:

--- a/src/dcc_mcp_blender/server.py
+++ b/src/dcc_mcp_blender/server.py
@@ -203,6 +203,16 @@ class BlenderMcpServer(DccServerBase):
         options: Optional[BlenderServerOptions] = None,
     ) -> None:
         if options is None:
+            if dispatcher is None and execution_bridge is None:
+                # Default to a UI or standalone dispatcher if none provided
+                # (essential for workers started via CLI)
+                try:
+                    from dcc_mcp_blender.dispatcher import create_dispatcher
+
+                    dispatcher = create_dispatcher(ui_mode=not self.is_background())
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("[%s] Failed to create default dispatcher: %s", _DCC_NAME, exc)
+
             options = BlenderServerOptions(
                 port=port,
                 extra_skill_paths=extra_skill_paths,
@@ -329,18 +339,31 @@ class BlenderMcpServer(DccServerBase):
     # ── Lifecycle ──────────────────────────────────────────────────────────────
 
     def start(self, *, install_atexit_hook: bool = True) -> "BlenderMcpServer":
-        """Start the MCP HTTP server.  Returns *self* for chaining."""
+        """Start the MCP HTTP server and the attached host dispatcher.
+
+        Returns *self* for chaining.
+        """
         super().start(install_atexit_hook=install_atexit_hook)
+        if self._blender_dispatcher is not None:
+            start_fn = getattr(self._blender_dispatcher, "start", None)
+            if callable(start_fn):
+                start_fn()
         return self
 
     def stop(self) -> None:
-        """Detach MCP resource handlers, then stop the HTTP server."""
+        """Detach MCP resource handlers, stop the HTTP server and the dispatcher."""
         if self._resources is not None:
             try:
                 self._resources.unbind()
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[%s] resources.unbind failed: %s", _DCC_NAME, exc)
+
         super().stop()
+
+        if self._blender_dispatcher is not None:
+            stop_fn = getattr(self._blender_dispatcher, "stop", None)
+            if callable(stop_fn):
+                stop_fn()
 
     # ── Builtin action registration + core integrations ────────────────────────
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -80,7 +80,7 @@ class TestBlenderMcpServerBasic:
         # so the bridge uses BlenderInlineCallableDispatcher for the hop
         assert isinstance(mode.bridge.dispatcher, BlenderInlineCallableDispatcher)
         assert mode.bridge.host_dispatcher is dispatcher.host_dispatcher
-        assert mode.bridge.dispatch_callable(lambda: "ok", affinity="main") == "ok"
+        assert mode.bridge.dispatch_callable(lambda: "ok", thread_affinity="main") == "ok"
 
     def test_explicit_execution_bridge_takes_precedence(self):
         from dcc_mcp_core import HostExecutionBridge

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -68,7 +68,7 @@ class TestBlenderMcpServerBasic:
         assert mode.bridge.dispatch_callable(lambda: "ok") == "ok"
 
     def test_core_backed_ui_dispatcher_is_used_as_execution_bridge(self):
-        from dcc_mcp_blender.host import BlenderUiDispatcher
+        from dcc_mcp_blender.host import BlenderInlineCallableDispatcher, BlenderUiDispatcher
         from dcc_mcp_blender.server import BlenderMcpServer
 
         dispatcher = BlenderUiDispatcher()
@@ -76,9 +76,11 @@ class TestBlenderMcpServerBasic:
 
         mode = server._options.execution.mode
         assert getattr(mode, "kind", None) == "bridge"
-        assert mode.bridge.dispatcher is dispatcher
-        assert mode.bridge.host_dispatcher is None
-        assert mode.bridge.dispatch_callable(lambda: "ok", thread_affinity="main") == "ok"
+        # The UI dispatcher now carries a host_dispatcher (QueueDispatcher)
+        # so the bridge uses BlenderInlineCallableDispatcher for the hop
+        assert isinstance(mode.bridge.dispatcher, BlenderInlineCallableDispatcher)
+        assert mode.bridge.host_dispatcher is dispatcher.host_dispatcher
+        assert mode.bridge.dispatch_callable(lambda: "ok", affinity="main") == "ok"
 
     def test_explicit_execution_bridge_takes_precedence(self):
         from dcc_mcp_core import HostExecutionBridge


### PR DESCRIPTION
This PR fixes an issue where Blender host tools with affinity=main would fail with thread-affinity-violation in interactive mode.

Changes:
- Updated BlenderUiDispatcher to hold and pump a core QueueDispatcher, and expose it via host_dispatcher property so it can be attached to the HTTP server.
- Updated BlenderStandaloneDispatcher to use core BlockingDispatcher for better core integration.
- Updated BlenderMcpServer to automatically create a default dispatcher if none is provided (essential for worker mode).
- Improved BlenderMcpServer to manage the dispatcher's lifecycle (start/stop) during server startup and shutdown.