### PR TITLE
feat: add observable background render jobs

### DIFF
--- a/src/dcc_mcp_blender/_render_job_ops.py
+++ b/src/dcc_mcp_blender/_render_job_ops.py
@@ -1,0 +1,236 @@
+"""Owned background Blender render jobs."""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import subprocess
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List
+
+from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
+
+_FRAME_TOKEN = re.compile(r"#+")
+_OPENEXR_MAGIC = b"\x76\x2f\x31\x01"
+_JOBS: Dict[str, Dict[str, Any]] = {}
+_LOCK = threading.Lock()
+
+
+def _expected_output_path(output_pattern: str, frame: int) -> Path:
+    if not Path(output_pattern).is_absolute():
+        raise ValueError("output_pattern must be an absolute path")
+    matches = list(_FRAME_TOKEN.finditer(output_pattern))
+    if not matches:
+        raise ValueError("output_pattern must contain a # frame placeholder")
+    if len(matches) != 1:
+        raise ValueError("output_pattern must contain exactly one # frame placeholder")
+    match = matches[0]
+    value = output_pattern[: match.start()] + str(frame).zfill(len(match.group())) + output_pattern[match.end() :]
+    path = Path(value)
+    return path if path.suffix.lower() == ".exr" else Path(value + ".exr")
+
+
+def _select_frames(
+    output_pattern: str,
+    start_frame: int,
+    end_frame: int,
+    step: int,
+    *,
+    resume_missing: bool,
+) -> List[int]:
+    if start_frame > end_frame:
+        raise ValueError("start_frame must be less than or equal to end_frame")
+    if step < 1:
+        raise ValueError("step must be at least 1")
+    frames = list(range(start_frame, end_frame + 1, step))
+    _expected_output_path(output_pattern, frames[0])
+    if not resume_missing:
+        return frames
+    return [frame for frame in frames if not _is_valid_output(_expected_output_path(output_pattern, frame))]
+
+
+def _is_valid_output(path: Path) -> bool:
+    try:
+        if not path.is_file() or path.stat().st_size < len(_OPENEXR_MAGIC):
+            return False
+        with path.open("rb") as stream:
+            return stream.read(len(_OPENEXR_MAGIC)) == _OPENEXR_MAGIC
+    except OSError:
+        return False
+
+
+def _build_blender_command(
+    *,
+    blender_path: str,
+    scene_path: str,
+    output_pattern: str,
+    frames: List[int],
+    device: str,
+    factory_startup: bool,
+) -> List[str]:
+    command = [blender_path, "--background"]
+    if factory_startup:
+        command.append("--factory-startup")
+    command.extend(
+        [
+            scene_path,
+            "--render-output",
+            output_pattern,
+            "--render-format",
+            "OPEN_EXR_MULTILAYER",
+            "--use-extension",
+            "1",
+        ]
+    )
+    for frame in frames:
+        command.extend(("--render-frame", str(frame)))
+    if device:
+        command.extend(("--", "--cycles-device", device.upper()))
+    return command
+
+
+def start_render_job(
+    output_pattern: str,
+    start_frame: int,
+    end_frame: int,
+    step: int = 1,
+    resume_missing: bool = True,
+    device: str = "OPTIX",
+    save_before_render: bool = True,
+    factory_startup: bool = False,
+) -> dict:
+    """Save the current scene and submit an isolated multi-layer EXR render."""
+    try:
+        import bpy  # Lazy import: requires Blender's embedded Python.
+
+        frames = _select_frames(
+            output_pattern,
+            start_frame,
+            end_frame,
+            step,
+            resume_missing=resume_missing,
+        )
+        scene_path = str(getattr(bpy.data, "filepath", ""))
+        if not scene_path:
+            return skill_error("Scene is not saved", "Save the .blend file before starting a background render.")
+        if save_before_render:
+            bpy.ops.wm.save_as_mainfile(filepath=scene_path)
+
+        output_dir = _expected_output_path(output_pattern, start_frame).parent
+        output_dir.mkdir(parents=True, exist_ok=True)
+        job_id = uuid.uuid4().hex
+        stdout_path = output_dir / (".dcc-mcp-render-{}.out.log".format(job_id))
+        stderr_path = output_dir / (".dcc-mcp-render-{}.err.log".format(job_id))
+        process = None
+        if frames:
+            command = _build_blender_command(
+                blender_path=str(bpy.app.binary_path),
+                scene_path=scene_path,
+                output_pattern=output_pattern,
+                frames=frames,
+                device=device,
+                factory_startup=factory_startup,
+            )
+            env = os.environ.copy()
+            env["DCC_MCP_BACKGROUND_RENDER"] = "1"
+            popen_kwargs: Dict[str, Any] = {"env": env, "cwd": str(output_dir)}
+            if os.name == "nt":
+                popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
+            else:
+                popen_kwargs["start_new_session"] = True
+            with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
+                process = subprocess.Popen(command, stdout=stdout, stderr=stderr, **popen_kwargs)
+
+        job = {
+            "job_id": job_id,
+            "process": process,
+            "status": "running" if process is not None else "completed",
+            "frames": frames,
+            "output_pattern": output_pattern,
+            "scene_path": scene_path,
+            "stdout_path": str(stdout_path),
+            "stderr_path": str(stderr_path),
+            "started_at": time.time(),
+        }
+        with _LOCK:
+            _JOBS[job_id] = job
+        return skill_success(
+            "Background render job submitted" if frames else "All requested frames already exist",
+            **_job_context(job),
+            prompt="Use get_render_job to monitor progress and cancel_render_job to stop the owned worker.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to start background render job")
+
+
+def get_render_job(job_id: str) -> dict:
+    with _LOCK:
+        job = _JOBS.get(job_id)
+    if job is None:
+        return skill_error("Render job not found", "Unknown job_id: {}".format(job_id))
+    return skill_success("Render job status", **_job_context(job))
+
+
+def cancel_render_job(job_id: str) -> dict:
+    with _LOCK:
+        job = _JOBS.get(job_id)
+    if job is None:
+        return skill_error("Render job not found", "Unknown job_id: {}".format(job_id))
+    _job_context(job)
+    if job["status"] not in {"completed", "failed", "cancelled"}:
+        process = job.get("process")
+        if process is not None:
+            _terminate_process_tree(process)
+        job["status"] = "cancelled"
+    return skill_success("Render job cancelled", **_job_context(job))
+
+
+def _job_context(job: Dict[str, Any]) -> Dict[str, Any]:
+    process = job.get("process")
+    if job["status"] == "running" and process is not None:
+        return_code = process.poll()
+        if return_code is not None:
+            expected = [_expected_output_path(job["output_pattern"], frame) for frame in job["frames"]]
+            job["status"] = (
+                "completed" if return_code == 0 and all(_is_valid_output(path) for path in expected) else "failed"
+            )
+    written = [
+        frame for frame in job["frames"] if _is_valid_output(_expected_output_path(job["output_pattern"], frame))
+    ]
+    written_set = set(written)
+    missing = [frame for frame in job["frames"] if frame not in written_set]
+    expected_count = len(job["frames"])
+    return {
+        "job_id": job["job_id"],
+        "status": job["status"],
+        "pid": None if process is None else process.pid,
+        "expected_frame_count": expected_count,
+        "written_frame_count": len(written),
+        "progress": 1.0 if expected_count == 0 else len(written) / expected_count,
+        "missing_frame_sample": missing[:32],
+        "output_pattern": job["output_pattern"],
+        "stdout_path": job["stdout_path"],
+        "stderr_path": job["stderr_path"],
+    }
+
+
+def _terminate_process_tree(process: Any) -> None:
+    if process.poll() is not None:
+        return
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            check=False,
+            capture_output=True,
+        )
+        return
+    try:
+        os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+    except (OSError, ProcessLookupError):
+        process.terminate()

