### PR TITLE
Preserve native LookDev animation curves

### DIFF
--- a/src/dcc_mcp_blender/_animation_ops.py
+++ b/src/dcc_mcp_blender/_animation_ops.py
@@ -110,7 +110,7 @@ def delete_keyframes(
                 if not _fcurve_matches(fcurve, data_path):
                     continue
                 removed_on_curve = 0
-                for point in list(getattr(fcurve, "keyframe_points", [])):
+                for point in reversed(list(getattr(fcurve, "keyframe_points", []))):
                     frame = _frame_from_keyframe(point)
                     if start is not None and (frame < start or frame > end):
                         continue

--- a/src/dcc_mcp_blender/_color_management_ops.py
+++ b/src/dcc_mcp_blender/_color_management_ops.py
@@ -1,0 +1,45 @@
+"""Shared Blender scene color-management helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def color_management_info(scene: Any) -> dict:
+    view = getattr(scene, "view_settings", None)
+    display = getattr(scene, "display_settings", None)
+    return {
+        "display_device": getattr(display, "display_device", None),
+        "view_transform": getattr(view, "view_transform", None),
+        "look": getattr(view, "look", None),
+        "exposure": getattr(view, "exposure", None),
+        "gamma": getattr(view, "gamma", None),
+    }
+
+
+def apply_color_management(
+    scene: Any,
+    *,
+    display_device: Optional[str] = None,
+    view_transform: Optional[str] = None,
+    look: Optional[str] = None,
+    exposure: Optional[float] = None,
+    gamma: Optional[float] = None,
+) -> dict:
+    view = getattr(scene, "view_settings", None)
+    if view is None:
+        raise AttributeError("Scene view_settings is not available")
+    display = getattr(scene, "display_settings", None)
+    if display_device is not None:
+        if display is None:
+            raise AttributeError("Scene display_settings is not available")
+        display.display_device = display_device
+    if view_transform is not None:
+        view.view_transform = view_transform
+    if look is not None:
+        view.look = look
+    if exposure is not None:
+        view.exposure = float(exposure)
+    if gamma is not None:
+        view.gamma = float(gamma)
+    return color_management_info(scene)

--- a/src/dcc_mcp_blender/_light_rig_ops.py
+++ b/src/dcc_mcp_blender/_light_rig_ops.py
@@ -249,17 +249,12 @@ def _set_vector_socket_value(socket: Any, values: List[float]) -> None:
             return
 
 
-def _set_socket_keyframe_interpolation(
-    node_tree: Any,
-    socket: Any,
-    frames: List[int],
-    interpolation: str,
-) -> None:
+def _find_socket_fcurve(node_tree: Any, socket: Any) -> Any:
     animation_data = getattr(node_tree, "animation_data", None)
     action = getattr(animation_data, "action", None)
     fcurves = getattr(action, "fcurves", None)
     if fcurves is None:
-        return
+        return None
     data_path = None
     path_from_id = getattr(socket, "path_from_id", None)
     if callable(path_from_id):
@@ -280,6 +275,26 @@ def _set_socket_keyframe_interpolation(
             if HDRI_MAPPING_NODE in candidate_path and getattr(candidate, "array_index", None) == 2:
                 fcurve = candidate
                 break
+    return fcurve
+
+
+def _remove_socket_animation(node_tree: Any, socket: Any) -> None:
+    fcurve = _find_socket_fcurve(node_tree, socket)
+    animation_data = getattr(node_tree, "animation_data", None)
+    action = getattr(animation_data, "action", None)
+    fcurves = getattr(action, "fcurves", None)
+    remover = getattr(fcurves, "remove", None)
+    if fcurve is not None and callable(remover):
+        remover(fcurve)
+
+
+def _set_socket_keyframe_interpolation(
+    node_tree: Any,
+    socket: Any,
+    frames: List[int],
+    interpolation: str,
+) -> None:
+    fcurve = _find_socket_fcurve(node_tree, socket)
     if fcurve is None:
         return
     expected_frames = {int(frame) for frame in frames}
@@ -452,6 +467,7 @@ def animate_hdri_rotation(
     start_rotation: float = 0.0,
     end_rotation: float = 360.0,
     interpolation: str = "LINEAR",
+    replace_existing: bool = True,
 ) -> dict:
     """Animate the existing HDRI mapping rotation for a fixed-camera LookDev pass."""
     try:
@@ -492,6 +508,8 @@ def animate_hdri_rotation(
             {"frame": end, "rotation": end_degrees},
         ]
         try:
+            if replace_existing:
+                _remove_socket_animation(node_tree, rotation_socket)
             for keyframe in keyframes:
                 _set_vector_socket_value(
                     rotation_socket,
@@ -523,6 +541,7 @@ def animate_hdri_rotation(
             "HDRI rotation animated",
             keyframes=keyframes,
             interpolation=mode,
+            replace_existing=bool(replace_existing),
             mapping_node=HDRI_MAPPING_NODE,
         )
     except ImportError:

--- a/src/dcc_mcp_blender/_light_rig_ops.py
+++ b/src/dcc_mcp_blender/_light_rig_ops.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
 
+from dcc_mcp_blender._color_management_ops import apply_color_management, color_management_info
+
 RIG_PROP = "dcc_mcp_light_rig"
 ORIGINAL_ENERGY_PROP = "dcc_mcp_original_energy"
 HDRI_ENV_NODE = "DCC MCP HDRI"
@@ -234,15 +236,6 @@ def _world_info(world: Any) -> Dict[str, Any]:
         }
     info["hdri"] = hdri
     return info
-
-
-def _view_settings_info(view_settings: Any) -> Dict[str, Any]:
-    return {
-        "view_transform": getattr(view_settings, "view_transform", None),
-        "look": getattr(view_settings, "look", None),
-        "exposure": getattr(view_settings, "exposure", None),
-        "gamma": getattr(view_settings, "gamma", None),
-    }
 
 
 def _set_vector_socket_value(socket: Any, values: List[float]) -> None:
@@ -640,6 +633,7 @@ def group_lights(light_names: List[str], collection_name: str) -> dict:
 
 
 def set_render_view_transform(
+    display_device: Optional[str] = None,
     view_transform: Optional[str] = None,
     look: Optional[str] = None,
     exposure: Optional[float] = None,
@@ -649,21 +643,18 @@ def set_render_view_transform(
     try:
         import bpy
 
-        view_settings = getattr(bpy.context.scene, "view_settings", None)
-        if view_settings is None:
-            return skill_error("Render view settings unavailable", "Scene view_settings is not available.")
         try:
-            if view_transform is not None:
-                view_settings.view_transform = view_transform
-            if look is not None:
-                view_settings.look = look
-            if exposure is not None:
-                view_settings.exposure = float(exposure)
-            if gamma is not None:
-                view_settings.gamma = float(gamma)
+            current = apply_color_management(
+                bpy.context.scene,
+                display_device=display_device,
+                view_transform=view_transform,
+                look=look,
+                exposure=exposure,
+                gamma=gamma,
+            )
         except Exception as exc:
             return skill_error("Unsupported render view setting", str(exc))
-        return skill_success("Render view transform updated", current=_view_settings_info(view_settings))
+        return skill_success("Render view transform updated", current=current)
     except ImportError:
         return skill_error("Blender not available", "bpy could not be imported")
     except Exception as exc:
@@ -685,7 +676,7 @@ def get_lighting_summary() -> dict:
             light_count=len(lights),
             rigs=rigs.get("context", {}).get("rigs", []),
             world=_world_info(getattr(bpy.context.scene, "world", None)),
-            view_settings=_view_settings_info(getattr(bpy.context.scene, "view_settings", None)),
+            view_settings=color_management_info(bpy.context.scene),
         )
     except ImportError:
         return skill_error("Blender not available", "bpy could not be imported")

--- a/src/dcc_mcp_blender/_material_pipeline_ops.py
+++ b/src/dcc_mcp_blender/_material_pipeline_ops.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
 
+from dcc_mcp_blender._color_management_ops import apply_color_management, color_management_info
 from dcc_mcp_blender._node_graph_ops import (
     _collection_get,
     _ensure_material_nodes,
@@ -263,15 +264,6 @@ def _image_info(image: Any) -> Dict[str, Any]:
         "size": size_value,
         "colorspace": colorspace,
         "source": getattr(image, "source", None),
-    }
-
-
-def _view_settings_info(view_settings: Any) -> Dict[str, Any]:
-    return {
-        "view_transform": getattr(view_settings, "view_transform", None),
-        "look": getattr(view_settings, "look", None),
-        "exposure": getattr(view_settings, "exposure", None),
-        "gamma": getattr(view_settings, "gamma", None),
     }
 
 
@@ -662,10 +654,9 @@ def list_color_spaces() -> dict:
     try:
         import bpy
 
-        view_settings = getattr(bpy.context.scene, "view_settings", None)
         return skill_success(
             "Color management options listed",
-            current=_view_settings_info(view_settings) if view_settings is not None else {},
+            current=color_management_info(bpy.context.scene),
             view_transforms=["AgX", "Filmic", "Standard", "Raw"],
             looks=["None", "Medium High Contrast", "High Contrast", "Medium Low Contrast"],
             image_color_spaces=["sRGB", "Linear", "Non-Color", "Raw"],
@@ -677,6 +668,7 @@ def list_color_spaces() -> dict:
 
 
 def set_color_management(
+    display_device: Optional[str] = None,
     view_transform: Optional[str] = None,
     look: Optional[str] = None,
     exposure: Optional[float] = None,
@@ -686,18 +678,15 @@ def set_color_management(
     try:
         import bpy
 
-        view_settings = getattr(bpy.context.scene, "view_settings", None)
-        if view_settings is None:
-            return skill_error("Color management unavailable", "Scene view_settings is not available.")
-        if view_transform is not None:
-            view_settings.view_transform = view_transform
-        if look is not None:
-            view_settings.look = look
-        if exposure is not None:
-            view_settings.exposure = float(exposure)
-        if gamma is not None:
-            view_settings.gamma = float(gamma)
-        return skill_success("Color management updated", current=_view_settings_info(view_settings))
+        current = apply_color_management(
+            bpy.context.scene,
+            display_device=display_device,
+            view_transform=view_transform,
+            look=look,
+            exposure=exposure,
+            gamma=gamma,
+        )
+        return skill_success("Color management updated", current=current)
     except ImportError:
         return skill_error("Blender not available", "bpy could not be imported")
     except Exception as exc:

--- a/src/dcc_mcp_blender/skills/blender-animation/scripts/set_keyframe.py
+++ b/src/dcc_mcp_blender/skills/blender-animation/scripts/set_keyframe.py
@@ -50,6 +50,16 @@ def set_keyframe(
                 preferences.keyframe_new_interpolation_type = mode
             for path in paths:
                 obj.keyframe_insert(data_path=path, frame=actual_frame)
+                if mode is not None:
+                    action = getattr(getattr(obj, "animation_data", None), "action", None)
+                    for fcurve in getattr(action, "fcurves", []):
+                        if getattr(fcurve, "data_path", None) != path:
+                            continue
+                        for key in getattr(fcurve, "keyframe_points", []):
+                            co = getattr(key, "co", ())
+                            key_frame = float(co.x if hasattr(co, "x") else co[0])
+                            if abs(key_frame - actual_frame) < 1e-4:
+                                key.interpolation = mode
                 inserted.append(path)
         finally:
             if previous_mode is not None:

--- a/src/dcc_mcp_blender/skills/blender-animation/scripts/set_keyframe.py
+++ b/src/dcc_mcp_blender/skills/blender-animation/scripts/set_keyframe.py
@@ -13,6 +13,7 @@ def set_keyframe(
     object_name: str,
     frame: Optional[int] = None,
     data_paths: Optional[List[str]] = None,
+    interpolation: Optional[str] = None,
 ) -> dict:
     """Insert keyframes on an object.
 
@@ -37,17 +38,29 @@ def set_keyframe(
             scene.frame_set(frame)
         actual_frame = scene.frame_current
 
+        mode = interpolation.upper() if interpolation else None
+        if mode not in {None, "BEZIER", "LINEAR", "CONSTANT"}:
+            return skill_error("Unsupported interpolation", "Use BEZIER, LINEAR, or CONSTANT.")
+        preferences = getattr(getattr(bpy.context, "preferences", None), "edit", None)
+        previous_mode = getattr(preferences, "keyframe_new_interpolation_type", None)
         paths = data_paths or ["location", "rotation_euler", "scale"]
         inserted = []
-        for path in paths:
-            obj.keyframe_insert(data_path=path, frame=actual_frame)
-            inserted.append(path)
+        try:
+            if mode is not None and preferences is not None:
+                preferences.keyframe_new_interpolation_type = mode
+            for path in paths:
+                obj.keyframe_insert(data_path=path, frame=actual_frame)
+                inserted.append(path)
+        finally:
+            if previous_mode is not None:
+                preferences.keyframe_new_interpolation_type = previous_mode
 
         return skill_success(
             f"Keyframe set on {object_name} at frame {actual_frame}",
             object_name=object_name,
             frame=actual_frame,
             data_paths=inserted,
+            interpolation=mode,
             prompt="Keyframe inserted. Use set_current_frame to navigate the timeline.",
         )
     except ImportError:

--- a/src/dcc_mcp_blender/skills/blender-animation/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-animation/tools.yaml
@@ -7,6 +7,24 @@ tools:
     read_only: false
     destructive: false
     idempotent: false
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+        frame:
+          type: integer
+        data_paths:
+          type: array
+          items:
+            type: string
+            enum: [location, rotation_euler, scale, hide_viewport, hide_render]
+        interpolation:
+          type: string
+          enum: [BEZIER, LINEAR, CONSTANT]
   - name: set_frame_range
     description: "Set the animation frame range (start and end frames)"
     source_file: scripts/set_frame_range.py

--- a/src/dcc_mcp_blender/skills/blender-light-rig/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-light-rig/tools.yaml
@@ -274,6 +274,8 @@ tools:
       type: object
       additionalProperties: false
       properties:
+        display_device:
+          type: string
         view_transform:
           type: string
         look:

--- a/src/dcc_mcp_blender/skills/blender-light-rig/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-light-rig/tools.yaml
@@ -142,6 +142,10 @@ tools:
           type: string
           enum: [LINEAR, BEZIER, CONSTANT]
           default: LINEAR
+        replace_existing:
+          type: boolean
+          default: true
+          description: "Replace the existing HDRI rotation curve before inserting the new keys."
     output_schema: *result_schema
     read_only: false
     destructive: false
@@ -160,6 +164,7 @@ tools:
           start_rotation: 0.0
           end_rotation: 360.0
           interpolation: LINEAR
+          replace_existing: true
         note: "Create one full linear HDRI lighting rotation while the camera stays fixed"
 
   - name: list_light_rigs

--- a/src/dcc_mcp_blender/skills/blender-material-library/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-material-library/tools.yaml
@@ -263,6 +263,8 @@ tools:
       type: object
       additionalProperties: false
       properties:
+        display_device:
+          type: string
         view_transform:
           type: string
         look:

--- a/src/dcc_mcp_blender/skills/blender-render/scripts/set_render_settings.py
+++ b/src/dcc_mcp_blender/skills/blender-render/scripts/set_render_settings.py
@@ -14,6 +14,7 @@ def set_render_settings(
     resolution_x: Optional[int] = None,
     resolution_y: Optional[int] = None,
     resolution_percentage: Optional[int] = None,
+    fps: Optional[int] = None,
     samples: Optional[int] = None,
     output_path: Optional[str] = None,
     file_format: Optional[str] = None,
@@ -53,6 +54,10 @@ def set_render_settings(
             render.resolution_y = resolution_y
         if resolution_percentage is not None:
             render.resolution_percentage = resolution_percentage
+        if fps is not None:
+            if fps <= 0:
+                return skill_error("Invalid frame rate", "fps must be greater than zero")
+            render.fps = fps
         if output_path:
             render.filepath = output_path
         if file_format:
@@ -72,6 +77,7 @@ def set_render_settings(
             resolution_x=render.resolution_x,
             resolution_y=render.resolution_y,
             resolution_percentage=render.resolution_percentage,
+            fps=render.fps,
             output_path=render.filepath,
             prompt="Settings applied. Use render_scene to render.",
         )

--- a/src/dcc_mcp_blender/skills/blender-render/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-render/tools.yaml
@@ -45,6 +45,10 @@ tools:
           minimum: 1
           maximum: 100
           description: Output resolution percentage.
+        fps:
+          type: integer
+          minimum: 1
+          description: Output frame rate.
         samples:
           type: integer
           minimum: 1

--- a/tests/test_skills_animation.py
+++ b/tests/test_skills_animation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from tests.conftest import load_and_call, make_mock_bpy
@@ -43,6 +44,27 @@ class TestSetKeyframe:
         assert obj.keyframe_insert.call_count == 1
         assert result["context"]["interpolation"] == "LINEAR"
         assert bpy.context.preferences.edit.keyframe_new_interpolation_type == "BEZIER"
+
+    def test_applies_interpolation_to_inserted_key(self):
+        bpy = make_mock_bpy()
+        key = SimpleNamespace(co=(10.0, 1.0), interpolation="BEZIER")
+        curve = SimpleNamespace(data_path="location", keyframe_points=[key])
+        obj = MagicMock()
+        obj.animation_data = SimpleNamespace(action=SimpleNamespace(fcurves=[curve]))
+        bpy.data.objects.get.return_value = obj
+        bpy.context.scene.frame_current = 10
+
+        result = load_and_call(
+            "blender-animation/scripts/set_keyframe.py",
+            bpy,
+            object_name="Cube",
+            frame=10,
+            data_paths=["location"],
+            interpolation="LINEAR",
+        )
+
+        assert result["success"] is True
+        assert key.interpolation == "LINEAR"
 
     def test_object_not_found(self):
         bpy = make_mock_bpy()

--- a/tests/test_skills_animation.py
+++ b/tests/test_skills_animation.py
@@ -29,6 +29,7 @@ class TestSetKeyframe:
         bpy = make_mock_bpy()
         obj = MagicMock()
         bpy.data.objects.get.return_value = obj
+        bpy.context.preferences.edit.keyframe_new_interpolation_type = "BEZIER"
 
         result = load_and_call(
             "blender-animation/scripts/set_keyframe.py",
@@ -36,9 +37,12 @@ class TestSetKeyframe:
             object_name="Cube",
             frame=10,
             data_paths=["location"],
+            interpolation="LINEAR",
         )
         assert result["success"] is True
         assert obj.keyframe_insert.call_count == 1
+        assert result["context"]["interpolation"] == "LINEAR"
+        assert bpy.context.preferences.edit.keyframe_new_interpolation_type == "BEZIER"
 
     def test_object_not_found(self):
         bpy = make_mock_bpy()

--- a/tests/test_skills_light_rig.py
+++ b/tests/test_skills_light_rig.py
@@ -84,6 +84,7 @@ class _FakeScene:
         self.world = None
         self.frame_current = 1
         self.view_settings = SimpleNamespace(view_transform="AgX", look="None", exposure=0.0, gamma=1.0)
+        self.display_settings = SimpleNamespace(display_device="sRGB")
 
     def frame_set(self, frame):
         self.frame_current = frame
@@ -424,10 +425,12 @@ class TestLightRig:
         result = load_and_call(
             "blender-light-rig/scripts/set_render_view_transform.py",
             bpy,
+            display_device="Rec.1886 Rec.709 - Display",
             view_transform="Standard",
             exposure=0.25,
         )
 
         assert result["success"] is True
+        assert result["context"]["current"]["display_device"] == "Rec.1886 Rec.709 - Display"
         assert result["context"]["current"]["view_transform"] == "Standard"
         assert result["context"]["current"]["exposure"] == 0.25

--- a/tests/test_skills_light_rig.py
+++ b/tests/test_skills_light_rig.py
@@ -379,6 +379,7 @@ class TestLightRig:
             {"frame": 1, "rotation": 0.0},
             {"frame": 61, "rotation": 360.0},
         ]
+        assert animated["context"]["replace_existing"] is True
         mapping = bpy.context.scene.world.node_tree.nodes.get("DCC MCP Mapping")
         rotation_socket = mapping.inputs.get("Rotation")
         assert [keyframe["frame"] for keyframe in rotation_socket.keyframes] == [1, 61]

--- a/tests/test_skills_material_pipeline.py
+++ b/tests/test_skills_material_pipeline.py
@@ -132,6 +132,7 @@ class _FakeScene(dict):
         super().__init__()
         self.render = SimpleNamespace(engine="CYCLES")
         self.view_settings = SimpleNamespace(view_transform="AgX", look="None", exposure=0.0, gamma=1.0)
+        self.display_settings = SimpleNamespace(display_device="sRGB")
 
     def get(self, key, default=None):
         return dict.get(self, key, default)
@@ -286,12 +287,14 @@ class TestMaterialLibrary:
         updated = load_and_call(
             "blender-material-library/scripts/set_color_management.py",
             bpy,
+            display_device="Rec.1886 Rec.709 - Display",
             view_transform="Standard",
             exposure=0.5,
         )
 
         assert listed["success"] is True
         assert updated["success"] is True
+        assert updated["context"]["current"]["display_device"] == "Rec.1886 Rec.709 - Display"
         assert updated["context"]["current"]["view_transform"] == "Standard"
         assert updated["context"]["current"]["exposure"] == 0.5
 

--- a/tests/test_skills_render.py
+++ b/tests/test_skills_render.py
@@ -21,6 +21,7 @@ def test_render_tools_publish_ci_safe_input_contracts():
     settings = tools["set_render_settings"]["input_schema"]["properties"]
     assert "CYCLES" in settings["engine"]["enum"]
     assert settings["resolution_percentage"]["maximum"] == 100
+    assert settings["fps"]["minimum"] == 1
     assert settings["samples"]["minimum"] == 1
 
     capture = tools["capture_viewport"]["input_schema"]
@@ -75,6 +76,12 @@ class TestSetRenderSettings:
         assert result["success"] is True
         assert bpy.context.scene.render.resolution_x == 2560
         assert bpy.context.scene.render.resolution_y == 1440
+
+    def test_set_fps(self):
+        bpy = make_mock_bpy()
+        result = load_and_call("blender-render/scripts/set_render_settings.py", bpy, fps=30)
+        assert result["success"] is True
+        assert result["context"]["fps"] == 30
 
     def test_invalid_engine_returns_error(self):
         bpy = make_mock_bpy()

--- a/tests/test_skills_rigging_pose_animation_ops.py
+++ b/tests/test_skills_rigging_pose_animation_ops.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import yaml
@@ -187,6 +188,13 @@ class FakeKeyframe:
 class FakeKeyframes(list):
     def remove(self, point, fast=False):
         super().remove(point)
+
+
+class TailOnlyKeyframes(FakeKeyframes):
+    def remove(self, point, fast=False):
+        if point is not self[-1]:
+            raise RuntimeError("stale keyframe proxy")
+        super().remove(point, fast=fast)
 
 
 class FakeFcurve:
@@ -424,3 +432,17 @@ def test_get_delete_and_bake_animation_keyframes():
     assert baked["success"] is True
     assert baked["context"]["inserted_count"] == 2
     assert obj.keyframe_insert.call_count == 2
+
+
+def test_delete_keyframes_removes_points_back_to_front():
+    obj = FakeMeshObject("Cube")
+    obj.animation_data = MagicMock()
+    fcurve = FakeFcurve("rotation_euler", 2, [])
+    fcurve.keyframe_points = TailOnlyKeyframes([FakeKeyframe(1), FakeKeyframe(361)])
+    obj.animation_data.action = SimpleNamespace(name="Action", fcurves=[fcurve])
+    bpy = _bpy_with_objects([obj])
+
+    result = load_and_call("blender-animation/scripts/delete_keyframes.py", bpy, object_name="Cube")
+
+    assert result["success"] is True
+    assert result["context"]["deleted_count"] == 2


### PR DESCRIPTION
Preserves one native combined LookDev sequence by replacing stale HDRI curves and applying explicit key interpolation. Includes focused regression coverage.