### PR TITLE
feat: configure Blender view-layer render passes

### DIFF
--- a/src/dcc_mcp_blender/_scene_assembly_ops.py
+++ b/src/dcc_mcp_blender/_scene_assembly_ops.py
@@ -7,6 +7,39 @@ from typing import Any
 
 from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
 
+_VIEW_LAYER_PASSES = {
+    "z": ("layer", "use_pass_z"),
+    "mist": ("layer", "use_pass_mist"),
+    "normal": ("layer", "use_pass_normal"),
+    "vector": ("layer", "use_pass_vector"),
+    "diffuse_direct": ("layer", "use_pass_diffuse_direct"),
+    "diffuse_indirect": ("layer", "use_pass_diffuse_indirect"),
+    "diffuse_color": ("layer", "use_pass_diffuse_color"),
+    "glossy_direct": ("layer", "use_pass_glossy_direct"),
+    "glossy_indirect": ("layer", "use_pass_glossy_indirect"),
+    "glossy_color": ("layer", "use_pass_glossy_color"),
+    "transmission_direct": ("layer", "use_pass_transmission_direct"),
+    "transmission_indirect": ("layer", "use_pass_transmission_indirect"),
+    "transmission_color": ("layer", "use_pass_transmission_color"),
+    "emit": ("layer", "use_pass_emit"),
+    "environment": ("layer", "use_pass_environment"),
+    "cryptomatte_object": ("layer", "use_pass_cryptomatte_object"),
+    "cryptomatte_material": ("layer", "use_pass_cryptomatte_material"),
+    "cryptomatte_asset": ("layer", "use_pass_cryptomatte_asset"),
+    "volume_direct": ("cycles", "use_pass_volume_direct"),
+    "volume_indirect": ("cycles", "use_pass_volume_indirect"),
+}
+
+
+def _find_layer_collection(root: Any, name: str) -> Any | None:
+    stack = [root]
+    while stack:
+        item = stack.pop()
+        if item.collection.name == name:
+            return item
+        stack.extend(item.children)
+    return None
+
 
 def _iter_items(data_from: Any, attr: str) -> list[str]:
     try:
@@ -208,6 +241,101 @@ def create_view_layer(name: str, scene_name: str | None = None) -> dict:
         return skill_error("Blender not available", "bpy could not be imported")
     except Exception as exc:
         return skill_exception(exc, message=f"Failed to create view layer {name}")
