### PR TITLE
fix: reject incompatible preloaded core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 `dcc-mcp-blender` embeds a standards-compliant MCP Streamable HTTP server directly inside Blender. It exposes 200+ Blender operations as MCP tools that any AI agent (Claude, Gemini, Cursor, etc.) can call over HTTP — no external gateway, no subprocess bridge.
 
 **Current version:** 0.1.20 <!-- x-release-please-version -->
-**Core dependency:** `dcc-mcp-core>=0.19.17,<1.0.0`
+**Core dependency:** `dcc-mcp-core>=0.19.42,<1.0.0`
 **Python:** 3.10+ (bundled with Blender)
 **Blender:** 3.6 LTS, 4.2 LTS, 4.3, 4.4
 

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -44,7 +44,7 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.19.17"
+MIN_CORE_VERSION = "0.19.42"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
 ]
 
 dependencies = [
-    # v0.19.17: align bundled add-on core with the current release train.
-    "dcc-mcp-core>=0.19.17,<1.0.0",
+    # v0.19.42: reserved request metadata is isolated from skill kwargs.
+    "dcc-mcp-core>=0.19.42,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_blender/__init__.py
+++ b/src/dcc_mcp_blender/__init__.py
@@ -1,6 +1,13 @@
 """dcc-mcp-blender — MCP Streamable HTTP server embedded in Blender."""
 
+# The compatibility gate must run before imports that bind core integrations.
+# ruff: noqa: E402
+
 from __future__ import annotations
+
+from dcc_mcp_blender._core_compat import require_compatible_core
+
+require_compatible_core()
 
 from dcc_mcp_blender.__version__ import __version__
 from dcc_mcp_blender._capability_manifest import (

--- a/src/dcc_mcp_blender/_core_compat.py
+++ b/src/dcc_mcp_blender/_core_compat.py
@@ -1,0 +1,37 @@
+"""Validate the core runtime before importing adapter integrations."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+MIN_CORE_VERSION = "0.19.42"
+
+
+def _release_tuple(version: str) -> tuple[int, int, int]:
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)", version)
+    if match is None:
+        raise RuntimeError(f"Invalid dcc-mcp-core version: {version!r}")
+    major, minor, patch = match.groups()
+    return int(major), int(minor), int(patch)
+
+
+def require_compatible_core(version: Optional[str] = None, *, module_path: Optional[str] = None) -> None:
+    """Reject a host-preloaded core that is older than the adapter contract."""
+    if version is None:
+        import dcc_mcp_core
+
+        version = str(dcc_mcp_core.__version__)
+        module_path = str(getattr(dcc_mcp_core, "__file__", "unknown"))
+
+    if _release_tuple(version) >= _release_tuple(MIN_CORE_VERSION):
+        return
+
+    raise RuntimeError(
+        f"dcc-mcp-blender requires dcc-mcp-core>={MIN_CORE_VERSION}, but Blender "
+        f"preloaded dcc-mcp-core {version} from {module_path or 'unknown'}. "
+        "Restart Blender with the bundled extension wheel ahead of host site-packages."
+    )
+
+
+__all__ = ["MIN_CORE_VERSION", "require_compatible_core"]

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -6,6 +6,8 @@ import importlib.util
 import pathlib
 import re
 
+import pytest
+
 ROOT = pathlib.Path(__file__).parent.parent
 
 
@@ -17,10 +19,10 @@ def _load_assemble_zip_module():
     return mod
 
 
-def test_core_dependency_floor_is_01917():
+def test_core_dependency_floor_is_01942():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert '"dcc-mcp-core>=0.19.17,<1.0.0"' in pyproject
+    assert '"dcc-mcp-core>=0.19.42,<1.0.0"' in pyproject
 
 
 def test_packaging_core_floor_matches_pyproject():
@@ -29,3 +31,16 @@ def test_packaging_core_floor_matches_pyproject():
 
     assert match is not None
     assert _load_assemble_zip_module().MIN_CORE_VERSION == match.group("version")
+
+
+def test_preloaded_core_below_floor_is_rejected():
+    from dcc_mcp_blender._core_compat import require_compatible_core
+
+    with pytest.raises(RuntimeError, match="preloaded dcc-mcp-core 0.19.21"):
+        require_compatible_core("0.19.21", module_path="/host/site-packages/dcc_mcp_core")
+
+
+def test_preloaded_core_at_floor_is_accepted():
+    from dcc_mcp_blender._core_compat import require_compatible_core
+
+    require_compatible_core("0.19.42", module_path="/extension/site-packages/dcc_mcp_core")


### PR DESCRIPTION
## Summary
- raise the supported dcc-mcp-core floor to 0.19.42
- reject an older core that the host imported before the Blender extension
- keep the add-on ZIP resolver and operator documentation aligned with the runtime floor

## Why
Blender can preload a host-installed dcc-mcp-core before extension wheels are added to the interpreter path. Python then keeps the older module in `sys.modules`, so the extension appears healthy but later request-context calls can fail inside skill entry points.

The startup gate turns that hidden mixed-version state into an immediate, actionable error and directs operators to restart with the bundled wheel ahead of host site-packages.

## Validation
- `vx uv run --extra dev python -m pytest -q`
- `vx uv run --with ruff ruff check src/dcc_mcp_blender/_core_compat.py src/dcc_mcp_blender/__init__.py tests/test_core_version.py packaging/assemble_zip.py`
