### PR TITLE
fix: reject retired capture helper bundles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ a running server.
 `dcc-mcp-blender` embeds a standards-compliant MCP Streamable HTTP server directly inside Blender. It exposes 200+ Blender operations as MCP tools that any AI agent (Claude, Gemini, Cursor, etc.) can call over HTTP — no external gateway, no subprocess bridge.
 
 **Current version:** 0.1.20 <!-- x-release-please-version -->
-**Core dependency:** `dcc-mcp-core>=0.19.45,<1.0.0`
+**Core dependency:** `dcc-mcp-core>=0.19.63,<1.0.0`
 **Python:** 3.10+ (bundled with Blender)
 **Blender:** 3.6 LTS, 4.2 LTS, 4.3, 4.4
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ attach a stable session id with `--meta-json`, query `dcc-mcp-cli stats --range 
 [![GitHub release downloads](https://img.shields.io/github/downloads/dcc-mcp/dcc-mcp-blender/total.svg?label=release%20downloads)](https://github.com/dcc-mcp/dcc-mcp-blender/releases)
 [![GitHub Release](https://img.shields.io/github/v/release/dcc-mcp/dcc-mcp-blender.svg)](https://github.com/dcc-mcp/dcc-mcp-blender/releases)
 [![Coverage](https://img.shields.io/badge/coverage-pytest--cov-blue.svg)](https://github.com/dcc-mcp/dcc-mcp-blender/blob/main/pyproject.toml)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.19.45-blue.svg)](https://github.com/dcc-mcp/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.19.63-blue.svg)](https://github.com/dcc-mcp/dcc-mcp-core)
 [![Blender](https://img.shields.io/badge/Blender-3.6%20LTS%20%7C%204.2%20LTS%20%7C%204.3%20%7C%204.4-orange.svg)](https://www.blender.org/download/releases/)
 [![MCP](https://img.shields.io/badge/MCP-2025--03--26-purple.svg)](https://modelcontextprotocol.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -44,9 +44,10 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.19.45"
+MIN_CORE_VERSION = "0.19.63"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
+REMOVED_CAPTURE_HELPER = "dcc-mcp-capture-helper.exe"
 
 # PyPI ships ``cp38-abi3-*`` wheels (stable ABI) for win/linux/macos — not cp311-tagged wheels.
 # Match platform first, then prefer stable abi3 builds.
@@ -206,6 +207,27 @@ def download_core_wheel(version: str, platform: str, dest_dir: pathlib.Path) -> 
     return dest
 
 
+def validate_core_wheel(wheel_path: pathlib.Path) -> None:
+    """Reject Core wheels containing the retired standalone capture helper."""
+    try:
+        with zipfile.ZipFile(wheel_path) as archive:
+            removed_members = [
+                name
+                for name in archive.namelist()
+                if pathlib.PurePosixPath(name.replace("\\", "/")).name.lower()
+                == REMOVED_CAPTURE_HELPER
+            ]
+    except zipfile.BadZipFile as exc:
+        raise RuntimeError(f"Invalid dcc-mcp-core wheel: {wheel_path.name}") from exc
+
+    if removed_members:
+        members = ", ".join(sorted(removed_members))
+        raise RuntimeError(
+            "Refusing to bundle dcc-mcp-core wheel containing the removed "
+            f"capture helper ({members})"
+        )
+
+
 def extract_wheel(wheel_path: pathlib.Path, dest_dir: pathlib.Path) -> None:
     """Extract a wheel into dest_dir, skipping .dist-info."""
     with zipfile.ZipFile(wheel_path, "r") as zf:
@@ -275,6 +297,7 @@ def assemble(platform: str, output_dir: pathlib.Path) -> pathlib.Path:
         core_version = resolve_core_version()
         wheels_dir = tmp_dir / "wheels"
         wheel = download_core_wheel(core_version, platform, wheels_dir)
+        validate_core_wheel(wheel)
         wheels_out = addon_dir / "wheels"
         wheels_out.mkdir(parents=True, exist_ok=True)
         staged_wheel = wheels_out / wheel.name

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -214,18 +214,14 @@ def validate_core_wheel(wheel_path: pathlib.Path) -> None:
             removed_members = [
                 name
                 for name in archive.namelist()
-                if pathlib.PurePosixPath(name.replace("\\", "/")).name.lower()
-                == REMOVED_CAPTURE_HELPER
+                if pathlib.PurePosixPath(name.replace("\\", "/")).name.lower() == REMOVED_CAPTURE_HELPER
             ]
     except zipfile.BadZipFile as exc:
         raise RuntimeError(f"Invalid dcc-mcp-core wheel: {wheel_path.name}") from exc
 
     if removed_members:
         members = ", ".join(sorted(removed_members))
-        raise RuntimeError(
-            "Refusing to bundle dcc-mcp-core wheel containing the removed "
-            f"capture helper ({members})"
-        )
+        raise RuntimeError(f"Refusing to bundle dcc-mcp-core wheel containing the removed capture helper ({members})")
 
 
 def extract_wheel(wheel_path: pathlib.Path, dest_dir: pathlib.Path) -> None:

--- a/packaging/release_smoke_checklist.md
+++ b/packaging/release_smoke_checklist.md
@@ -16,6 +16,16 @@ This checklist validates the GUI Extension install path for Blender 4.2+.
   python packaging/assemble_zip.py --platform win64 --output-dir dist_addon/
   ```
 
