### PR TITLE
feat: add typed Alembic import

### DIFF
--- a/src/dcc_mcp_blender/_interchange_ops.py
+++ b/src/dcc_mcp_blender/_interchange_ops.py
@@ -9,7 +9,7 @@ from typing import Any, Mapping, Sequence
 from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
 
 _PRESET_STORE_KEY = "dcc_mcp_export_presets"
-_IMPORT_FORMATS = {"fbx", "obj", "gltf", "usd"}
+_IMPORT_FORMATS = {"fbx", "obj", "gltf", "usd", "alembic"}
 _EXPORT_FORMATS = {"fbx", "obj", "gltf", "usd", "alembic"}
 _FORMAT_EXTENSIONS = {
     ".fbx": "fbx",
@@ -186,6 +186,15 @@ def _import_by_format(
                 )
             base = {"filepath": str(target)}
             _call_with_options(usd_import, base, options, warnings)
+        elif format == "alembic":
+            alembic_import = getattr(bpy.ops.wm, "alembic_import", None)
+            if not callable(alembic_import):
+                return (
+                    [],
+                    warnings,
+                    skill_error("Alembic import unavailable", "Blender Alembic import operator is not available."),
+                )
+            _call_with_options(alembic_import, {"filepath": str(target)}, options, warnings)
         else:
             return [], warnings, skill_error("Unsupported import format", f"Format '{format}' is not importable.")
     except Exception as exc:
@@ -329,6 +338,11 @@ def import_fbx(path: str, options: Mapping[str, Any] | None = None) -> dict:
 def import_obj(path: str, options: Mapping[str, Any] | None = None) -> dict:
     """Import an OBJ file."""
     return import_file(path=path, format="obj", options=options)
+
+
+def import_alembic(path: str, options: Mapping[str, Any] | None = None) -> dict:
+    """Import an Alembic cache."""
+    return import_file(path=path, format="alembic", options=options)
 
 
 def _summarize_imported_scene(bpy: Any, imported_names: list[str]) -> dict[str, Any]:

--- a/src/dcc_mcp_blender/skills/blender-interchange/scripts/import_alembic.py
+++ b/src/dcc_mcp_blender/skills/blender-interchange/scripts/import_alembic.py
@@ -1,0 +1,19 @@
+"""Import an Alembic cache into Blender."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._interchange_ops import import_alembic
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`import_alembic`."""
+    return import_alembic(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-interchange/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-interchange/tools.yaml
@@ -1,6 +1,6 @@
 tools:
   - name: import_file
-    description: "Import an FBX, OBJ, GLTF, or GLB file using Blender-native import operators."
+    description: "Import an FBX, OBJ, GLTF, GLB, or Alembic file using Blender-native import operators."
     source_file: scripts/import_file.py
     execution: sync
     affinity: main
@@ -16,7 +16,7 @@ tools:
           description: File path to import.
         format:
           type: string
-          enum: [fbx, obj, gltf]
+          enum: [fbx, obj, gltf, alembic]
           description: Optional format override; inferred from extension when omitted.
         collection_name:
           type: string
@@ -94,6 +94,35 @@ tools:
           type: object
           additionalProperties: true
           description: Blender OBJ import options.
+    output_schema: *interchange_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: true
+
+  - name: import_alembic
+    description: "Import an Alembic cache using Blender's native Alembic importer."
+    source_file: scripts/import_alembic.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [path]
+      properties:
+        path:
+          type: string
+          minLength: 1
+          description: Alembic cache path (.abc).
+        options:
+          type: object
+          additionalProperties: true
+          description: Blender Alembic import options.
     output_schema: *interchange_result_schema
     read_only: false
     destructive: false

--- a/tests/test_skills_interchange_export.py
+++ b/tests/test_skills_interchange_export.py
@@ -21,6 +21,7 @@ INTERCHANGE_TOOLS = {
     "import_fbx",
     "import_obj",
     "import_usd",
+    "import_alembic",
     "export_gltf",
     "export_usd",
     "export_alembic",
@@ -144,6 +145,25 @@ def test_import_obj_reports_imported_objects_and_missing_file(tmp_path):
 
     missing = load_and_call("blender-interchange/scripts/import_file.py", bpy, path=str(tmp_path / "missing.fbx"))
     assert missing["success"] is False
+
+
+def test_import_alembic_reports_imported_cache_objects(tmp_path):
+    source = tmp_path / "energy_fx.abc"
+    source.write_bytes(b"Ogawa")
+    bpy = _bpy_with_scene([])
+
+    def alembic_import(filepath, **_kwargs):
+        assert filepath == str(source)
+        bpy.data.objects.append(FakeObject("EnergyFxCache"))
+        return {"FINISHED"}
+
+    bpy.ops.wm.alembic_import.side_effect = alembic_import
+
+    result = load_and_call("blender-interchange/scripts/import_alembic.py", bpy, path=str(source))
+
+    assert result["success"] is True
+    assert result["context"]["format"] == "alembic"
+    assert result["context"]["imported_object_names"] == ["EnergyFxCache"]
 
 
 def test_import_file_supports_gltf(tmp_path):


### PR DESCRIPTION
Adds a typed Alembic import path to the interchange skill, matching the existing export support. Includes focused operator and manifest coverage.