### PR TITLE
fix: preserve supported USD import options

### DIFF
--- a/src/dcc_mcp_blender/_interchange_ops.py
+++ b/src/dcc_mcp_blender/_interchange_ops.py
@@ -95,7 +95,30 @@ def _select_objects(bpy: Any, object_names: Sequence[str] | None) -> tuple[bool,
     return True, [obj.name for obj in objects], None
 
 
+def _operator_property_names(operator: Any) -> set[str] | None:
+    """Return Blender RNA option names when the operator exposes them."""
+    get_rna_type = getattr(operator, "get_rna_type", None)
+    if not callable(get_rna_type):
+        return None
+    try:
+        properties = get_rna_type().properties
+        names = set()
+        for prop in properties:
+            identifier = getattr(prop, "identifier", None)
+            if identifier and identifier != "rna_type":
+                names.add(identifier)
+    except Exception:
+        return None
+    return names or None
+
+
 def _call_with_options(operator: Any, base: dict[str, Any], options: dict[str, Any], warnings: list[str]) -> None:
+    supported = _operator_property_names(operator)
+    if supported is not None:
+        ignored = sorted(set(options) - supported)
+        if ignored:
+            warnings.append(f"Ignored unsupported options: {ignored}")
+        options = {key: value for key, value in options.items() if key in supported}
     payload = dict(base)
     payload.update(options)
     try:

--- a/tests/test_skills_interchange_export.py
+++ b/tests/test_skills_interchange_export.py
@@ -318,6 +318,64 @@ def test_import_usd_reports_imported_objects_and_summary(tmp_path):
     assert summary["by_type"] == {"MESH": 1, "LIGHT": 1}
 
 
+def test_import_usd_filters_only_unsupported_operator_options(tmp_path):
+    """One unsupported Blender option must not discard the supported USD options."""
+    source = tmp_path / "scene.usda"
+    source.write_text("#usda 1.0\n", encoding="utf-8")
+    bpy = _bpy_with_scene([])
+    received = {}
+
+    class Property:
+        def __init__(self, identifier):
+            self.identifier = identifier
+
+    class UsdImportOperator:
+        def get_rna_type(self):
+            properties = [
+                Property("rna_type"),
+                Property("filepath"),
+                Property("import_meshes"),
+                Property("import_materials"),
+                Property("import_cameras"),
+                Property("import_lights"),
+                Property("import_subdiv"),
+                Property("scale"),
+            ]
+            return type("RnaType", (), {"properties": properties})()
+
+        def __call__(self, **kwargs):
+            received.update(kwargs)
+            bpy.data.objects.append(FakeObject("UsdMesh"))
+            return {"FINISHED"}
+
+    bpy.ops.wm.usd_import = UsdImportOperator()
+
+    result = load_and_call(
+        "blender-interchange/scripts/import_usd.py",
+        bpy,
+        filepath=str(source),
+        import_meshes=True,
+        import_materials=True,
+        import_cameras=True,
+        import_lights=True,
+        import_textures=True,
+        import_subdiv=True,
+        scale=0.5,
+    )
+
+    assert result["success"] is True
+    assert received == {
+        "filepath": str(source),
+        "import_meshes": True,
+        "import_materials": True,
+        "import_cameras": True,
+        "import_lights": True,
+        "import_subdiv": True,
+        "scale": 0.5,
+    }
+    assert result["context"]["warnings"] == ["Ignored unsupported options: ['import_textures']"]
+
+
 def test_import_usd_reports_missing_file(tmp_path):
     """USD import should fail gracefly for missing file."""
     bpy = _bpy_with_scene([])


### PR DESCRIPTION
## Summary
- negotiate USD import options against Blender RNA metadata
- ignore only unsupported options instead of dropping the full typed payload
- add regression coverage for mixed supported and unsupported options

## Validation
- 452 passed, 19 skipped
- ruff check and format check passed