+## 0. Windows Security Gate
+
+- [ ] Confirm the nested Core wheel does not contain the retired
+  `dcc-mcp-capture-helper.exe`. The package assembler enforces this
+  automatically and must fail closed if the file is present.
+- [ ] Scan the final Windows release ZIP on a clean, Defender-enabled Windows
+  host and record the Defender engine/signature versions with the result.
+- [ ] Do not publish when Defender reports a detection. Preserve the exact ZIP
+  and nested member path for false-positive submission and investigation.
+
 ## 1. Extension Install from Disk
 
 - [ ] Open Blender with a clean profile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
 ]
 
 dependencies = [
-    # v0.19.45: instance ports default to operating-system assignment.
-    "dcc-mcp-core>=0.19.45,<1.0.0",
+    # v0.19.63: the retired standalone capture helper is no longer bundled.
+    "dcc-mcp-core>=0.19.63,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -10,6 +10,8 @@ import sys
 import zipfile
 from types import SimpleNamespace
 
+import pytest
+
 ROOT = pathlib.Path(__file__).parent.parent
 ADDON_ENTRY = ROOT / "packaging" / "addon_entry" / "__init__.py"
 
@@ -38,6 +40,13 @@ def _manifest_wheels(manifest: str):
     return re.findall(r'"\.\/(wheels\/dcc_mcp_core-[^"]+\.whl)"', manifest)
 
 
+def _write_fake_core_wheel(path: pathlib.Path, members: tuple[str, ...] = ()) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("dcc_mcp_core/__init__.py", "")
+        for member in members:
+            archive.writestr(member, b"MZ")
+
+
 def test_addon_entry_bl_info_version_is_static_tuple_literal():
     """Blender parses ``bl_info`` via AST, so version must not be computed."""
     tree = ast.parse(ADDON_ENTRY.read_text(encoding="utf-8"))
@@ -56,7 +65,7 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     """The add-on package root must directly contain ``server.py`` and skills."""
     assemble_zip = _load_assemble_zip_module()
     fake_wheel = tmp_path / "dcc_mcp_core-0.19.17-cp38-abi3-win_amd64.whl"
-    fake_wheel.write_bytes(b"fake wheel")
+    _write_fake_core_wheel(fake_wheel)
 
     monkeypatch.setattr(assemble_zip, "resolve_core_version", lambda min_version="0.19.17": "0.19.17")
     monkeypatch.setattr(assemble_zip, "download_core_wheel", lambda version, platform, dest_dir: fake_wheel)
@@ -105,6 +114,47 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     ]
     assert core_import_lines
     assert gate_call.lineno < min(core_import_lines)
+
+
+def test_validate_core_wheel_rejects_removed_capture_helper(tmp_path):
+    assemble_zip = _load_assemble_zip_module()
+    wheel = tmp_path / "dcc_mcp_core-0.19.63-cp38-abi3-win_amd64.whl"
+    _write_fake_core_wheel(
+        wheel,
+        ("dcc_mcp_core/bin/dcc-mcp-capture-helper.exe",),
+    )
+
+    with pytest.raises(RuntimeError, match="removed capture helper"):
+        assemble_zip.validate_core_wheel(wheel)
+
+
+def test_validate_core_wheel_accepts_current_ui_control_host(tmp_path):
+    assemble_zip = _load_assemble_zip_module()
+    wheel = tmp_path / "dcc_mcp_core-0.19.69-cp38-abi3-win_amd64.whl"
+    _write_fake_core_wheel(
+        wheel,
+        ("dcc_mcp_core/bin/dcc-mcp-ui-control-host.exe",),
+    )
+
+    assemble_zip.validate_core_wheel(wheel)
+
+
+def test_assemble_rejects_core_wheel_with_removed_capture_helper(tmp_path, monkeypatch):
+    assemble_zip = _load_assemble_zip_module()
+    wheel = tmp_path / "dcc_mcp_core-0.19.63-cp38-abi3-win_amd64.whl"
+    _write_fake_core_wheel(
+        wheel,
+        ("dcc_mcp_core/bin/dcc-mcp-capture-helper.exe",),
+    )
+    monkeypatch.setattr(assemble_zip, "resolve_core_version", lambda: "0.19.63")
+    monkeypatch.setattr(
+        assemble_zip,
+        "download_core_wheel",
+        lambda version, platform, dest_dir: wheel,
+    )
+
+    with pytest.raises(RuntimeError, match="removed capture helper"):
+        assemble_zip.assemble(platform="win64", output_dir=tmp_path)
 
 
 def test_addon_register_starts_server_with_core_backed_blender_ui_dispatcher(monkeypatch):

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -19,10 +19,10 @@ def _load_assemble_zip_module():
     return mod
 
 
-def test_core_dependency_floor_is_01945():
+def test_core_dependency_floor_is_01963():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert '"dcc-mcp-core>=0.19.45,<1.0.0"' in pyproject
+    assert '"dcc-mcp-core>=0.19.63,<1.0.0"' in pyproject
 
 
 def test_packaging_core_floor_matches_pyproject():
@@ -43,4 +43,4 @@ def test_preloaded_core_below_floor_is_rejected():
 def test_preloaded_core_at_floor_is_accepted():
     from dcc_mcp_blender._core_compat import require_compatible_core
 
-    require_compatible_core("0.19.45", module_path="/extension/site-packages/dcc_mcp_core")
+    require_compatible_core("0.19.63", module_path="/extension/site-packages/dcc_mcp_core")


### PR DESCRIPTION
Fixes #166.

- require Core 0.19.63 or newer
- reject nested Core wheels that contain the retired capture helper
- add regression coverage and a Defender-enabled release gate

Validation:
- focused packaging/version tests pass
- non-Blender test suite passes
- Ruff and Skill lint pass
- Windows package assembled with Core 0.19.69; retired helper absent

Defender scanning remains a release gate because the local validation host has Defender disabled.
