### PR TITLE
fix: use OS-assigned MCP instance ports

### DIFF
--- a/.github/scripts/start_mcp_server.py
+++ b/.github/scripts/start_mcp_server.py
@@ -6,6 +6,7 @@ import os
 import sys
 import threading
 import time
+from pathlib import Path
 
 try:
     import bpy  # noqa: F401
@@ -22,6 +23,9 @@ def main() -> None:
     host = BlenderHost(dispatcher)
     server = dcc_mcp_blender.start_server(dispatcher=dispatcher)
     print(f"MCP server started at {server.mcp_url}", flush=True)
+
+    url_file = Path(os.environ.get("RUNNER_TEMP", "/tmp")) / "mcp_server_url"
+    url_file.write_text(server.mcp_url, encoding="utf-8")
 
     for skill in server.list_skills():
         name = skill.get("name", "")

--- a/.github/scripts/start_mcp_server.py
+++ b/.github/scripts/start_mcp_server.py
@@ -20,7 +20,7 @@ from dcc_mcp_blender.host import BlenderCallableDispatcher, BlenderHost
 def main() -> None:
     dispatcher = BlenderCallableDispatcher()
     host = BlenderHost(dispatcher)
-    server = dcc_mcp_blender.start_server(port=8765, dispatcher=dispatcher)
+    server = dcc_mcp_blender.start_server(dispatcher=dispatcher)
     print(f"MCP server started at {server.mcp_url}", flush=True)
 
     for skill in server.list_skills():

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -278,17 +278,32 @@ jobs:
         shell: bash
         run: |
           # Start Blender MCP server in background
+          MCP_URL_FILE="$RUNNER_TEMP/mcp_server_url"
+          rm -f "$MCP_URL_FILE"
           "$BLENDER_BIN" --background --python "$GITHUB_WORKSPACE/.github/scripts/start_mcp_server.py" &
           SERVER_PID=$!
           echo "Server PID: $SERVER_PID"
 
-          # Wait for the server to become ready (retry with backoff)
-          sleep 15
+          # Wait for Blender to publish the OS-assigned listener URL.
+          for attempt in $(seq 1 60); do
+            if [ -s "$MCP_URL_FILE" ]; then
+              break
+            fi
+            if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+              echo "Blender exited before publishing the MCP URL" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          test -s "$MCP_URL_FILE"
+          MCP_SERVER_URL="$(<"$MCP_URL_FILE")"
+          export MCP_SERVER_URL
+          echo "MCP server URL: $MCP_SERVER_URL"
 
           # ── 1. Verify MCP initialize handshake ──────────────────────────────
           "$BLENDER_PYTHON" -c "
