### PR TITLE
docs: document CLI-first agent workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 ## Agent Control Path
 
 AI agent runtimes default to the shared gateway through the
-`dcc-cli-gateway` skill and `dcc-mcp-cli` REST commands:
+`dcc-mcp` skill and `dcc-mcp-cli` REST commands:
 
 ```bash
 dcc-mcp-cli search --query "<task>" --dcc-type blender
@@ -17,6 +17,20 @@ dcc-mcp-cli call <tool-slug> --json '{"key":"value"}'
 Use `dcc-mcp-cli list` for live instances and `dcc-mcp-cli dcc-types` for
 release-catalog support. IDE users may continue to configure the gateway MCP
 endpoint; adapter-local Python start APIs are for host bootstrap and tests.
+
+### CLI availability and updates
+
+If `dcc-mcp-cli` is missing, obtain user consent before using the official
+install commands in the README Agent workflow. Keep an official build current
+with:
+
+```bash
+dcc-mcp-cli update check
+dcc-mcp-cli update apply
+```
+
+`update apply` stages the latest CLI for the next launch; it does not replace
+a running server.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,30 @@
 AI agents should use the shared gateway through `dcc-mcp-cli`; IDE users may
 continue to use the MCP endpoint. Prefer typed skills and tools over raw scripts.
 
+### Install or update the CLI
+
+`dcc-mcp-cli` is the preferred control path for every shell-capable agent. If
+it is missing, ask the user before installing the latest official release:
+
+```bash
+# Linux/macOS
+curl -fsSL https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.sh | sh
+
+# Windows PowerShell
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-core/main/scripts/install-cli.ps1 | iex"
+```
+
+Keep an official build current through the release manifest:
+
+```bash
+dcc-mcp-cli update check
+dcc-mcp-cli update apply
+```
+
+`update apply` downloads and stages the latest CLI for the next launch. It
+does not update a running `dcc-mcp-server`; update that server in its own
+environment.
+
 ```bash
 dcc-mcp-cli dcc-types
 dcc-mcp-cli list


### PR DESCRIPTION
## Summary
- document dcc-mcp-cli as the preferred agent control path
- add official installation and self-update commands
- clarify that server updates remain environment-scoped

## Validation
- documentation content and diff audit