### PR TITLE
chore: bump dcc-mcp-core to >=0.19.8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 `dcc-mcp-blender` embeds a standards-compliant MCP Streamable HTTP server directly inside Blender. It exposes 200+ Blender operations as MCP tools that any AI agent (Claude, Gemini, Cursor, etc.) can call over HTTP — no external gateway, no subprocess bridge.
 
 **Current version:** 0.1.20 <!-- x-release-please-version -->
-**Core dependency:** `dcc-mcp-core>=0.19.8,<1.0.0`
+**Core dependency:** `dcc-mcp-core>=0.19.9,<1.0.0`
 **Python:** 3.10+ (bundled with Blender)
 **Blender:** 3.6 LTS, 4.2 LTS, 4.3, 4.4
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 `dcc-mcp-blender` embeds a standards-compliant MCP Streamable HTTP server directly inside Blender. It exposes 200+ Blender operations as MCP tools that any AI agent (Claude, Gemini, Cursor, etc.) can call over HTTP — no external gateway, no subprocess bridge.
 
 **Current version:** 0.1.20 <!-- x-release-please-version -->
-**Core dependency:** `dcc-mcp-core>=0.18.34,<1.0.0`
+**Core dependency:** `dcc-mcp-core>=0.19.8,<1.0.0`
 **Python:** 3.10+ (bundled with Blender)
 **Blender:** 3.6 LTS, 4.2 LTS, 4.3, 4.4
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![GitHub release downloads](https://img.shields.io/github/downloads/dcc-mcp/dcc-mcp-blender/total.svg?label=release%20downloads)](https://github.com/dcc-mcp/dcc-mcp-blender/releases)
 [![GitHub Release](https://img.shields.io/github/v/release/dcc-mcp/dcc-mcp-blender.svg)](https://github.com/dcc-mcp/dcc-mcp-blender/releases)
 [![Coverage](https://img.shields.io/badge/coverage-pytest--cov-blue.svg)](https://github.com/dcc-mcp/dcc-mcp-blender/blob/main/pyproject.toml)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.18.34-blue.svg)](https://github.com/loonghao/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.19.8-blue.svg)](https://github.com/loonghao/dcc-mcp-core)
 [![Blender](https://img.shields.io/badge/Blender-3.6%20LTS%20%7C%204.2%20LTS%20%7C%204.3%20%7C%204.4-orange.svg)](https://www.blender.org/download/releases/)
 [![MCP](https://img.shields.io/badge/MCP-2025--03--26-purple.svg)](https://modelcontextprotocol.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@
 **Repo:** https://github.com/dcc-mcp/dcc-mcp-blender
 **Python:** >=3.10 (bundled with Blender)
 **Blender:** 3.6 LTS, 4.2 LTS, 4.3, 4.4
-**Core dep:** `dcc-mcp-core>=0.19.8,<1.0.0`
+**Core dep:** `dcc-mcp-core>=0.19.9,<1.0.0`
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@
 **Repo:** https://github.com/dcc-mcp/dcc-mcp-blender
 **Python:** >=3.10 (bundled with Blender)
 **Blender:** 3.6 LTS, 4.2 LTS, 4.3, 4.4
-**Core dep:** `dcc-mcp-core>=0.18.34,<1.0.0`
+**Core dep:** `dcc-mcp-core>=0.19.8,<1.0.0`
 
 ---
 

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -44,7 +44,7 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.18.34"
+MIN_CORE_VERSION = "0.19.8"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
 

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -44,7 +44,7 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.19.8"
+MIN_CORE_VERSION = "0.19.9"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
 ]
 
 dependencies = [
-    # v0.18.34: bump dcc-mcp-core minimum version.
-    "dcc-mcp-core>=0.18.34,<1.0.0",
+    # v0.19.8: bump dcc-mcp-core minimum version.
+    "dcc-mcp-core>=0.19.8,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
 ]
 
 dependencies = [
-    # v0.19.8: bump dcc-mcp-core minimum version.
-    "dcc-mcp-core>=0.19.8,<1.0.0",
+    # v0.19.9: bump dcc-mcp-core minimum version.
+    "dcc-mcp-core>=0.19.9,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -17,10 +17,10 @@ def _load_assemble_zip_module():
     return mod
 
 
-def test_core_dependency_floor_is_01834():
+def test_core_dependency_floor_is_0198():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert '"dcc-mcp-core>=0.18.34,<1.0.0"' in pyproject
+    assert '"dcc-mcp-core>=0.19.8,<1.0.0"' in pyproject
 
 
 def test_packaging_core_floor_matches_pyproject():

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -20,7 +20,7 @@ def _load_assemble_zip_module():
 def test_core_dependency_floor_is_0198():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert '"dcc-mcp-core>=0.19.8,<1.0.0"' in pyproject
+    assert '"dcc-mcp-core>=0.19.9,<1.0.0"' in pyproject
 
 
 def test_packaging_core_floor_matches_pyproject():


### PR DESCRIPTION
## Summary

- Bump `dcc-mcp-core` dependency floor from `>=0.18.34` to `>=0.19.8,<1.0.0` in `pyproject.toml`.
- Sync `packaging/assemble_zip.py` `MIN_CORE_VERSION`, version floor tests, and documentation badges.

## Test plan

- [x] `pytest` (447 passed, e2e excluded)
- [x] `ruff check` clean
- [x] Local Blender 4.2.10 host import: `dcc_mcp_core` 0.19.8 + `dcc_mcp_blender` OK
- [x] MCP `initialize` handshake via embedded server OK
- [ ] CI green (packaging job may need PyPI `0.19.8` wheel — GitHub release assets exist; PyPI latest is still `0.19.7` at PR open time)

## Local test matrix

| DCC | Core | Command | Result |
|-----|------|---------|--------|
| Blender 4.2.10 LTS (thm `blender-4.2.10`) | 0.19.8 (GitHub release wheel) | `blender --background --python` import + `start_server` + MCP initialize | PASS |
