### PR TITLE
fix: preserve MCP dispatcher timer after new_scene factory reset

### DIFF
--- a/src/dcc_mcp_blender/_readiness.py
+++ b/src/dcc_mcp_blender/_readiness.py
@@ -159,6 +159,28 @@ class ReadinessBinder:
         if value:
             logger.info("[blender] readiness: dcc-ready — main thread is pumping")
 
+    def revalidate_dispatcher(self) -> bool:
+        """Re-probe the dispatcher after a scene reset that may have wiped timers.
+
+        Resets the ``dcc`` readiness bit and schedules a new main-thread probe.
+        Callers (e.g. ``new_scene``) should have already re-registered the timer
+        pump before invoking this.
+
+        Returns:
+            ``True`` if a probe was scheduled, ``False`` if no dispatcher is bound.
+        """
+        if self.bound_dispatcher is None:
+            return False
+        # Mark dcc as not ready until the new probe completes.
+        self.mark_dcc_ready(False)
+        try:
+            self.dcc_scheduled = bool(self.probe_scheduler(self.bound_dispatcher, self.mark_dcc_ready))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[blender] readiness: revalidate probe scheduler raised: %s", exc)
+            self.mark_dcc_ready()
+            self.dcc_scheduled = True
+        return self.dcc_scheduled
+
 
 def install_readiness(
     server: Any,

--- a/src/dcc_mcp_blender/host.py
+++ b/src/dcc_mcp_blender/host.py
@@ -49,6 +49,21 @@ class BlenderTimerPump:
         """Return whether a timer callback is currently registered."""
         return self._registered_fn is not None
 
+    def verify_installed(self) -> bool:
+        """Check with Blender's timer API whether the callback is still registered.
+
+        After ``bpy.ops.wm.read_factory_settings(use_empty=True)`` Blender wipes all
+        registered timers without notifying our Python objects.  This method queries
+        ``bpy.app.timers.is_registered`` directly so health checks can distinguish
+        "port open but dispatcher dead" from fully functional.
+        """
+        tick_fn = self._registered_fn
+        if tick_fn is None:
+            return False
+        import bpy
+
+        return bpy.app.timers.is_registered(tick_fn)
+
     def install(self, tick_fn: TickFn) -> None:
         """Register ``tick_fn`` with Blender's timer API."""
         if self._registered_fn is not None:

--- a/src/dcc_mcp_blender/skills/blender-scene/scripts/new_scene.py
+++ b/src/dcc_mcp_blender/skills/blender-scene/scripts/new_scene.py
@@ -1,8 +1,53 @@
-"""Create a new empty Blender scene."""
+"""Create a new empty Blender scene.
+
+After ``read_factory_settings`` Blender wipes all registered timers — including
+the MCP main-thread dispatcher pump.  This module restores the pump so subsequent
+tool calls succeed without restarting Blender.
+"""
 
 from __future__ import annotations
 
+import logging
+
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+logger = logging.getLogger(__name__)
+
+
+def _preserve_mcp_dispatcher() -> None:
+    """Re-register the MCP main-thread dispatcher timer after Blender factory reset.
+
+    ``bpy.ops.wm.read_factory_settings(use_empty=True)`` unregisters all
+    ``bpy.app.timers`` callbacks including the dispatcher pump.  The HTTP
+    server stays alive (port remains open) but subsequent tool calls hang
+    because the queue is never drained.
+
+    This is best-effort — it must not raise or the ``new_scene`` operation
+    would fail with a half-applied factory reset.
+    """
+    try:
+        from dcc_mcp_blender.server import get_server
+
+        server = get_server()
+        if server is None:
+            return
+
+        dispatcher = getattr(server, "_blender_dispatcher", None)
+        if dispatcher is None:
+            return
+
+        start_pump = getattr(dispatcher, "start_pump", None)
+        if callable(start_pump):
+            start_pump()
+            logger.info("new_scene: re-registered MCP dispatcher timer after factory reset")
+
+        # Re-run the readiness probe so /v1/readyz reflects the restored pump.
+        readiness = getattr(server, "readiness", None)
+        if readiness is not None and hasattr(readiness, "revalidate_dispatcher"):
+            readiness.revalidate_dispatcher()
+    except Exception:
+        # Best-effort: never let dispatcher preservation break new_scene.
+        logger.debug("new_scene: dispatcher preservation skipped", exc_info=True)
 
 
 def new_scene() -> dict:
@@ -15,6 +60,7 @@ def new_scene() -> dict:
         import bpy
 
         bpy.ops.wm.read_factory_settings(use_empty=True)
+        _preserve_mcp_dispatcher()
         return skill_success(
             "New scene created",
             prompt="Check the result with list_objects or use related actions to continue.",

--- a/tests/e2e/test_scene_e2e.py
+++ b/tests/e2e/test_scene_e2e.py
@@ -75,6 +75,46 @@ class TestSceneSkillsE2E:
         # Scene should be empty
         assert len(bpy.data.objects) == 0
 
+    def test_new_scene_preserves_dispatcher(self):
+        """Regression: new_scene must not wipe the MCP main-thread dispatcher.
+
+        After ``read_factory_settings(use_empty=True)`` the dispatcher timer
+        is re-registered so subsequent main-thread tool calls succeed without
+        restarting Blender.  Failure mode: second call hangs or times out.
+        """
+        # Prime: create an object so we have something to query.
+        bpy.ops.mesh.primitive_cube_add()
+
+        # Step 1 — new_scene (this internally calls read_factory_settings +
+        # the dispatcher preservation logic).
+        mod_scene = load_skill("blender-scene", "new_scene")
+        result = mod_scene.new_scene()
+        assert result["success"] is True
+
+        # Step 2 — immediate main-thread tool call (must NOT hang).
+        mod_list = load_skill("blender-scene", "list_objects")
+        result2 = mod_list.list_objects()
+        assert result2["success"] is True
+        # Factory-reset scene has zero objects.
+        assert result2["context"]["count"] == 0
+
+        # Step 3 — verify the dispatcher timer is actually installed.
+        try:
+            from dcc_mcp_blender.server import get_server
+
+            server = get_server()
+            if server is not None:
+                dispatcher = getattr(server, "_blender_dispatcher", None)
+                if dispatcher is not None:
+                    pump = getattr(dispatcher, "pump", None)
+                    if pump is not None and hasattr(pump, "verify_installed"):
+                        assert pump.verify_installed(), (
+                            "Dispatcher timer is not registered with bpy.app.timers "
+                            "after new_scene"
+                        )
+        except ImportError:
+            pass  # server module not importable in --background without addon
+
     def test_get_scene_info_structure(self):
         bpy.ops.mesh.primitive_cube_add()
         mod = load_skill("blender-scene", "get_scene_info")

--- a/tests/e2e/test_scene_e2e.py
+++ b/tests/e2e/test_scene_e2e.py
@@ -109,8 +109,7 @@ class TestSceneSkillsE2E:
                     pump = getattr(dispatcher, "pump", None)
                     if pump is not None and hasattr(pump, "verify_installed"):
                         assert pump.verify_installed(), (
-                            "Dispatcher timer is not registered with bpy.app.timers "
-                            "after new_scene"
+                            "Dispatcher timer is not registered with bpy.app.timers after new_scene"
                         )
         except ImportError:
             pass  # server module not importable in --background without addon


### PR DESCRIPTION
## Problem

`blender_scene__new_scene` calls `bpy.ops.wm.read_factory_settings(use_empty=True)` which wipes all `bpy.app.timers` callbacks including the MCP main-thread dispatcher pump. The HTTP server stays alive (port remains open) but subsequent tool calls hang because the queue is never drained.

## Root Cause

Blender's factory reset unregisters every timer without notifying our Python objects. `BlenderTimerPump.is_installed` still returns `True` (the Python attribute is still set) — only `bpy.app.timers.is_registered()` reveals the truth.

## Fix (3 layers)

1. **`BlenderTimerPump.verify_installed()`** — queries `bpy.app.timers.is_registered()` directly so health checks can distinguish "port open" from "dispatcher functional".

2. **`new_scene.py`** — after `read_factory_settings`, re-registers the dispatcher pump via the server singleton and re-validates readiness. Best-effort (never breaks the operation).

3. **`ReadinessBinder.revalidate_dispatcher()`** — resets the `dcc` readiness bit and re-probes after scene resets so `/v1/readyz` reflects the actual pump state.

## Regression Test

`test_new_scene_preserves_dispatcher` — E2E: `new_scene` followed by `list_objects` succeeds without restart. Verifies `verify_installed()` on the timer pump.

Closes #133