--- a/src/dcc_mcp_blender/skills/blender-render/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-render/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: blender-render
-description: "Blender rendering — render scenes, capture viewport images, set render settings, manage cameras"
+description: "Blender rendering — render scenes, run observable background animation jobs, capture viewport images, and configure output"
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
 metadata:
@@ -10,7 +10,7 @@ metadata:
     tags: [blender, render, viewport, camera]
     search-hint: "render, viewport screenshot, output, resolution, camera, cycles, eevee, render preview"
     search-aliases: [render scene, render preview, viewport capture, screenshot, set render resolution, render settings, cycles render, eevee render, image output, render engine]
-    intent: "Configure render settings, render scenes, capture viewport images, and inspect render status in Blender."
+    intent: "Configure render settings, render scenes, submit/query/cancel isolated animation jobs, and capture viewport images."
     recall-context:
       app_type: blender
       domain: rendering
@@ -35,4 +35,6 @@ metadata:
 
 # blender-render
 
-Blender rendering skill.
+Use `render_scene` for short stills. Use `start_render_job` for animation or
+multi-layer EXR output so the interactive Blender process remains responsive;
+poll with `get_render_job` and cancel only through the returned job id.

--- a/src/dcc_mcp_blender/skills/blender-render/scripts/cancel_render_job.py
+++ b/src/dcc_mcp_blender/skills/blender-render/scripts/cancel_render_job.py
@@ -1,0 +1,10 @@
+"""Cancel an owned Blender render job."""
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._render_job_ops import cancel_render_job
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return cancel_render_job(**kwargs)

