### PR TITLE
fix: publish scripting and render tool schemas

### DIFF
--- a/src/dcc_mcp_blender/skills/blender-render/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-render/tools.yaml
@@ -4,6 +4,18 @@ tools:
     source_file: scripts/render_scene.py
     execution: sync
     affinity: main
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        output_path:
+          type: string
+          minLength: 1
+          description: Optional destination image path; defaults to the scene output path.
+        write_still:
+          type: boolean
+          default: true
+          description: Write the rendered image to disk.
     read_only: false
     destructive: false
     idempotent: false
@@ -12,6 +24,39 @@ tools:
     source_file: scripts/set_render_settings.py
     execution: sync
     affinity: main
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        engine:
+          type: string
+          enum: [CYCLES, BLENDER_EEVEE, BLENDER_EEVEE_NEXT, BLENDER_WORKBENCH]
+          description: Blender render engine identifier.
+        resolution_x:
+          type: integer
+          minimum: 1
+          description: Horizontal output resolution in pixels.
+        resolution_y:
+          type: integer
+          minimum: 1
+          description: Vertical output resolution in pixels.
+        resolution_percentage:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Output resolution percentage.
+        samples:
+          type: integer
+          minimum: 1
+          description: Render sample count for Cycles or EEVEE.
+        output_path:
+          type: string
+          minLength: 1
+          description: Output file path or directory used by Blender.
+        file_format:
+          type: string
+          minLength: 1
+          description: Blender image format identifier such as PNG, JPEG, or OPEN_EXR.
     read_only: false
     destructive: false
     idempotent: true
@@ -20,6 +65,10 @@ tools:
     source_file: scripts/get_render_info.py
     execution: sync
     affinity: main
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties: {}
     read_only: true
     destructive: false
     idempotent: true
@@ -28,6 +77,23 @@ tools:
     source_file: scripts/capture_viewport.py
     execution: sync
     affinity: main
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [filepath]
+      properties:
+        filepath:
+          type: string
+          minLength: 1
+          description: Destination image path.
+        resolution_x:
+          type: integer
+          minimum: 1
+          description: Optional temporary viewport capture width.
+        resolution_y:
+          type: integer
+          minimum: 1
+          description: Optional temporary viewport capture height.
     read_only: false
     destructive: false
     idempotent: false

--- a/src/dcc_mcp_blender/skills/blender-scripting/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-scripting/tools.yaml
@@ -4,6 +4,19 @@ tools:
     source_file: scripts/execute_python.py
     execution: sync
     affinity: main
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [code]
+      properties:
+        code:
+          type: string
+          minLength: 1
+          description: Python source code to execute inside Blender.
+        context:
+          type: object
+          additionalProperties: true
+          description: Optional variables injected into the execution namespace.
     read_only: false
     destructive: false
     idempotent: false
@@ -24,6 +37,15 @@ tools:
     source_file: scripts/execute_script_file.py
     execution: sync
     affinity: main
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [filepath]
+      properties:
+        filepath:
+          type: string
+          minLength: 1
+          description: Absolute path to a Python script readable by Blender.
     read_only: false
     destructive: false
     idempotent: false
@@ -44,6 +66,10 @@ tools:
     source_file: scripts/get_blender_info.py
     execution: sync
     affinity: main
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties: {}
     read_only: true
     destructive: false
     idempotent: true

--- a/tests/test_skills_render.py
+++ b/tests/test_skills_render.py
@@ -2,9 +2,32 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
+import yaml
+
 from tests.conftest import load_and_call, make_mock_bpy
+
+
+def test_render_tools_publish_ci_safe_input_contracts():
+    tools_path = Path("src/dcc_mcp_blender/skills/blender-render/tools.yaml")
+    tools = {tool["name"]: tool for tool in yaml.safe_load(tools_path.read_text(encoding="utf-8"))["tools"]}
+
+    render_scene = tools["render_scene"]["input_schema"]
+    assert render_scene["properties"]["write_still"]["default"] is True
+    assert render_scene["additionalProperties"] is False
+
+    settings = tools["set_render_settings"]["input_schema"]["properties"]
+    assert "CYCLES" in settings["engine"]["enum"]
+    assert settings["resolution_percentage"]["maximum"] == 100
+    assert settings["samples"]["minimum"] == 1
+
+    capture = tools["capture_viewport"]["input_schema"]
+    assert capture["required"] == ["filepath"]
+    assert capture["properties"]["resolution_x"]["minimum"] == 1
+
+    assert tools["get_render_info"]["input_schema"]["properties"] == {}
 
 
 class TestGetRenderInfo:

--- a/tests/test_skills_scripting.py
+++ b/tests/test_skills_scripting.py
@@ -3,8 +3,27 @@
 from __future__ import annotations
 
 import tempfile
+from pathlib import Path
+
+import yaml
 
 from tests.conftest import load_and_call, make_mock_bpy
+
+
+def test_scripting_tools_publish_ci_safe_input_contracts():
+    tools_path = Path("src/dcc_mcp_blender/skills/blender-scripting/tools.yaml")
+    tools = {tool["name"]: tool for tool in yaml.safe_load(tools_path.read_text(encoding="utf-8"))["tools"]}
+
+    execute_python = tools["execute_python"]["input_schema"]
+    assert execute_python["required"] == ["code"]
+    assert execute_python["properties"]["code"]["minLength"] == 1
+    assert execute_python["additionalProperties"] is False
+
+    execute_file = tools["execute_script_file"]["input_schema"]
+    assert execute_file["required"] == ["filepath"]
+    assert execute_file["properties"]["filepath"]["type"] == "string"
+
+    assert tools["get_blender_info"]["input_schema"]["properties"] == {}
 
 
 class TestExecutePython:


### PR DESCRIPTION
## Summary
- publish explicit JSON input schemas for Blender scripting tools
- publish explicit JSON input schemas for Blender render tools
- add contract tests for required parameters, defaults, enums, and ranges

## Validation
- 451 passed, 19 skipped
- Ruff and skill lint passed