+
+
+def configure_view_layer(
+    name: str,
+    scene_name: str | None = None,
+    enabled: bool | None = None,
+    passes: list[str] | None = None,
+    exclude_collections: list[str] | None = None,
+    include_collections: list[str] | None = None,
+    cryptomatte_depth: int | None = None,
+) -> dict:
+    """Configure render passes and collection visibility for one view layer."""
+    if not name:
+        return skill_error("Invalid name", "name must be a non-empty string.")
+    requested_passes = list(dict.fromkeys(passes or []))
+    unknown_passes = sorted(set(requested_passes) - set(_VIEW_LAYER_PASSES))
+    if unknown_passes:
+        return skill_error(
+            "Unsupported view-layer pass",
+            "Unsupported passes: {}. Supported passes: {}.".format(
+                ", ".join(unknown_passes), ", ".join(sorted(_VIEW_LAYER_PASSES))
+            ),
+        )
+    if cryptomatte_depth is not None and not 2 <= cryptomatte_depth <= 16:
+        return skill_error("Invalid Cryptomatte depth", "cryptomatte_depth must be between 2 and 16.")
+
+    try:
+        import bpy
+
+        scene = bpy.context.scene if scene_name is None else bpy.data.scenes.get(scene_name)
+        if scene is None:
+            return skill_error(f"Scene not found: {scene_name}", f"No scene named '{scene_name}'.")
+        if name not in scene.view_layers:
+            return skill_error(
+                f"View layer not found: {name}",
+                f"Scene '{scene.name}' has no view layer named '{name}'.",
+            )
+        layer = scene.view_layers[name]
+
+        collection_changes: list[tuple[Any, bool]] = []
+        missing_collections: list[str] = []
+        for collection_name, excluded in (
+            *((value, True) for value in (exclude_collections or [])),
+            *((value, False) for value in (include_collections or [])),
+        ):
+            layer_collection = _find_layer_collection(layer.layer_collection, collection_name)
+            if layer_collection is None:
+                missing_collections.append(collection_name)
+            else:
+                collection_changes.append((layer_collection, excluded))
+        if missing_collections:
+            return skill_error(
+                "Collection not found in view layer",
+                "Missing collections: {}.".format(", ".join(sorted(set(missing_collections)))),
+            )
+
+        pass_targets = {
+            pass_name: layer if target_name == "layer" else getattr(layer, "cycles", None)
+            for pass_name, (target_name, _) in _VIEW_LAYER_PASSES.items()
+        }
+        unsupported_in_host = [
+            pass_name
+            for pass_name in requested_passes
+            if pass_targets[pass_name] is None or not hasattr(pass_targets[pass_name], _VIEW_LAYER_PASSES[pass_name][1])
+        ]
+        if unsupported_in_host:
+            return skill_error(
+                "View-layer pass unavailable in this Blender version",
+                "Unavailable passes: {}.".format(", ".join(unsupported_in_host)),
+            )
+
+        if enabled is not None:
+            layer.use = enabled
+        for pass_name in requested_passes:
+            setattr(pass_targets[pass_name], _VIEW_LAYER_PASSES[pass_name][1], True)
+        for layer_collection, excluded in collection_changes:
+            layer_collection.exclude = excluded
+        if cryptomatte_depth is not None:
+            layer.pass_cryptomatte_depth = cryptomatte_depth
+
+        return skill_success(
+            f"Configured view layer {name}",
+            scene_name=scene.name,
+            view_layer_name=name,
+            enabled=getattr(layer, "use", True),
+            enabled_passes=requested_passes,
+            excluded_collections=[item.collection.name for item, excluded in collection_changes if excluded],
+            included_collections=[item.collection.name for item, excluded in collection_changes if not excluded],
+            cryptomatte_depth=getattr(layer, "pass_cryptomatte_depth", None),
+            prompt="Use list_view_layers to inspect layers before rendering a multilayer EXR.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message=f"Failed to configure view layer {name}")
 
 
 def remove_view_layer(name: str, scene_name: str | None = None) -> dict:

--- a/src/dcc_mcp_blender/skills/blender-scene-assembly/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-scene-assembly/SKILL.md
@@ -46,6 +46,7 @@ and inspecting library references. Mirrors Maya's scene assembly surface.
 | `link_from_blend` | Link data blocks as library references |
 | `list_view_layers` | List view layers in a scene |
 | `create_view_layer` | Create a new view layer |
+| `configure_view_layer` | Configure render passes and collection exclusions |
 | `remove_view_layer` | Remove a view layer |
 | `set_active_view_layer` | Set the active view layer |
 | `list_external_references` | List all external .blend file references |
@@ -55,4 +56,4 @@ and inspecting library references. Mirrors Maya's scene assembly surface.
 - **Scene composition**: `merge_scene` to combine multiple .blend files
 - **Selective import**: `append_from_blend` with targeted data types
 - **Library workflow**: `link_from_blend` for shared assets -> `list_external_references`
-- **Layer management**: `list_view_layers` -> `create_view_layer` / `set_active_view_layer`
+- **Layer management**: `list_view_layers` -> `create_view_layer` -> `configure_view_layer` -> `set_active_view_layer`

--- a/src/dcc_mcp_blender/skills/blender-scene-assembly/scripts/configure_view_layer.py
+++ b/src/dcc_mcp_blender/skills/blender-scene-assembly/scripts/configure_view_layer.py
@@ -1,0 +1,19 @@
+"""Configure Blender view-layer passes and collection visibility."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._scene_assembly_ops import configure_view_layer
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`configure_view_layer`."""
+    return configure_view_layer(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-scene-assembly/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-scene-assembly/tools.yaml
@@ -185,6 +185,60 @@ tools:
       idempotent_hint: false
       open_world_hint: false
 
+  - name: configure_view_layer
+    description: "Configure one view layer's render-pass selection and collection exclusions for multilayer rendering."
+    source_file: scripts/configure_view_layer.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 0
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: View-layer name.
+        scene_name:
+          type: string
+          minLength: 1
+          description: Optional scene name; uses the current scene if omitted.
+        enabled:
+          type: boolean
+          description: Whether Blender should render this view layer.
+        passes:
+          type: array
+          uniqueItems: true
+          description: Passes to enable without disabling existing passes.
+          items:
+            type: string
+            enum: [z, mist, normal, vector, diffuse_direct, diffuse_indirect, diffuse_color, glossy_direct, glossy_indirect, glossy_color, transmission_direct, transmission_indirect, transmission_color, emit, environment, cryptomatte_object, cryptomatte_material, cryptomatte_asset, volume_direct, volume_indirect]
+        exclude_collections:
+          type: array
+          uniqueItems: true
+          items: {type: string, minLength: 1}
+          description: Collection names to exclude from this layer.
+        include_collections:
+          type: array
+          uniqueItems: true
+          items: {type: string, minLength: 1}
+          description: Collection names to include in this layer.
+        cryptomatte_depth:
+          type: integer
+          minimum: 2
+          maximum: 16
+          description: Cryptomatte manifest depth when Crypto passes are enabled.
+    output_schema: *layer_result_schema
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
   - name: set_active_view_layer
     description: "Set the active view layer."
     source_file: scripts/set_active_view_layer.py

--- a/tests/test_skills_scene_assembly.py
+++ b/tests/test_skills_scene_assembly.py
@@ -99,6 +99,79 @@ def test_remove_view_layer_last_one():
     assert result["success"] is False
 
 
+def test_configure_view_layer_passes_and_collections():
+    bpy = make_mock_bpy()
+    scene = _make_scene("Scene")
+    bpy.context.scene = scene
+    layer = MagicMock()
+    layer.use = True
+    layer.use_pass_z = False
+    layer.use_pass_cryptomatte_object = False
+    layer.cycles.use_pass_volume_direct = False
+    layer.pass_cryptomatte_depth = 6
+    root = MagicMock()
+    root.collection.name = "Scene Collection"
+    fx = MagicMock()
+    fx.collection.name = "FX"
+    root.children = [fx]
+    fx.children = []
+    layer.layer_collection = root
+    scene.view_layers.__contains__ = MagicMock(return_value=True)
+    scene.view_layers.__getitem__ = MagicMock(return_value=layer)
+
+    result = load_and_call(
+        "blender-scene-assembly/scripts/configure_view_layer.py",
+        bpy,
+        name="Beauty",
+        passes=["z", "cryptomatte_object", "volume_direct"],
+        exclude_collections=["FX"],
+        cryptomatte_depth=8,
+    )
+
+    assert result["success"] is True
+    assert layer.use_pass_z is True
+    assert layer.use_pass_cryptomatte_object is True
+    assert layer.cycles.use_pass_volume_direct is True
+    assert layer.pass_cryptomatte_depth == 8
+    assert fx.exclude is True
+
+
+def test_configure_view_layer_validates_before_mutation():
+    bpy = make_mock_bpy()
+    scene = _make_scene("Scene")
+    bpy.context.scene = scene
+    layer = MagicMock()
+    layer.use_pass_z = False
+    root = MagicMock()
+    root.collection.name = "Scene Collection"
+    root.children = []
+    layer.layer_collection = root
+    scene.view_layers.__contains__ = MagicMock(return_value=True)
+    scene.view_layers.__getitem__ = MagicMock(return_value=layer)
+
+    result = load_and_call(
+        "blender-scene-assembly/scripts/configure_view_layer.py",
+        bpy,
+        name="Beauty",
+        passes=["z"],
+        exclude_collections=["Missing"],
+    )
+
+    assert result["success"] is False
+    assert layer.use_pass_z is False
+
+
+def test_configure_view_layer_rejects_unknown_pass():
+    bpy = make_mock_bpy()
+    result = load_and_call(
+        "blender-scene-assembly/scripts/configure_view_layer.py",
+        bpy,
+        name="Beauty",
+        passes=["not_a_pass"],
+    )
+    assert result["success"] is False
+
+
 def test_set_active_view_layer():
     bpy = make_mock_bpy()
     scene = _make_scene("Scene")
@@ -136,6 +209,7 @@ def test_tools_yaml_declares_tools():
         "link_from_blend",
         "list_view_layers",
         "create_view_layer",
+        "configure_view_layer",
         "remove_view_layer",
         "set_active_view_layer",
         "list_external_references",


### PR DESCRIPTION
## Summary\n- add a typed configure_view_layer tool\n- enable Cycles lighting, volume, and Cryptomatte passes\n- include or exclude collections per view layer with preflight validation\n\n## Validation\n- full Python test suite\n- focused skill/structure/lint tests: 22 passed\n- live Blender 5.1.1 smoke for Z, Normal, Emit, Object/Material Cryptomatte, Volume Direct/Indirect, and collection exclusion\n\n## Why\nMultilayer EXR workflows previously required arbitrary Python after creating a view layer. This keeps the durable render-layer intent typed and auditable.