--- a/src/dcc_mcp_blender/skills/blender-render/scripts/get_render_job.py
+++ b/src/dcc_mcp_blender/skills/blender-render/scripts/get_render_job.py
@@ -1,0 +1,10 @@
+"""Query an owned Blender render job."""
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._render_job_ops import get_render_job
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_render_job(**kwargs)

--- a/src/dcc_mcp_blender/skills/blender-render/scripts/start_render_job.py
+++ b/src/dcc_mcp_blender/skills/blender-render/scripts/start_render_job.py
@@ -1,0 +1,10 @@
+"""Submit an isolated Blender animation render."""
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._render_job_ops import start_render_job
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return start_render_job(**kwargs)

--- a/src/dcc_mcp_blender/skills/blender-render/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-render/tools.yaml
@@ -97,3 +97,80 @@ tools:
     read_only: false
     destructive: false
     idempotent: false
+  - name: start_render_job
+    description: "Save the current .blend and start an isolated background animation render to multi-layer OpenEXR; optionally render only missing frames."
+    source_file: scripts/start_render_job.py
+    execution: sync
+    affinity: main
+    read_only: false
+    destructive: false
+    idempotent: false
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [output_pattern, start_frame, end_frame]
+      properties:
+        output_pattern:
+          type: string
+          minLength: 1
+          description: "Absolute output pattern containing # placeholders, for example C:/renders/beauty_####. Blender appends .exr."
+        start_frame:
+          type: integer
+          minimum: 0
+        end_frame:
+          type: integer
+          minimum: 0
+        step:
+          type: integer
+          minimum: 1
+          default: 1
+        resume_missing:
+          type: boolean
+          default: true
+          description: "Skip existing non-empty EXR files and render only missing frames."
+        device:
+          type: string
+          enum: [OPTIX, CUDA, HIP, ONEAPI, METAL, CPU]
+          default: OPTIX
+        save_before_render:
+          type: boolean
+          default: true
+        factory_startup:
+          type: boolean
+          default: false
+          description: "Disable user preferences and add-ons in the worker. Enable only after proving the scene has no external add-on dependency."
+    next-tools:
+      on-success: [blender_render__get_render_job]
+      on-failure: [dcc_diagnostics__process_status]
+  - name: get_render_job
+    description: "Return bounded frame progress, process status, and log paths for an owned background render job."
+    source_file: scripts/get_render_job.py
+    execution: sync
+    affinity: any
+    read_only: true
+    destructive: false
+    idempotent: true
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [job_id]
+      properties:
+        job_id:
+          type: string
+          minLength: 1
+  - name: cancel_render_job
+    description: "Cancel the owned background Blender process tree for a render job; repeated cancellation is safe."
+    source_file: scripts/cancel_render_job.py
+    execution: sync
+    affinity: any
+    read_only: false
+    destructive: true
+    idempotent: true
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [job_id]
+      properties:
+        job_id:
+          type: string
+          minLength: 1

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -184,6 +184,39 @@ def test_addon_register_starts_server_with_core_backed_blender_ui_dispatcher(mon
     ]
 
 