-          import urllib.request, json, time, sys
-          url = 'http://127.0.0.1:8765/mcp'
+          import os, urllib.request, json, time, sys
+          url = os.environ['MCP_SERVER_URL']
           body = json.dumps({
               'jsonrpc': '2.0', 'id': 0, 'method': 'initialize',
               'params': {'protocolVersion': '2025-03-26', 'capabilities': {},
@@ -312,14 +327,14 @@ jobs:
 
           # ── 2. List all registered tools via mcporter ───────────────────────
           mcporter list \
-            --http-url http://127.0.0.1:8765/mcp \
+            --http-url "$MCP_SERVER_URL" \
             --name blender-ci \
             --allow-http
 
           call_tool() {
             set +e
             output=$(mcporter call \
-              --http-url http://127.0.0.1:8765/mcp \
+              --http-url "$MCP_SERVER_URL" \
               --allow-http \
               "$@" 2>&1)
             status=$?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 `dcc-mcp-blender` embeds a standards-compliant MCP Streamable HTTP server directly inside Blender. It exposes 200+ Blender operations as MCP tools that any AI agent (Claude, Gemini, Cursor, etc.) can call over HTTP — no external gateway, no subprocess bridge.
 
 **Current version:** 0.1.20 <!-- x-release-please-version -->
-**Core dependency:** `dcc-mcp-core>=0.19.42,<1.0.0`
+**Core dependency:** `dcc-mcp-core>=0.19.45,<1.0.0`
 **Python:** 3.10+ (bundled with Blender)
 **Blender:** 3.6 LTS, 4.2 LTS, 4.3, 4.4
 
@@ -20,8 +20,8 @@
 
 ```python
 import dcc_mcp_blender
-handle = dcc_mcp_blender.start_server(port=8765)
-# MCP client connects to http://127.0.0.1:8765/mcp
+handle = dcc_mcp_blender.start_server()
+# MCP client connects through http://127.0.0.1:9765/mcp
 ```
 
 Or install the Blender extension (ZIP) and the server starts automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Add to `claude_desktop_config.json`:
 {
   "mcpServers": {
     "blender": {
-      "url": "http://127.0.0.1:8765/mcp"
+      "url": "http://127.0.0.1:9765/mcp"
     }
   }
 }

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -58,7 +58,7 @@ Use Gemini's search capability with the built-in discovery tools:
 If your Gemini client supports MCP over HTTP, configure:
 
 ```
-Endpoint: http://127.0.0.1:8765/mcp
+Gateway endpoint: http://127.0.0.1:9765/mcp
 Protocol: MCP Streamable HTTP (2025-03-26 spec)
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The tested interchange chain used baked FBX for the rig, Alembic for animated ef
 │  ├─ JSON-RPC 2.0                │
 │  └─ SSE Streaming               │
 └─────────────────────────────────┘
-         ↓ http://127.0.0.1:8765/mcp
+         ↓ http://127.0.0.1:9765/mcp (stable gateway)
 ┌─────────────────────────────────┐
 │  MCP Host (Claude / etc.)       │
 └─────────────────────────────────┘
@@ -140,7 +140,7 @@ options below are for manual installation.
 2. In Blender 4.2+: **Edit → Preferences → Extensions → Install from Disk…** → select the ZIP.
    (Do **NOT** use **Edit → Preferences → Add-ons → Install** — that legacy path is unsupported.)
 3. Enable **DCC MCP Blender**
-4. The MCP server starts automatically on `http://127.0.0.1:8765`
+4. The MCP server starts on an OS-assigned instance port and registers with the local gateway.
 
 Release ZIPs are Blender 4.2+ Extension packages. They include `blender_manifest.toml` and the matching `dcc-mcp-core` wheel under `wheels/`, so Blender installs the Python dependency into the extension's isolated environment.
 
@@ -185,7 +185,7 @@ Add to your `claude_desktop_config.json`:
 {
   "mcpServers": {
     "blender": {
-      "url": "http://127.0.0.1:8765/mcp"
+      "url": "http://127.0.0.1:9765/mcp"
     }
   }
 }
@@ -198,7 +198,7 @@ Make sure the Blender addon is enabled and the server is running, then restart C
 ```python
 import dcc_mcp_blender
 
-# Start the server (default port 8765)
+# Start the server on an OS-assigned instance port
 dcc_mcp_blender.start_server()
 
 # Stop the server

--- a/install.md
+++ b/install.md
@@ -59,11 +59,10 @@ import dcc_mcp_blender
 dcc_mcp_blender.start_server()
 ```
 
-Blender uses first-wins auto-gateway on port `8765`, so the MCP server is
-exposed at:
+Blender instances use OS-assigned ports and register with the stable gateway:
 
 ```text
-http://127.0.0.1:8765/mcp
+http://127.0.0.1:9765/mcp
 ```
 
 ## MCP Config
@@ -74,7 +73,7 @@ Use this JSON for Cursor, Claude Desktop, or any MCP Streamable HTTP host:
 {
   "mcpServers": {
     "blender": {
-      "url": "http://127.0.0.1:8765/mcp"
+      "url": "http://127.0.0.1:9765/mcp"
     }
   }
 }

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@
 **Repo:** https://github.com/dcc-mcp/dcc-mcp-blender
 **Python:** >=3.10 (bundled with Blender)
 **Blender:** 3.6 LTS, 4.2 LTS, 4.3, 4.4
-**Core dep:** `dcc-mcp-core>=0.19.17,<1.0.0`
+**Core dep:** `dcc-mcp-core>=0.19.45,<1.0.0`
 
 ---
 
@@ -20,8 +20,8 @@
 
 ```python
 import dcc_mcp_blender
-handle = dcc_mcp_blender.start_server(port=8765)
-# MCP host → http://127.0.0.1:8765/mcp
+handle = dcc_mcp_blender.start_server()
+# Direct MCP host → handle.mcp_url() (OS-assigned); gateway → http://127.0.0.1:9765/mcp
 handle.shutdown()
 ```
 
@@ -38,7 +38,7 @@ blender --background --python src/dcc_mcp_blender/blender_bootstrap.py
 
 ```python
 start_server(
-    port: int = 8765,
+    port: Optional[int] = None,
     server_name: str = "blender-mcp",
     register_builtins: bool = True,
     extra_skill_paths: Optional[List[str]] = None,
@@ -53,7 +53,7 @@ stop_server() -> None
 
 ```python
 BlenderMcpServer(
-    port: int = 8765,
+    port: Optional[int] = None,
     server_name: str = "blender-mcp",
     server_version: str = "0.1.20",  # x-release-please-version
     enable_gateway_failover: bool = True,
@@ -99,7 +99,7 @@ Tool naming: `{skill_name.replace("-","_")}__{script_stem}` (e.g. `blender_scene
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DCC_MCP_BLENDER_PORT` | `8765` | TCP port |
+| `DCC_MCP_BLENDER_PORT` | OS-assigned | Optional fixed instance TCP port |
 | `DCC_MCP_BLENDER_SERVER_NAME` | `blender-mcp` | MCP init name |
 | `DCC_MCP_BLENDER_SKILL_PATHS` | — | Blender skill search roots |
 | `DCC_MCP_SKILL_PATHS` | — | Global fallback skill search roots |

--- a/packaging/addon_entry/__init__.py
+++ b/packaging/addon_entry/__init__.py
@@ -87,7 +87,6 @@ def _start_server_with_host():
     dispatcher = BlenderUiDispatcher()
     try:
         server = start_server(
-            port=_env_port("DCC_MCP_BLENDER_PORT", 8765),
             gateway_port=_env_port("DCC_MCP_GATEWAY_PORT", _DEFAULT_GATEWAY_PORT),
             registry_dir=os.environ.get("DCC_MCP_REGISTRY_DIR") or None,
             dispatcher=dispatcher,

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -44,7 +44,7 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.19.42"
+MIN_CORE_VERSION = "0.19.45"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
 

--- a/packaging/release_smoke_checklist.md
+++ b/packaging/release_smoke_checklist.md
@@ -32,18 +32,21 @@ This checklist validates the GUI Extension install path for Blender 4.2+.
 - [ ] Enable the **DCC MCP Blender** extension
 - [ ] Check Blender console / Info area:
   ```
-  [DCC MCP Blender] Server started — http://127.0.0.1:8765/mcp
+  [DCC MCP Blender] Server started — http://127.0.0.1:<assigned-port>/mcp
   ```
-- [ ] Navigate to `http://127.0.0.1:8765/mcp` in a browser —
+- [ ] Record the exact URL from the log or `dcc-mcp-cli list`; do not assume a
+  fixed instance port.
+- [ ] Navigate to `<instance-url>/mcp` in a browser —
   expect `{"jsonrpc":"2.0","error":...}` (valid MCP endpoint, not a connection error)
-- [ ] Navigate to `http://127.0.0.1:8765/health` — expect HTTP 200
-- [ ] Navigate to `http://127.0.0.1:8765/docs` — expect OpenAPI docs page
+- [ ] Navigate to `<instance-url>/health` — expect HTTP 200
+- [ ] Navigate to `<instance-url>/docs` — expect OpenAPI docs page
 
 ## 3. MCP Initialize Handshake
 
 - [ ] Send an MCP `initialize` request and verify server info:
   ```python
-  import urllib.request, json
+  import os, urllib.request, json
+  base = os.environ["BLENDER_MCP_BASE_URL"].rstrip("/")
   body = json.dumps({
       "jsonrpc": "2.0",
       "id": 0,
@@ -55,7 +58,7 @@ This checklist validates the GUI Extension install path for Blender 4.2+.
       }
   }).encode()
   req = urllib.request.Request(
-      "http://127.0.0.1:8765/mcp", data=body,
+      f"{base}/mcp", data=body,
       headers={"Content-Type": "application/json",
                "Accept": "application/json, text/event-stream"},
       method="POST"
@@ -71,7 +74,7 @@ This checklist validates the GUI Extension install path for Blender 4.2+.
   ```python
   body = json.dumps({"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}).encode()
   req = urllib.request.Request(
-      "http://127.0.0.1:8765/mcp", data=body,
+      f"{base}/mcp", data=body,
       headers={"Content-Type": "application/json",
                "Accept": "application/json, text/event-stream"},
       method="POST"
@@ -94,7 +97,7 @@ fail with `THREAD_AFFINITY_UNAVAILABLE`.
       "params": {"name": "get_scene_info", "arguments": {}}
   }).encode()
   req = urllib.request.Request(
-      "http://127.0.0.1:8765/mcp", data=body,
+      f"{base}/mcp", data=body,
       headers={"Content-Type": "application/json",
                "Accept": "application/json, text/event-stream"},
       method="POST"
@@ -114,7 +117,7 @@ fail with `THREAD_AFFINITY_UNAVAILABLE`.
                  "arguments": {"object_type": "cube", "name": "SmokeCube"}}
   }).encode()
   req = urllib.request.Request(
-      "http://127.0.0.1:8765/mcp", data=body,
+      f"{base}/mcp", data=body,
       headers={"Content-Type": "application/json",
                "Accept": "application/json, text/event-stream"},
       method="POST"
@@ -135,7 +138,7 @@ fail with `THREAD_AFFINITY_UNAVAILABLE`.
 
 - [ ] Check `/v1/readyz` returns all-green:
   ```python
-  req = urllib.request.Request("http://127.0.0.1:8765/v1/readyz")
+  req = urllib.request.Request(f"{base}/v1/readyz")
   resp = json.loads(urllib.request.urlopen(req, timeout=5).read())
   print(json.dumps(resp, indent=2))
   assert resp.get("process") is True, "process bit should be True"
@@ -154,7 +157,7 @@ fail with `THREAD_AFFINITY_UNAVAILABLE`.
 ## 7. Graceful Shutdown & Restart
 
 - [ ] Disable the **DCC MCP Blender** extension in Preferences → Extensions
-- [ ] Confirm server port is released (no HTTP response on `http://127.0.0.1:8765`)
+- [ ] Confirm the recorded instance URL no longer responds.
 - [ ] Re-enable the extension and verify server restarts cleanly
 - [ ] Verify `/v1/readyz` goes through the green transition again
 
@@ -165,7 +168,7 @@ If two Blender instances are available:
 - [ ] Start Blender #1 with the extension enabled — verify it becomes gateway
 - [ ] Start Blender #2 with the extension enabled —
   verify it registers on an ephemeral port
-- [ ] Check `http://127.0.0.1:8765/gateway/instances` — both should appear
+- [ ] Run `dcc-mcp-cli list` — both instances and distinct direct URLs should appear
 - [ ] Close Blender #1 — verify Blender #2 takes over gateway port
 
 ---
@@ -176,9 +179,9 @@ Save as `smoke_test.py` and run against a running Blender instance:
 
 ```python
 """Quick MCP smoke test — requires requests: pip install requests"""
-import json, sys, requests
+import json, os, sys, requests
 
-BASE = "http://127.0.0.1:8765"
+BASE = os.environ["BLENDER_MCP_BASE_URL"].rstrip("/")
 HEADERS = {
     "Content-Type": "application/json",
     "Accept": "application/json, text/event-stream",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
 ]
 
 dependencies = [
-    # v0.19.42: reserved request metadata is isolated from skill kwargs.
-    "dcc-mcp-core>=0.19.42,<1.0.0",
+    # v0.19.45: instance ports default to operating-system assignment.
+    "dcc-mcp-core>=0.19.45,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/skills/dcc-mcp-blender-setup/SKILL.md
+++ b/skills/dcc-mcp-blender-setup/SKILL.md
@@ -84,21 +84,21 @@ python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py --blender-p
 
 ## MCP Configuration
 
-Blender uses first-wins auto-gateway on port `8765`. Configure the MCP host
-with:
+Blender instances use OS-assigned ports. Configure the MCP host with the stable
+local gateway:
 
 ```json
 {
   "mcpServers": {
     "blender": {
-      "url": "http://127.0.0.1:8765/mcp"
+      "url": "http://127.0.0.1:9765/mcp"
     }
   }
 }
 ```
 
-When multiple Blender instances run, the first to bind `8765` becomes the
-gateway and later instances register behind it; point your host at `8765`.
+Multiple Blender instances register their exact endpoints automatically; use
+`dcc-mcp-cli list` when a direct URL is required.
 
 When editing an existing MCP config, preserve unrelated servers. Merge only the
 `blender` server entry unless the user asks for a different server name.
@@ -115,7 +115,7 @@ After pip setup and MCP JSON generation, tell the user:
 5. The embedded MCP server starts automatically; use the top-bar
    `DCC MCP > Show Server URLs…` menu to confirm the URL.
 
-The expected URL is `http://127.0.0.1:8765/mcp`.
+The stable gateway URL is `http://127.0.0.1:9765/mcp`.
 
 For pip/CI installs without the add-on, start the server from Blender's Python
 console instead:

--- a/skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py
+++ b/skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py
@@ -12,8 +12,7 @@ import sys
 from pathlib import Path
 from typing import Iterable, Optional
 
-
-DEFAULT_MCP_URL = "http://127.0.0.1:8765/mcp"
+DEFAULT_MCP_URL = "http://127.0.0.1:9765/mcp"
 
 
 def run(command: list[str], cwd: Optional[Path] = None) -> None:

--- a/src/dcc_mcp_blender/_core_compat.py
+++ b/src/dcc_mcp_blender/_core_compat.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from typing import Optional
 
-MIN_CORE_VERSION = "0.19.42"
+MIN_CORE_VERSION = "0.19.45"
 
 
 def _release_tuple(version: str) -> tuple[int, int, int]:

--- a/src/dcc_mcp_blender/blender_bootstrap.py
+++ b/src/dcc_mcp_blender/blender_bootstrap.py
@@ -6,13 +6,15 @@ Run with:
 
 from __future__ import annotations
 
+from typing import Optional
+
 from dcc_mcp_core.host import BlockingDispatcher
 
 from dcc_mcp_blender.host import BlenderHost
 from dcc_mcp_blender.server import BlenderMcpServer
 
 
-def main(port: int = 18765) -> None:
+def main(port: Optional[int] = None) -> None:
     """Start the MCP server and block while Blender services dispatcher ticks."""
     dispatcher = BlockingDispatcher()
     server = BlenderMcpServer(port=port, dispatcher=dispatcher)

--- a/src/dcc_mcp_blender/server.py
+++ b/src/dcc_mcp_blender/server.py
@@ -10,7 +10,7 @@ Usage (inside Blender Python console or startup script)::
 
     import dcc_mcp_blender
 
-    # Start with default port (auto-gateway: first instance wins 8765)
+    # Start with an OS-assigned instance port and discover it through the gateway.
     server = dcc_mcp_blender.start_server()
 
     # Progressive loading — discover skills without loading them immediately
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 
 SERVER_NAME = "dcc-mcp-blender"
 SERVER_VERSION = __version__
-DEFAULT_PORT = 8765
+DEFAULT_PORT = 0
 
 # Built-in skills directory shipped with this package
 _BUILTIN_SKILLS_DIR = Path(__file__).resolve().parent / "skills"
@@ -82,7 +82,7 @@ def _host_dispatcher_from(dispatcher: Any) -> Any | None:
 class BlenderServerOptions:
     """Adapter-local options collapsed for the dcc-mcp-core 0.17+ server contract."""
 
-    port: int = DEFAULT_PORT
+    port: Optional[int] = None
     extra_skill_paths: Optional[List[str]] = None
     server_name: str = SERVER_NAME
     server_version: str = SERVER_VERSION
@@ -166,10 +166,8 @@ class BlenderMcpServer(DccServerBase):
 
     Multi-instance / gateway
     ------------------------
-    dcc-mcp-core implements an **auto-gateway** with first-wins port competition:
-    the first Blender process to bind the well-known port (8765) becomes the
-    gateway; subsequent instances start on ephemeral ports and register
-    themselves automatically.
+    Each Blender process binds an OS-assigned instance port and registers its
+    exact endpoint with the stable local gateway.
 
     Progressive loading
     -------------------
@@ -186,7 +184,7 @@ class BlenderMcpServer(DccServerBase):
 
     def __init__(
         self,
-        port: int = DEFAULT_PORT,
+        port: Optional[int] = None,
         extra_skill_paths: Optional[List[str]] = None,
         server_name: str = SERVER_NAME,
         server_version: str = SERVER_VERSION,
@@ -641,7 +639,7 @@ _server_instance: Optional[BlenderMcpServer] = None
 
 
 def start_server(
-    port: int = DEFAULT_PORT,
+    port: Optional[int] = None,
     extra_skill_paths: Optional[List[str]] = None,
     register_builtins: bool = True,
     include_bundled: bool = True,
@@ -664,12 +662,10 @@ def start_server(
 
     Multi-instance support (gateway mode)
     --------------------------------------
-    dcc-mcp-core implements first-wins port competition: if port 8765 is already
-    taken by another Blender process, this instance starts on a random port and
-    registers with the gateway automatically.
+    Every instance uses an OS-assigned port and registers with the gateway.
 
     Args:
-        port: Preferred TCP port (default 8765; use 0 for a random port).
+        port: Explicit TCP port, or ``None`` to let core resolve the environment/default.
         extra_skill_paths: Additional skill directories beyond built-ins.
         register_builtins: If ``True``, discover and load all skills.
         include_bundled: Include dcc-mcp-core bundled skills.

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -156,7 +156,7 @@ def test_addon_register_starts_server_with_core_backed_blender_ui_dispatcher(mon
     monkeypatch.setattr(server_mod, "get_server", lambda: None)
     monkeypatch.setattr(server_mod, "start_server", _start_server)
     monkeypatch.setattr(server_mod, "stop_server", lambda: calls.append(("stop_server", None)))
-    monkeypatch.setenv("DCC_MCP_BLENDER_PORT", "0")
+    monkeypatch.setenv("DCC_MCP_BLENDER_PORT", "18765")
     monkeypatch.setenv("DCC_MCP_GATEWAY_PORT", "19765")
     monkeypatch.setenv("DCC_MCP_REGISTRY_DIR", "/tmp/dcc-mcp-registry")
 
@@ -166,7 +166,6 @@ def test_addon_register_starts_server_with_core_backed_blender_ui_dispatcher(mon
     assert len(menu_callbacks) == 1
     assert [call[0] for call in calls] == ["start_server", "dispatcher.start"]
     assert calls[0][1] == {
-        "port": 0,
         "gateway_port": 19765,
         "registry_dir": "/tmp/dcc-mcp-registry",
         "dispatcher": calls[1][1],

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -19,10 +19,10 @@ def _load_assemble_zip_module():
     return mod
 
 
-def test_core_dependency_floor_is_01942():
+def test_core_dependency_floor_is_01945():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert '"dcc-mcp-core>=0.19.42,<1.0.0"' in pyproject
+    assert '"dcc-mcp-core>=0.19.45,<1.0.0"' in pyproject
 
 
 def test_packaging_core_floor_matches_pyproject():
@@ -43,4 +43,4 @@ def test_preloaded_core_below_floor_is_rejected():
 def test_preloaded_core_at_floor_is_accepted():
     from dcc_mcp_blender._core_compat import require_compatible_core
 
-    require_compatible_core("0.19.42", module_path="/extension/site-packages/dcc_mcp_core")
+    require_compatible_core("0.19.45", module_path="/extension/site-packages/dcc_mcp_core")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -30,6 +30,12 @@ class TestBlenderMcpServerBasic:
         server = BlenderMcpServer()
         assert server.port == DEFAULT_PORT
 
+    def test_explicit_zero_port_overrides_environment(self, monkeypatch):
+        from dcc_mcp_blender.server import BlenderServerOptions
+
+        monkeypatch.setenv("DCC_MCP_BLENDER_PORT", "18765")
+        assert BlenderServerOptions(port=0).to_core_options().port == 0
+
     def test_custom_port(self):
         from dcc_mcp_blender.server import BlenderMcpServer
 

--- a/tests/test_workflow_ci.py
+++ b/tests/test_workflow_ci.py
@@ -42,6 +42,18 @@ def test_workflow_server_uses_blender_inprocess_dispatcher():
     assert "host.stop()" in text
 
 
+def test_connectivity_checks_use_the_os_assigned_server_url():
+    workflow = E2E_WORKFLOW.read_text(encoding="utf-8")
+    launcher = START_MCP_SERVER.read_text(encoding="utf-8")
+
+    assert 'Path(os.environ.get("RUNNER_TEMP", "/tmp")) / "mcp_server_url"' in launcher
+    assert "url_file.write_text(server.mcp_url" in launcher
+    assert 'MCP_SERVER_URL="$(<"$MCP_URL_FILE")"' in workflow
+    assert "url = os.environ['MCP_SERVER_URL']" in workflow
+    assert '--http-url "$MCP_SERVER_URL"' in workflow
+    assert "http://127.0.0.1:8765/mcp" not in workflow
+
+
 def test_execute_python_smoke_call_avoids_shell_key_value_assignment():
     text = E2E_WORKFLOW.read_text(encoding="utf-8")
 

--- a/tests/test_workflow_ci.py
+++ b/tests/test_workflow_ci.py
@@ -37,7 +37,7 @@ def test_workflow_server_uses_blender_inprocess_dispatcher():
     assert ".github/scripts/start_mcp_server.py" in workflow
     assert "from dcc_mcp_blender.host import BlenderCallableDispatcher, BlenderHost" in text
     assert "dispatcher = BlenderCallableDispatcher()" in text
-    assert "dcc_mcp_blender.start_server(port=8765, dispatcher=dispatcher)" in text
+    assert "dcc_mcp_blender.start_server(dispatcher=dispatcher)" in text
     assert "host.run_headless(stop_event=stop_event)" in text
     assert "host.stop()" in text
 

--- a/tools/blender-dev-build-link-core-win.ps1
+++ b/tools/blender-dev-build-link-core-win.ps1
@@ -213,8 +213,8 @@ try {
 Write-Host ""
 Write-Host "Done. Start Blender $BlenderVersion → Edit → Preferences → Add-ons → Enable 'DCC MCP Blender'." -ForegroundColor Cyan
 Write-Host ""
-Write-Host "MCP (Streamable HTTP, default):" -ForegroundColor Cyan
-Write-Host "   http://127.0.0.1:8765/mcp"
+Write-Host "MCP instance: OS-assigned; inspect the Blender log or run dcc-mcp-cli list" -ForegroundColor Cyan
+Write-Host "Gateway: http://127.0.0.1:9765/mcp" -ForegroundColor Cyan
 Write-Host "Docs: See dcc-mcp-blender docs for Cursor/Bender MCP setup" -ForegroundColor Gray
 
 if ($LaunchBlender) {


### PR DESCRIPTION
## Summary
- delegate the default MCP instance listener to the OS with port 0
- preserve explicit fixed-port arguments and DCC-specific environment overrides
- keep the stable gateway control-plane port unchanged
- require dcc-mcp-core 0.19.45 for the shared dynamic-port contract

## Validation
- 470 tests passed; Ruff passed
- fresh no-cache PyPI install verified dcc-mcp-core 0.19.45 and dcc-mcp-server 0.19.45
- two same-type instances received distinct ports and were discoverable by both the local CLI and gateway