### PR TITLE
fix: skip MCP autostart in Blender render workers

### DIFF
--- a/packaging/addon_entry/__init__.py
+++ b/packaging/addon_entry/__init__.py
@@ -41,6 +41,7 @@ bl_info = {
 }
 
 _DEFAULT_GATEWAY_PORT = 9765
+_BACKGROUND_RENDER_ENV = "DCC_MCP_BACKGROUND_RENDER"
 
 _draw_handlers: List[Tuple[str, object]] = []
 _server_dispatcher: Any = None
@@ -331,6 +332,10 @@ def register() -> None:
         _draw_handlers.append(("TOPBAR_MT_blender", _draw_topbar_menu))
     else:
         logger.warning("TOPBAR_MT_blender missing — DCC MCP top-bar menu not attached")
+
+    if os.environ.get(_BACKGROUND_RENDER_ENV, "").strip().lower() in {"1", "true", "yes", "on"}:
+        print("[DCC MCP Blender] Background render worker detected; server autostart skipped")
+        return
 
     try:
         srv = _start_server_with_host()

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -166,3 +166,38 @@ def test_addon_register_starts_server_with_core_backed_blender_ui_dispatcher(mon
         "stop_server",
         "dispatcher.stop",
     ]
+
+
+def test_addon_register_skips_server_autostart_in_background_render_worker(monkeypatch):
+    """Isolated render workers must not claim the interactive MCP endpoint."""
+    registered_classes = []
+
+    class _Menu:
+        @staticmethod
+        def append(_fn):
+            pass
+
+        @staticmethod
+        def remove(_fn):
+            pass
+
+    fake_bpy = SimpleNamespace(
+        types=SimpleNamespace(Operator=object, Menu=object, TOPBAR_MT_blender=_Menu),
+        utils=SimpleNamespace(
+            register_class=lambda cls: registered_classes.append(cls),
+            unregister_class=lambda cls: registered_classes.remove(cls),
+        ),
+    )
+
+    spec = importlib.util.spec_from_file_location("addon_entry_worker_test", str(ADDON_ENTRY))
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "bpy", fake_bpy)
+    spec.loader.exec_module(mod)
+    monkeypatch.setenv("DCC_MCP_BACKGROUND_RENDER", "1")
+    monkeypatch.setattr(mod, "_start_server_with_host", lambda: (_ for _ in ()).throw(AssertionError("started")))
+
+    mod.register()
+
+    assert registered_classes == list(mod._CLASSES)
+    mod.unregister()
+    assert registered_classes == []


### PR DESCRIPTION
## Summary
- skip Blender add-on server autostart when an isolated render worker declares `DCC_MCP_BACKGROUND_RENDER`
- preserve normal GUI and intentional background MCP startup behavior
- cover the packaged add-on lifecycle contract with a regression test

## Validation
- `PYTHONPATH=src python -m pytest -q` (458 passed, 19 skipped)
- `python -m ruff check packaging/addon_entry/__init__.py tests/test_addon_packaging.py`
- `git diff --check`

## Production evidence
A released v0.1.30 add-on enabled inside a clean Blender render worker attempted to claim a second MCP endpoint. The worker now has an explicit opt-out without changing interactive Blender behavior.