+def test_addon_register_does_not_start_server_in_background_render_worker(monkeypatch):
+    registered_classes = []
+
+    class _Menu:
+        @staticmethod
+        def append(_fn):
+            pass
+
+        @staticmethod
+        def remove(_fn):
+            pass
+
+    fake_bpy = SimpleNamespace(
+        types=SimpleNamespace(Operator=object, Menu=object, TOPBAR_MT_blender=_Menu),
+        utils=SimpleNamespace(
+            register_class=lambda cls: registered_classes.append(cls),
+            unregister_class=lambda cls: registered_classes.remove(cls),
+        ),
+    )
+    spec = importlib.util.spec_from_file_location("addon_entry_background_render_test", str(ADDON_ENTRY))
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "bpy", fake_bpy)
+    spec.loader.exec_module(mod)
+    starts = []
+    monkeypatch.setattr(mod, "_start_server_with_host", lambda: starts.append(True))
+    monkeypatch.setenv("DCC_MCP_BACKGROUND_RENDER", "1")
+
+    mod.register()
+
+    assert registered_classes == list(mod._CLASSES)
+    assert starts == []
+
+
 def test_addon_register_skips_server_autostart_in_background_render_worker(monkeypatch):
     """Isolated render workers must not claim the interactive MCP endpoint."""
     registered_classes = []

