### PR TITLE
fix: align Blender add-on bundled core with 0.19.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
           python - <<'PY'
           import glob
           import os
+          import re
           import zipfile
 
           platform = os.environ["PLATFORM"]
@@ -167,4 +168,8 @@ jobs:
               raw = zf.read("blender_manifest.toml").decode("utf-8")
           assert "wheels = [" in raw and "./wheels/" in raw, raw[:400]
           assert raw.index("wheels = [") < raw.index("[permissions]"), raw
+          manifest_wheels = re.findall(r'"./(wheels/dcc_mcp_core-[^"]+\.whl)"', raw)
+          assert sorted(manifest_wheels) == sorted(wheels), (manifest_wheels, wheels)
+          assert any("dcc_mcp_core-0.19.17-" in wheel for wheel in wheels), wheels
+          print(f"{platform}: manifest wheels={manifest_wheels}")
           PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 `dcc-mcp-blender` embeds a standards-compliant MCP Streamable HTTP server directly inside Blender. It exposes 200+ Blender operations as MCP tools that any AI agent (Claude, Gemini, Cursor, etc.) can call over HTTP — no external gateway, no subprocess bridge.
 
 **Current version:** 0.1.20 <!-- x-release-please-version -->
-**Core dependency:** `dcc-mcp-core>=0.19.9,<1.0.0`
+**Core dependency:** `dcc-mcp-core>=0.19.17,<1.0.0`
 **Python:** 3.10+ (bundled with Blender)
 **Blender:** 3.6 LTS, 4.2 LTS, 4.3, 4.4
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![GitHub release downloads](https://img.shields.io/github/downloads/dcc-mcp/dcc-mcp-blender/total.svg?label=release%20downloads)](https://github.com/dcc-mcp/dcc-mcp-blender/releases)
 [![GitHub Release](https://img.shields.io/github/v/release/dcc-mcp/dcc-mcp-blender.svg)](https://github.com/dcc-mcp/dcc-mcp-blender/releases)
 [![Coverage](https://img.shields.io/badge/coverage-pytest--cov-blue.svg)](https://github.com/dcc-mcp/dcc-mcp-blender/blob/main/pyproject.toml)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.19.8-blue.svg)](https://github.com/loonghao/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.19.17-blue.svg)](https://github.com/loonghao/dcc-mcp-core)
 [![Blender](https://img.shields.io/badge/Blender-3.6%20LTS%20%7C%204.2%20LTS%20%7C%204.3%20%7C%204.4-orange.svg)](https://www.blender.org/download/releases/)
 [![MCP](https://img.shields.io/badge/MCP-2025--03--26-purple.svg)](https://modelcontextprotocol.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@
 **Repo:** https://github.com/dcc-mcp/dcc-mcp-blender
 **Python:** >=3.10 (bundled with Blender)
 **Blender:** 3.6 LTS, 4.2 LTS, 4.3, 4.4
-**Core dep:** `dcc-mcp-core>=0.19.9,<1.0.0`
+**Core dep:** `dcc-mcp-core>=0.19.17,<1.0.0`
 
 ---
 

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -44,7 +44,7 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.19.9"
+MIN_CORE_VERSION = "0.19.17"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
 ]
 
 dependencies = [
-    # v0.19.9: bump dcc-mcp-core minimum version.
-    "dcc-mcp-core>=0.19.9,<1.0.0",
+    # v0.19.17: align bundled add-on core with the current release train.
+    "dcc-mcp-core>=0.19.17,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -34,6 +34,10 @@ def _load_assemble_zip_module():
     return mod
 
 
+def _manifest_wheels(manifest: str):
+    return re.findall(r'"\.\/(wheels\/dcc_mcp_core-[^"]+\.whl)"', manifest)
+
+
 def test_addon_entry_bl_info_version_is_static_tuple_literal():
     """Blender parses ``bl_info`` via AST, so version must not be computed."""
     tree = ast.parse(ADDON_ENTRY.read_text(encoding="utf-8"))
@@ -51,10 +55,10 @@ def test_addon_entry_bl_info_version_is_static_tuple_literal():
 def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monkeypatch):
     """The add-on package root must directly contain ``server.py`` and skills."""
     assemble_zip = _load_assemble_zip_module()
-    fake_wheel = tmp_path / "dcc_mcp_core-0.18.9-cp38-abi3-win_amd64.whl"
+    fake_wheel = tmp_path / "dcc_mcp_core-0.19.17-cp38-abi3-win_amd64.whl"
     fake_wheel.write_bytes(b"fake wheel")
 
-    monkeypatch.setattr(assemble_zip, "resolve_core_version", lambda min_version="0.18.9": "0.18.9")
+    monkeypatch.setattr(assemble_zip, "resolve_core_version", lambda min_version="0.19.17": "0.19.17")
     monkeypatch.setattr(assemble_zip, "download_core_wheel", lambda version, platform, dest_dir: fake_wheel)
 
     zip_path = assemble_zip.assemble(platform="win64", output_dir=tmp_path)
@@ -69,6 +73,9 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     assert "host.py" in names
     assert "skills/blender-scene/SKILL.md" in names
     assert not any(name.startswith("dcc_mcp_blender/") for name in names)
+    assert [name for name in sorted(names) if name.startswith("wheels/dcc_mcp_core-")] == [
+        "wheels/dcc_mcp_core-0.19.17-cp38-abi3-win_amd64.whl"
+    ]
     addon_tree = ast.parse(addon_init)
     addon_bl_info = next(
         node for node in addon_tree.body if isinstance(node, ast.Assign) and node.targets[0].id == "bl_info"
@@ -80,7 +87,7 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     )
     assert isinstance(addon_version_node, ast.Tuple)
     assert ast.literal_eval(addon_version_node) == _parse_version_tuple(_get_addon_version())
-    assert "./wheels/dcc_mcp_core-0.18.9-cp38-abi3-win_amd64.whl" in manifest
+    assert _manifest_wheels(manifest) == ["wheels/dcc_mcp_core-0.19.17-cp38-abi3-win_amd64.whl"]
     assert manifest.index("wheels = [") < manifest.index("[permissions]")
 
 

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -17,10 +17,10 @@ def _load_assemble_zip_module():
     return mod
 
 
-def test_core_dependency_floor_is_0198():
+def test_core_dependency_floor_is_01917():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert '"dcc-mcp-core>=0.19.9,<1.0.0"' in pyproject
+    assert '"dcc-mcp-core>=0.19.17,<1.0.0"' in pyproject
 
 
 def test_packaging_core_floor_matches_pyproject():


### PR DESCRIPTION
## Summary
- raise the Blender add-on bundled `dcc-mcp-core` floor to `0.19.17`
- keep `pyproject.toml`, `packaging/assemble_zip.py`, and docs aligned on that floor
- tighten addon ZIP CI so the manifest wheel list must exactly match the packaged `wheels/` entry and include `dcc_mcp_core-0.19.17-*`

## Evidence
The published `v0.1.22` win64 add-on artifact contains:

```text
blender_manifest.toml: ./wheels/dcc_mcp_core-0.19.1-cp38-abi3-win_amd64.whl
wheels/: dcc_mcp_core-0.19.1-cp38-abi3-win_amd64.whl
```

A local win64 rebuild after this change resolves and packages:

```text
wheels/dcc_mcp_core-0.19.17-cp38-abi3-win_amd64.whl
manifest_wheels: wheels/dcc_mcp_core-0.19.17-cp38-abi3-win_amd64.whl
manifest_version: 0.1.22
```

## Validation
- `python -m pytest tests/test_core_version.py tests/test_addon_packaging.py -q`
- `python -m ruff check packaging/assemble_zip.py tests/test_addon_packaging.py tests/test_core_version.py`
- `python -m ruff format --check packaging/assemble_zip.py tests/test_addon_packaging.py tests/test_core_version.py`
- `python packaging/assemble_zip.py --platform win64 --output-dir dist_addon_proof`