### PR TITLE
fix(physics): activate objects through the view layer

### DIFF
--- a/src/dcc_mcp_blender/_physics_ops.py
+++ b/src/dcc_mcp_blender/_physics_ops.py
@@ -53,7 +53,6 @@ def _activate_object(bpy, obj) -> None:
     except Exception:
         pass
     bpy.context.view_layer.objects.active = obj
-    bpy.context.active_object = obj
 
 
 def _objects(bpy) -> Iterable[Any]:

--- a/tests/test_skills_physics.py
+++ b/tests/test_skills_physics.py
@@ -480,6 +480,36 @@ class TestRigidBodyConstraints:
 
 
 class TestForceFields:
+    def test_adds_force_field_with_read_only_active_object_context(self):
+        bpy = make_mock_bpy()
+        obj = _make_obj()
+        obj.field = SimpleNamespace(type="FORCE", strength=1.0, falloff_power=2.0)
+        bpy.data.objects.get.return_value = obj
+
+        class ReadOnlyActiveObjectContext:
+            def __init__(self, view_layer):
+                self.view_layer = view_layer
+
+            @property
+            def active_object(self):
+                return None
+
+            @active_object.setter
+            def active_object(self, _value):
+                raise AttributeError('Context property "active_object" is read-only')
+
+        bpy.context = ReadOnlyActiveObjectContext(bpy.context.view_layer)
+
+        result = load_and_call(
+            "blender-physics/scripts/add_force_field.py",
+            bpy,
+            object_name="Cube",
+            field_type="TURBULENCE",
+        )
+
+        assert result["success"] is True, result
+        assert bpy.context.view_layer.objects.active is obj
+
     def test_adds_force_field(self):
         bpy = make_mock_bpy()
         obj = _make_obj()


### PR DESCRIPTION
## Summary
- stop assigning Blender's read-only context.active_object property
- keep the supported view-layer active-object assignment
- add a regression test using a read-only active-object context

## Validation
- 472 passed, 19 skipped
- physics skill tests: 33 passed
- ruff: passed