--- a/tests/test_render_jobs.py
+++ b/tests/test_render_jobs.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from dcc_mcp_blender import _render_job_ops as jobs
+
+
+def _write_valid_exr(path):
+    path.write_bytes(b"\x76\x2f\x31\x01payload")
+
+
+def test_build_command_uses_multilayer_exr_and_exact_frames(tmp_path):
+    command = jobs._build_blender_command(
+        blender_path="blender",
+        scene_path=str(tmp_path / "scene.blend"),
+        output_pattern=str(tmp_path / "beauty_####"),
+        frames=[1, 3, 7],
+        device="OPTIX",
+        factory_startup=False,
+    )
+
+    assert command[:3] == ["blender", "--background", str(tmp_path / "scene.blend")]
+    assert "--factory-startup" not in command
+    assert command[command.index("--render-format") + 1] == "OPEN_EXR_MULTILAYER"
+    assert [command[index + 1] for index, value in enumerate(command) if value == "--render-frame"] == [
+        "1",
+        "3",
+        "7",
+    ]
+    assert command[-3:] == ["--", "--cycles-device", "OPTIX"]
+
+    factory_command = jobs._build_blender_command(
+        blender_path="blender",
+        scene_path=str(tmp_path / "scene.blend"),
+        output_pattern=str(tmp_path / "beauty_####"),
+        frames=[1],
+        device="CPU",
+        factory_startup=True,
+    )
+    assert factory_command[2] == "--factory-startup"
+
+
+def test_select_frames_resumes_only_missing_nonempty_exrs(tmp_path):
+    pattern = str(tmp_path / "beauty_####")
+    _write_valid_exr(jobs._expected_output_path(pattern, 1))
+    jobs._expected_output_path(pattern, 3).write_bytes(b"not an exr")
+
+    assert jobs._select_frames(pattern, 1, 4, 1, resume_missing=True) == [2, 3, 4]
+    assert jobs._select_frames(pattern, 1, 4, 2, resume_missing=False) == [1, 3]
+
+
+def test_start_get_cancel_background_render_job(monkeypatch, tmp_path):
+    blend = tmp_path / "scene.blend"
+    blend.write_bytes(b"blend")
+    pattern = str(tmp_path / "beauty_####")
+    saved = []
+    fake_bpy = SimpleNamespace(
+        app=SimpleNamespace(binary_path="blender"),
+        data=SimpleNamespace(filepath=str(blend)),
+        ops=SimpleNamespace(wm=SimpleNamespace(save_as_mainfile=lambda filepath: saved.append(filepath))),
+    )
+    monkeypatch.setitem(sys.modules, "bpy", fake_bpy)
+
+    created = []
+
+    class FakeProcess:
+        pid = 4321
+
+        def poll(self):
+            return None
+
+    def fake_popen(command, **kwargs):
+        created.append((command, kwargs))
+        return FakeProcess()
+
+    terminated = []
+    monkeypatch.setattr(jobs.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(jobs, "_terminate_process_tree", lambda process: terminated.append(process.pid))
+    jobs._JOBS.clear()
+
+    started = jobs.start_render_job(
+        output_pattern=pattern,
+        start_frame=1,
+        end_frame=3,
+        device="OPTIX",
+    )
+    assert started["success"] is True
+    job_id = started["context"]["job_id"]
+    assert started["context"]["expected_frame_count"] == 3
+    assert saved == [str(blend)]
+    assert created[0][1]["env"]["DCC_MCP_BACKGROUND_RENDER"] == "1"
+
+    status = jobs.get_render_job(job_id)
+    assert status["context"]["status"] == "running"
+    assert status["context"]["written_frame_count"] == 0
+
+    cancelled = jobs.cancel_render_job(job_id)
+    assert cancelled["context"]["status"] == "cancelled"
+    assert terminated == [4321]
+    repeated = jobs.cancel_render_job(job_id)
+    assert repeated["context"]["status"] == "cancelled"
+    assert terminated == [4321]
+
+
+def test_rejects_output_pattern_without_frame_placeholder(tmp_path):
+    with pytest.raises(ValueError, match="#"):
+        jobs._select_frames(str(tmp_path / "beauty"), 1, 2, 1, resume_missing=True)
+
+    with pytest.raises(ValueError, match="absolute"):
+        jobs._select_frames("beauty_####", 1, 2, 1, resume_missing=True)
+
+    with pytest.raises(ValueError, match="exactly one"):
+        jobs._select_frames(str(tmp_path / "shot_##_beauty_####"), 1, 2, 1, resume_missing=True)
+
+
+def test_cancel_does_not_overwrite_a_just_completed_job(tmp_path):
+    pattern = str(tmp_path / "beauty_####")
+    _write_valid_exr(jobs._expected_output_path(pattern, 1))
+
+    class CompletedProcess:
+        pid = 99
+
+        def poll(self):
+            return 0
+
+    job_id = "completed-race"
+    jobs._JOBS[job_id] = {
+        "job_id": job_id,
+        "process": CompletedProcess(),
+        "status": "running",
+        "frames": [1],
+        "output_pattern": pattern,
+        "scene_path": str(tmp_path / "scene.blend"),
+        "stdout_path": str(tmp_path / "out.log"),
+        "stderr_path": str(tmp_path / "err.log"),
+        "started_at": 0.0,
+    }
+
+    result = jobs.cancel_render_job(job_id)
+
+    assert result["context"]["status"] == "completed"


### PR DESCRIPTION
## Summary
- add typed start, status, and cancel tools for isolated Blender render jobs
- support resumable multi-layer EXR animation rendering by skipping only valid existing frames
- preserve GUI responsiveness and prevent background workers from registering another MCP service
- expose bounded progress, logs, missing-frame samples, PID, and idempotent cancellation

## Validation
- 469 tests passed, 19 skipped
- Ruff and packaging checks passed
- Blender 5.1 live smoke: two-frame six-view-layer OpenEXR completed with GUI responsive
- live cancellation terminated the owned worker tree and left the control port unclaimed