### PR TITLE
fix: enforce core gate in addon entry

### DIFF
--- a/packaging/addon_entry/__init__.py
+++ b/packaging/addon_entry/__init__.py
@@ -68,6 +68,13 @@ def _start_server_with_host():
     """Start the MCP server with a Blender main-thread dispatcher attached."""
     global _server_dispatcher, _server_host  # noqa: PLW0603
 
+    # The release ZIP replaces the library package entrypoint with this Blender
+    # add-on entrypoint. Enforce the same compatibility contract here before
+    # importing host/server modules that bind dcc-mcp-core integrations.
+    from dcc_mcp_blender._core_compat import require_compatible_core  # noqa: PLC0415
+
+    require_compatible_core()
+
     from dcc_mcp_blender.host import BlenderUiDispatcher  # noqa: PLC0415
     from dcc_mcp_blender.server import get_server, start_server, stop_server  # noqa: PLC0415
 

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -91,9 +91,7 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     assert manifest.index("wheels = [") < manifest.index("[permissions]")
 
     start_server = next(
-        node
-        for node in addon_tree.body
-        if isinstance(node, ast.FunctionDef) and node.name == "_start_server_with_host"
+        node for node in addon_tree.body if isinstance(node, ast.FunctionDef) and node.name == "_start_server_with_host"
     )
     gate_call = next(
         node

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -90,6 +90,24 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     assert _manifest_wheels(manifest) == ["wheels/dcc_mcp_core-0.19.17-cp38-abi3-win_amd64.whl"]
     assert manifest.index("wheels = [") < manifest.index("[permissions]")
 
+    start_server = next(
+        node
+        for node in addon_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_start_server_with_host"
+    )
+    gate_call = next(
+        node
+        for node in ast.walk(start_server)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "require_compatible_core"
+    )
+    core_import_lines = [
+        node.lineno
+        for node in ast.walk(start_server)
+        if isinstance(node, ast.ImportFrom) and node.module in {"dcc_mcp_blender.host", "dcc_mcp_blender.server"}
+    ]
+    assert core_import_lines
+    assert gate_call.lineno < min(core_import_lines)
+
 
 def test_addon_register_starts_server_with_core_backed_blender_ui_dispatcher(monkeypatch):
     """GUI add-on enable must wire the core-backed UI dispatcher before serving tools."""


### PR DESCRIPTION
## Summary
- run the existing core compatibility gate from the packaged Blender add-on entry
- enforce the gate before importing host/server integrations
- verify the assembled ZIP preserves this call ordering

## Validation
- full Python test suite
- Ruff
- assembled Windows add-on ZIP
- Blender 5.1 cold-start regression with an older preloaded core