### PR TITLE
ci: add py37 syntax gate for Blender 2.83 LTS compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,22 @@ permissions:
   contents: read
 
 jobs:
+  # ── Python 3.7 syntax gate ──────────────────────────────────────────────
+  # Blender 2.83 LTS embeds Python 3.7.7; pure-Python modules must remain
+  # syntax-compatible with 3.7 through 2026-12-31.  This job runs
+  # check_py37_syntax.py with a 3.7 interpreter to catch PEP 604 unions,
+  # walrus operators, and other 3.8+ syntax.
+  py37-syntax-check:
+    name: py37 syntax check
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.7"
+      - name: Run py37 syntax check
+        run: python tools/check_py37_syntax.py
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/tools/check_py37_syntax.py
+++ b/tools/check_py37_syntax.py
@@ -1,0 +1,75 @@
+"""Verify pure-Python modules are syntax-compatible with Python 3.7 (Blender 2.83 LTS).
+
+Must be invoked with a Python 3.7 interpreter (``python3.7 tools/check_py37_syntax.py``).
+PEP 604 unions (``str | None``) and builtin generics (``dict[str, Any]``) are syntax
+errors on 3.7 even with ``from __future__ import annotations``.
+
+This is enforced in CI via the ``py37-syntax-check`` job.  Blender 2.83 LTS
+embeds Python 3.7.7; pure-Python modules must remain importable there.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Iterator
+from typing import List
+from typing import Tuple
+
+if sys.version_info[:2] != (3, 7):
+    sys.stderr.write("check_py37_syntax: requires Python 3.7, got {}.{}.{}\n".format(*sys.version_info[:3]))
+    raise SystemExit(2)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCAN_ROOTS = (
+    _REPO_ROOT / "src" / "dcc_mcp_blender",
+    _REPO_ROOT / "tests",
+    _REPO_ROOT / "tools",
+    _REPO_ROOT / "packaging",
+)
+_SKIP_NAMES: frozenset = frozenset()
+_SKIP_RELATIVE: frozenset = frozenset()
+
+
+def _iter_py_files() -> Iterator[Path]:
+    for root in _SCAN_ROOTS:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            if path.name in _SKIP_NAMES:
+                continue
+            rel = path.relative_to(_REPO_ROOT).as_posix()
+            if rel in _SKIP_RELATIVE:
+                continue
+            yield path
+    # Also check the root-level integration_test.py
+    root_test = _REPO_ROOT / "integration_test.py"
+    if root_test.is_file():
+        yield root_test
+
+
+def main() -> int:
+    """Scan the repo tree and exit non-zero on any SyntaxError under 3.7."""
+    failures: List[Tuple[Path, SyntaxError]] = []  # noqa: UP006
+    count = 0
+    for path in _iter_py_files():
+        count += 1
+        source = path.read_text(encoding="utf-8")
+        try:
+            compile(source, str(path), "exec")
+        except SyntaxError as exc:
+            failures.append((path, exc))
+
+    if failures:
+        for path, exc in failures:
+            location = exc.lineno or 0
+            sys.stderr.write("{}:{}: {}\n".format(path, location, exc.msg))
+        sys.stderr.write("check_py37_syntax: {} file(s) failed to parse on Python 3.7\n".format(len(failures)))
+        return 1
+
+    sys.stdout.write("check_py37_syntax: OK ({} files)\n".format(count))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a lightweight `py37-syntax-check` CI job that compiles all pure-Python source files with a Python 3.7 interpreter, following the same pattern as [dcc-mcp-core's py37-syntax-check](https://github.com/loonghao/dcc-mcp-core/blob/main/.github/workflows/ci.yml).

Blender 2.83 LTS embeds Python 3.7.7 and is a red-line host for py37 support through 2026-12-31.  This syntax gate catches PEP 604 unions, walrus operators, and other 3.8+ syntax before they reach the E2E test stage.

## Changes

- **`.github/workflows/ci.yml`**: adds `py37-syntax-check` job (runs on `ubuntu-22.04` with `actions/setup-python@v6` Python 3.7)
- **`tools/check_py37_syntax.py`**: scans `src/dcc_mcp_blender/`, `tests/`, `tools/`, `packaging/` with `compile()` under Python 3.7

## Verification

- `requires-python = ">=3.7"` already in pyproject.toml ✅
- `target-version = "py37"` already in ruff config ✅
- The skip lists (`_SKIP_NAMES`, `_SKIP_RELATIVE`) are empty and ready for any edge cases found at runtime