### PR TITLE
fix: prepare Blender Extensions distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ attach a stable session id with `--meta-json`, query `dcc-mcp-cli stats --range 
 
 > Blender addon for the [DCC Model Context Protocol (MCP)](https://github.com/dcc-mcp/dcc-mcp-core) ecosystem — embeds a Streamable HTTP MCP server directly inside Blender, letting any MCP-compatible AI client drive your 3D workflow.
 
+## Blender Extensions distribution
+
+The source repository and PyPI package are MIT licensed. The ZIP submitted to
+[Blender Extensions](https://extensions.blender.org/) is GPL-3.0-or-later, as
+required for add-ons listed there; it also retains the bundled MIT notice.
+Download the platform-specific ZIP from the GitHub Release and install it with
+**Preferences → Get Extensions → Install from Disk**.
+
 [![PyPI version](https://badge.fury.io/py/dcc-mcp-blender.svg)](https://badge.fury.io/py/dcc-mcp-blender)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dcc-mcp-blender.svg)](https://pypi.org/project/dcc-mcp-blender/)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/dcc-mcp-blender.svg)](https://pypi.org/project/dcc-mcp-blender/#files)
@@ -210,7 +218,7 @@ options below are for manual installation.
 
 Release ZIPs are Blender 4.2+ Extension packages. They include `blender_manifest.toml` and the matching `dcc-mcp-core` wheel under `wheels/`, so Blender installs the Python dependency into the extension's isolated environment.
 
-The extension ZIP is assembled by `packaging/assemble_zip.py`. It resolves the latest compatible `dcc-mcp-core` wheel, places it under `wheels/`, and injects that wheel into `blender_manifest.toml`; Blender 4.2+ then installs it through the extension wheel mechanism instead of relying on global `pip` packages or `sys.path` edits. See [`packaging/release_smoke_checklist.md`](packaging/release_smoke_checklist.md) for the manual smoke test procedure.
+The extension ZIP is assembled by `packaging/assemble_zip.py`. It resolves the latest compatible `dcc-mcp-core` wheel, places it under `wheels/`, and injects that wheel into `blender_manifest.toml`; Blender 4.2+ then installs it through the extension wheel mechanism instead of relying on global `pip` packages or `sys.path` edits. Build locally with `just blender-addon-zip` for the host platform, or `just blender-addon-zip win64 dist_addon` (replace `win64` with `linux` or `macos`) for an explicit target. See [`packaging/release_smoke_checklist.md`](packaging/release_smoke_checklist.md) for the manual smoke test procedure.
 
 ### Option 2 — Install via pip (for scripts / CI)
 

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["loonghao"]
+}

--- a/justfile
+++ b/justfile
@@ -279,10 +279,11 @@ _blender-addons-dir := _blender-scripts-dir + "/addons"
 @blender-link-win:
     powershell -NoProfile -ExecutionPolicy Bypass -File tools/blender-link-win.ps1 -BlenderVersion {{ blender-version }}
 
-# Build a Blender-installable addon ZIP (bundles dcc-mcp-core from PyPI). Output: dist_addon/
-# Pick platform from host OS — run with explicit platform: `python packaging/assemble_zip.py --platform win64`
-blender-addon-zip:
-    python packaging/assemble_zip.py --platform {{ if os() == "windows" { "win64" } else if os() == "macos" { "macos" } else { "linux" } }} --output-dir dist_addon/
+# Build a Blender-installable addon ZIP (bundles dcc-mcp-core from PyPI).
+# Usage: `just blender-addon-zip [platform] [output_dir]`.
+blender-addon-platform := if os() == "windows" { "win64" } else if os() == "macos" { "macos" } else { "linux" }
+blender-addon-zip platform=blender-addon-platform output_dir="dist_addon":
+    python packaging/assemble_zip.py --platform {{ platform }} --output-dir {{ output_dir }}
 
 # Remove dev symlinks and addon files
 @blender-unlink:

--- a/packaging/addon_entry/__init__.py
+++ b/packaging/addon_entry/__init__.py
@@ -7,20 +7,14 @@ extension manifest for Blender 4.2+ extension workflows.
 
 from __future__ import annotations
 
+import importlib
 import logging
 import os
-import sys
 import webbrowser
 from contextlib import suppress
 from typing import Any, List, Tuple
 
 import bpy
-
-# Do not mutate sys.path — Blender extensions forbid injecting the add-on root into
-# sys.path (policy violation). Dependencies are loaded via blender_manifest.toml wheels.
-_self_module = sys.modules.get(__name__)
-if __name__ != "dcc_mcp_blender" and globals().get("__path__") is not None and _self_module is not None:
-    sys.modules.setdefault("dcc_mcp_blender", _self_module)
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +42,12 @@ _server_dispatcher: Any = None
 _server_host: Any = None
 
 
+def _addon_module(name: str):
+    """Import a bundled module through the active add-on package namespace."""
+    package = __package__ if (__package__ or "").startswith("bl_ext.") else "dcc_mcp_blender"
+    return importlib.import_module(f"{package}.{name}")
+
+
 def _env_port(name: str, default: int) -> int:
     """Read a TCP port while preserving zero as the random-port request."""
     raw = os.environ.get(name, "").strip()
@@ -71,12 +71,13 @@ def _start_server_with_host():
     # The release ZIP replaces the library package entrypoint with this Blender
     # add-on entrypoint. Enforce the same compatibility contract here before
     # importing host/server modules that bind dcc-mcp-core integrations.
-    from dcc_mcp_blender._core_compat import require_compatible_core  # noqa: PLC0415
-
-    require_compatible_core()
-
-    from dcc_mcp_blender.host import BlenderUiDispatcher  # noqa: PLC0415
-    from dcc_mcp_blender.server import get_server, start_server, stop_server  # noqa: PLC0415
+    _addon_module("_core_compat").require_compatible_core()
+    host = _addon_module("host")
+    server_module = _addon_module("server")
+    BlenderUiDispatcher = host.BlenderUiDispatcher
+    get_server = server_module.get_server
+    start_server = server_module.start_server
+    stop_server = server_module.stop_server
 
     existing = get_server()
     if existing is not None and getattr(existing, "is_running", False):
@@ -110,9 +111,7 @@ def _stop_server_with_host() -> None:
 
     host = _server_host
     try:
-        from dcc_mcp_blender.server import stop_server  # noqa: PLC0415
-
-        stop_server()
+        _addon_module("server").stop_server()
     finally:
         if host is not None:
             with suppress(Exception):
@@ -123,9 +122,7 @@ def _stop_server_with_host() -> None:
 
 def _running_server():
     try:
-        from dcc_mcp_blender.server import get_server  # noqa: PLC0415
-
-        return get_server()
+        return _addon_module("server").get_server()
     except Exception as exc:  # noqa: BLE001
         logger.debug("get_server failed: %s", exc)
         return None

--- a/packaging/addon_entry/blender_manifest.toml
+++ b/packaging/addon_entry/blender_manifest.toml
@@ -7,7 +7,7 @@ schema_version = "1.0.0"
 id = "dcc_mcp_blender"
 version = "0.1.42"
 name = "DCC MCP Blender"
-tagline = "MCP Streamable HTTP server inside Blender for AI-driven workflows"
+tagline = "MCP HTTP server inside Blender for AI-driven workflows"
 maintainer = "Long Hao <hal.long@outlook.com>"
 type = "add-on"
 
@@ -16,7 +16,10 @@ tags = ["System", "Pipeline", "Animation"]
 # Minimum Blender version for the Extensions + wheels workflow (see Blender manual).
 blender_version_min = "4.2.0"
 
-license = ["SPDX:MIT"]
+# The source repository remains MIT. Blender Extensions accepts add-ons under
+# GPL-compatible terms, so the assembled marketplace archive is GPL-3.0-or-later
+# and retains the bundled MIT notice.
+license = ["SPDX:GPL-3.0-or-later"]
 
 location = "Top Bar > DCC MCP"
 description = "Embeds an MCP HTTP server (2025-03-26) for Claude, Cursor, and other MCP clients."

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -8,7 +8,8 @@ This script:
    ``blender_manifest.toml`` under ``wheels = [...]`` so Blender installs it into
    the extension's isolated ``site-packages`` (no ``sys.path`` hacks, no loose
    ``dcc_mcp_core/`` tree — required for Blender 4.2+ extensions policy).
-4. Bundles the adapter modules and skills directly in the add-on package root.
+4. Bundles the adapter modules, skills, and required distribution licenses at
+   the add-on package root.
 5. Produces ``dcc_mcp_blender_addon_{platform}_v{version}.zip`` — install via
    **Edit → Preferences → Extensions → Install from Disk** (recommended) or
    Blender's extension package installer.
@@ -16,8 +17,8 @@ This script:
 Version strings in ``pyproject.toml``, ``src/dcc_mcp_blender/__version__.py``, and
 ``packaging/addon_entry/blender_manifest.toml`` are maintained by **release-please**
 only; this script reads ``pyproject.toml`` for the ZIP filename, copies the manifest
-from ``addon_entry/``, then appends the ``wheels = [...]`` entry for the downloaded
-``dcc-mcp-core`` wheel basename.
+from ``addon_entry/``, then appends the ``wheels = [...]`` and ``platforms = [...]``
+entries for the downloaded ``dcc-mcp-core`` wheel basename.
 
 Usage::
 
@@ -29,12 +30,15 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import hashlib
 import pathlib
 import re
 import shutil
 import tempfile
 import urllib.request
 import zipfile
+from http.client import IncompleteRead
+from urllib.error import URLError
 
 # ── configuration ─────────────────────────────────────────────────────────────
 
@@ -53,6 +57,8 @@ REMOVED_CAPTURE_HELPER = "dcc-mcp-capture-helper.exe"
 # Match platform first, then prefer stable abi3 builds.
 
 PYPI_URL = "https://pypi.org/pypi/{package}/json"
+GPL_3_0_URL = "https://raw.githubusercontent.com/spdx/license-list-data/60fbd82486310a2d0d70dd4d2cca1165c14d59b5/text/GPL-3.0-only.txt"
+GPL_3_0_SHA256 = "fb981668c18a279e285fc4d83fba1e836cc84dd4daa73c9697d3cfd2d8aca6e0"
 
 # Never bundle mistaken local trees (e.g. accidental wheel extracts under src/).
 _SKIPPED_TOP_LEVEL_NAMES = frozenset({"dcc_mcp_blender", "dcc_mcp_core", "__pycache__", "__init__.py"})
@@ -144,9 +150,9 @@ def _wheel_matches_platform(filename: str, platform: str) -> bool:
     if not filename.endswith(".whl"):
         return False
     if platform == "win64":
-        return "win_amd64" in filename or "win32" in filename
+        return "win_amd64" in filename
     if platform == "linux":
-        return "linux" in filename and ("x86_64" in filename or "aarch64" in filename)
+        return "linux" in filename and "x86_64" in filename
     if platform == "macos":
         return "macosx" in filename
     return False
@@ -222,6 +228,37 @@ def validate_core_wheel(wheel_path: pathlib.Path) -> None:
     if removed_members:
         members = ", ".join(sorted(removed_members))
         raise RuntimeError(f"Refusing to bundle dcc-mcp-core wheel containing the removed capture helper ({members})")
+
+
+def _manifest_platforms_for_wheel(filename: str) -> list[str]:
+    """Return the Blender Extension platforms supported by a wheel filename."""
+    if "win_amd64" in filename:
+        return ["windows-x64"]
+    if "linux" in filename and "x86_64" in filename:
+        return ["linux-x64"]
+    if "macosx" in filename:
+        platforms = []
+        if "universal2" in filename or "x86_64" in filename:
+            platforms.append("macos-x64")
+        if "universal2" in filename or "arm64" in filename:
+            platforms.append("macos-arm64")
+        return platforms
+    raise RuntimeError(f"Unsupported wheel platform for Blender Extensions: {filename}")
+
+
+def download_gpl_distribution_license(dest_path: pathlib.Path) -> None:
+    """Download the GPL text that must accompany the marketplace archive."""
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(GPL_3_0_URL, timeout=30) as response:  # noqa: S310
+                license_text = response.read()
+            break
+        except (IncompleteRead, URLError):
+            if attempt == 2:
+                raise
+    if hashlib.sha256(license_text).hexdigest() != GPL_3_0_SHA256:
+        raise RuntimeError("Downloaded GPL-3.0 text did not match its expected SHA-256")
+    dest_path.write_bytes(license_text)
 
 
 def extract_wheel(wheel_path: pathlib.Path, dest_dir: pathlib.Path) -> None:
@@ -303,6 +340,7 @@ def assemble(platform: str, output_dir: pathlib.Path) -> pathlib.Path:
         # 3) Stage add-on root: ``__init__.py`` + ``blender_manifest.toml`` (4.2+ extensions)
         _stage_addon_entry(addon_dir, version=version)
         _inject_wheels_into_manifest(addon_dir / "blender_manifest.toml", [wheel.name])
+        _inject_platforms_into_manifest(addon_dir / "blender_manifest.toml", _manifest_platforms_for_wheel(wheel.name))
 
         # 4) Zip the extension package contents at archive root. Blender's
         # extension installer expects ``blender_manifest.toml`` at ZIP root.
@@ -326,6 +364,19 @@ def _inject_wheels_into_manifest(manifest_path: pathlib.Path, wheel_basenames: l
     text = re.sub(r"\n+wheels\s*=\s*\[.*?\]\s*", "\n", text, flags=re.DOTALL)
     lines = [f'    "./wheels/{name}"' for name in wheel_basenames]
     block = "\nwheels = [\n" + ",\n".join(lines) + ",\n]\n"
+    first_table = re.search(r"\n\[[^\]]+\]", text)
+    if first_table is None:
+        rendered = text.rstrip() + block
+    else:
+        rendered = text[: first_table.start()].rstrip() + block + text[first_table.start() :]
+    manifest_path.write_text(rendered, encoding="utf-8")
+
+
+def _inject_platforms_into_manifest(manifest_path: pathlib.Path, platforms: list[str]) -> None:
+    """Write the exact Blender Extension platforms supplied by bundled wheels."""
+    text = manifest_path.read_text(encoding="utf-8")
+    text = re.sub(r"\n+platforms\s*=\s*\[.*?\]\s*", "\n", text, flags=re.DOTALL)
+    block = "\nplatforms = [" + ", ".join(f'"{platform}"' for platform in platforms) + "]\n"
     first_table = re.search(r"\n\[[^\]]+\]", text)
     if first_table is None:
         rendered = text.rstrip() + block
@@ -362,6 +413,8 @@ def _stage_addon_entry(addon_dir: pathlib.Path, *, version: str) -> None:
     shutil.copy2(init_src, addon_dir / "__init__.py")
     _render_static_bl_info_version(addon_dir / "__init__.py", version)
     shutil.copy2(manifest_src, addon_dir / "blender_manifest.toml")
+    download_gpl_distribution_license(addon_dir / "COPYING")
+    shutil.copy2(PACKAGE_ROOT / "LICENSE", addon_dir / "LICENSE-MIT")
 
 
 # ── CLI ────────────────────────────────────────────────────────────────────────

--- a/src/dcc_mcp_blender/_project_tools.py
+++ b/src/dcc_mcp_blender/_project_tools.py
@@ -23,7 +23,7 @@ import logging
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-from dcc_mcp_blender import _env
+from . import _env
 
 logger = logging.getLogger(__name__)
 

--- a/src/dcc_mcp_blender/_readiness.py
+++ b/src/dcc_mcp_blender/_readiness.py
@@ -28,7 +28,7 @@ from typing import Any, Callable, Optional
 
 from dcc_mcp_core.readiness import AdapterReadinessBinder
 
-from dcc_mcp_blender import _env
+from . import _env
 
 logger = logging.getLogger(__name__)
 

--- a/src/dcc_mcp_blender/_resources.py
+++ b/src/dcc_mcp_blender/_resources.py
@@ -22,7 +22,7 @@ import threading
 import time
 from typing import Any, Callable, Dict, List, Optional
 
-from dcc_mcp_blender import _env
+from . import _env
 
 logger = logging.getLogger(__name__)
 

--- a/src/dcc_mcp_blender/_semantic_index.py
+++ b/src/dcc_mcp_blender/_semantic_index.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import logging
 from typing import Any, List, Optional, Sequence
 
-from dcc_mcp_blender import _env
+from . import _env
 
 logger = logging.getLogger(__name__)
 

--- a/src/dcc_mcp_blender/dispatcher/__init__.py
+++ b/src/dcc_mcp_blender/dispatcher/__init__.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 # Import local modules
-from dcc_mcp_blender.dispatcher.cancel import check_blender_cancelled
-from dcc_mcp_blender.dispatcher.job import DEFAULT_JOB_TIMEOUT_MS, _current_job, _JobEntry
-from dcc_mcp_blender.dispatcher.pump import (
+from .cancel import check_blender_cancelled
+from .job import DEFAULT_JOB_TIMEOUT_MS, _current_job, _JobEntry
+from .pump import (
     DEFAULT_BUDGET_MS,
     OVERRUN_MULTIPLIER,
     BlenderTimerPump,
@@ -15,8 +15,8 @@ from dcc_mcp_blender.dispatcher.pump import (
     create_dispatcher,
     create_pumped_dispatcher,
 )
-from dcc_mcp_blender.dispatcher.standalone import BlenderStandaloneDispatcher
-from dcc_mcp_blender.dispatcher.ui import BlenderUiDispatcher
+from .standalone import BlenderStandaloneDispatcher
+from .ui import BlenderUiDispatcher
 
 __all__ = [
     # Cancellation

--- a/src/dcc_mcp_blender/dispatcher/pump.py
+++ b/src/dcc_mcp_blender/dispatcher/pump.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from dcc_mcp_core import PyPumpedDispatcher
 
-from dcc_mcp_blender.host import BlenderTimerPump, BlenderUiDispatcher
+from ..host import BlenderTimerPump, BlenderUiDispatcher
 
 DEFAULT_BUDGET_MS = 200
 OVERRUN_MULTIPLIER = 1.0
@@ -23,7 +23,7 @@ def create_dispatcher(
     if ui_mode:
         return BlenderUiDispatcher(timeout_ms=timeout_ms)
 
-    from dcc_mcp_blender.dispatcher.standalone import BlenderStandaloneDispatcher
+    from .standalone import BlenderStandaloneDispatcher
 
     return BlenderStandaloneDispatcher(timeout_ms=timeout_ms)
 

--- a/src/dcc_mcp_blender/dispatcher/ui.py
+++ b/src/dcc_mcp_blender/dispatcher/ui.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from dcc_mcp_blender.host import BlenderUiDispatcher
+from ..host import BlenderUiDispatcher
 
 __all__ = ["BlenderUiDispatcher"]

--- a/src/dcc_mcp_blender/server.py
+++ b/src/dcc_mcp_blender/server.py
@@ -30,7 +30,7 @@ from typing import Any, Dict, List, Optional
 from dcc_mcp_core import DccServerOptions, HostExecutionBridge
 from dcc_mcp_core.server_base import DccServerBase
 
-from dcc_mcp_blender import (
+from . import (
     _capability_manifest,
     _env,
     _project_tools,
@@ -38,9 +38,9 @@ from dcc_mcp_blender import (
     _resources,
     _semantic_index,
 )
-from dcc_mcp_blender.__version__ import __version__
-from dcc_mcp_blender.context_snapshot import BlenderContextSnapshotProvider
-from dcc_mcp_blender.host import BlenderInlineCallableDispatcher
+from .__version__ import __version__
+from .context_snapshot import BlenderContextSnapshotProvider
+from .host import BlenderInlineCallableDispatcher
 
 logger = logging.getLogger(__name__)
 
@@ -205,7 +205,7 @@ class BlenderMcpServer(DccServerBase):
                 # Default to a UI or standalone dispatcher if none provided
                 # (essential for workers started via CLI)
                 try:
-                    from dcc_mcp_blender.dispatcher import create_dispatcher
+                    from .dispatcher import create_dispatcher
 
                     dispatcher = create_dispatcher(ui_mode=not self.is_background())
                 except Exception as exc:  # noqa: BLE001

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/cancel_render_job.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/cancel_render_job.py
@@ -16,6 +16,14 @@ from typing import Optional
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 
+def _online_access_enabled() -> bool:
+    try:
+        import bpy  # noqa: PLC0415
+    except ImportError:
+        return True
+    return bool(getattr(bpy.app, "online_access", True))
+
+
 def cancel_render_job(
     job_id: str,
     farm: str = "flamenco",
@@ -109,6 +117,8 @@ def _cancel_flamenco_job(job_id: str, flamenco_server_url: Optional[str]) -> dic
 
         server_url = flamenco_server_url or os.environ.get("FLAMENCO_SERVER_URL", "http://localhost:8080")
         server_url = server_url.rstrip("/")
+        if not _online_access_enabled():
+            return skill_error("Online access is disabled", "Enable Allow Online Access in Blender Preferences.")
 
         check_dcc_cancelled()
 

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/get_render_job_status.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/get_render_job_status.py
@@ -16,6 +16,14 @@ from typing import Optional
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 
+def _online_access_enabled() -> bool:
+    try:
+        import bpy  # noqa: PLC0415
+    except ImportError:
+        return True
+    return bool(getattr(bpy.app, "online_access", True))
+
+
 def get_render_job_status(
     job_id: str,
     farm: str = "flamenco",
@@ -121,6 +129,8 @@ def _query_flamenco(job_id: str, flamenco_server_url: Optional[str]) -> dict:
 
         server_url = flamenco_server_url or os.environ.get("FLAMENCO_SERVER_URL", "http://localhost:8080")
         server_url = server_url.rstrip("/")
+        if not _online_access_enabled():
+            return skill_error("Online access is disabled", "Enable Allow Online Access in Blender Preferences.")
 
         check_dcc_cancelled()
 

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/list_render_jobs.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/list_render_jobs.py
@@ -16,6 +16,14 @@ from typing import Optional
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 
+def _online_access_enabled() -> bool:
+    try:
+        import bpy  # noqa: PLC0415
+    except ImportError:
+        return True
+    return bool(getattr(bpy.app, "online_access", True))
+
+
 def list_render_jobs(
     farm: str = "flamenco",
     limit: int = 20,
@@ -136,6 +144,8 @@ def _list_flamenco_jobs(
 
         server_url = flamenco_server_url or os.environ.get("FLAMENCO_SERVER_URL", "http://localhost:8080")
         server_url = server_url.rstrip("/")
+        if not _online_access_enabled():
+            return skill_error("Online access is disabled", "Enable Allow Online Access in Blender Preferences.")
 
         check_dcc_cancelled()
 

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/render_farm_status.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/render_farm_status.py
@@ -17,6 +17,14 @@ from typing import Optional
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 
+def _online_access_enabled() -> bool:
+    try:
+        import bpy  # noqa: PLC0415
+    except ImportError:
+        return True
+    return bool(getattr(bpy.app, "online_access", True))
+
+
 def render_farm_status(
     farm: str = "flamenco",
     deadline_command: Optional[str] = None,
@@ -132,6 +140,8 @@ def _query_flamenco_status(flamenco_server_url: Optional[str]) -> dict:
 
         server_url = flamenco_server_url or os.environ.get("FLAMENCO_SERVER_URL", "http://localhost:8080")
         server_url = server_url.rstrip("/")
+        if not _online_access_enabled():
+            return skill_error("Online access is disabled", "Enable Allow Online Access in Blender Preferences.")
 
         # 1. Manager health via GET /api/v3/status
         healthy = True

--- a/src/dcc_mcp_blender/skills/blender-render-farm/scripts/submit_render_job.py
+++ b/src/dcc_mcp_blender/skills/blender-render-farm/scripts/submit_render_job.py
@@ -14,6 +14,14 @@ from typing import Optional
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 
+def _online_access_enabled() -> bool:
+    try:
+        import bpy  # noqa: PLC0415
+    except ImportError:
+        return True
+    return bool(getattr(bpy.app, "online_access", True))
+
+
 def submit_render_job(
     farm: str = "flamenco",
     job_name: Optional[str] = None,
@@ -244,6 +252,8 @@ def _submit_to_flamenco(
 
         server_url = flamenco_server_url or os.environ.get("FLAMENCO_SERVER_URL", "http://localhost:8080")
         server_url = server_url.rstrip("/")
+        if not _online_access_enabled():
+            return skill_error("Online access is disabled", "Enable Allow Online Access in Blender Preferences.")
 
         check_dcc_cancelled()
 

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import ast
+import hashlib
 import importlib.util
 import pathlib
 import re
 import sys
 import zipfile
-from types import SimpleNamespace
+from http.client import IncompleteRead
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -61,6 +63,44 @@ def test_addon_entry_bl_info_version_is_static_tuple_literal():
     assert ast.literal_eval(version_node) == _parse_version_tuple(_get_addon_version())
 
 
+def test_manifest_tagline_meets_blender_extensions_limit():
+    manifest = (ROOT / "packaging" / "addon_entry" / "blender_manifest.toml").read_text(encoding="utf-8")
+    tagline = re.search(r'^tagline\s*=\s*"([^"]+)"', manifest, re.MULTILINE)
+
+    assert tagline is not None
+    assert len(tagline.group(1)) <= 64
+
+
+def test_extension_namespace_import_does_not_create_top_level_alias(monkeypatch):
+    """Extension startup must keep its bundled modules in Blender's namespace."""
+    extension_name = "bl_ext.user_default.dcc_mcp_blender"
+    source_root = ROOT / "src" / "dcc_mcp_blender"
+    fake_bpy = SimpleNamespace(types=SimpleNamespace(Operator=object, Menu=object))
+
+    for package in ("bl_ext", "bl_ext.user_default"):
+        module = ModuleType(package)
+        module.__path__ = []
+        monkeypatch.setitem(sys.modules, package, module)
+    for name in tuple(sys.modules):
+        if name == "dcc_mcp_blender" or name.startswith("dcc_mcp_blender."):
+            monkeypatch.delitem(sys.modules, name)
+    monkeypatch.setitem(sys.modules, "bpy", fake_bpy)
+
+    spec = importlib.util.spec_from_file_location(
+        extension_name,
+        ADDON_ENTRY,
+        submodule_search_locations=[str(source_root)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, extension_name, module)
+    spec.loader.exec_module(module)
+
+    server = module._addon_module("server")
+
+    assert server.__name__ == f"{extension_name}.server"
+    assert not any(name == "dcc_mcp_blender" or name.startswith("dcc_mcp_blender.") for name in sys.modules)
+
+
 def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monkeypatch):
     """The add-on package root must directly contain ``server.py`` and skills."""
     assemble_zip = _load_assemble_zip_module()
@@ -69,6 +109,11 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
 
     monkeypatch.setattr(assemble_zip, "resolve_core_version", lambda min_version="0.19.17": "0.19.17")
     monkeypatch.setattr(assemble_zip, "download_core_wheel", lambda version, platform, dest_dir: fake_wheel)
+    monkeypatch.setattr(
+        assemble_zip,
+        "download_gpl_distribution_license",
+        lambda path: path.write_text("GNU GENERAL PUBLIC LICENSE", encoding="utf-8"),
+    )
 
     zip_path = assemble_zip.assemble(platform="win64", output_dir=tmp_path)
 
@@ -81,6 +126,8 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     assert "server.py" in names
     assert "host.py" in names
     assert "skills/blender-scene/SKILL.md" in names
+    assert "COPYING" in names
+    assert "LICENSE-MIT" in names
     assert not any(name.startswith("dcc_mcp_blender/") for name in names)
     assert [name for name in sorted(names) if name.startswith("wheels/dcc_mcp_core-")] == [
         "wheels/dcc_mcp_core-0.19.17-cp38-abi3-win_amd64.whl"
@@ -97,23 +144,78 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     assert isinstance(addon_version_node, ast.Tuple)
     assert ast.literal_eval(addon_version_node) == _parse_version_tuple(_get_addon_version())
     assert _manifest_wheels(manifest) == ["wheels/dcc_mcp_core-0.19.17-cp38-abi3-win_amd64.whl"]
+    assert 'license = ["SPDX:GPL-3.0-or-later"]' in manifest
+    assert 'platforms = ["windows-x64"]' in manifest
     assert manifest.index("wheels = [") < manifest.index("[permissions]")
 
     start_server = next(
         node for node in addon_tree.body if isinstance(node, ast.FunctionDef) and node.name == "_start_server_with_host"
     )
-    gate_call = next(
-        node
-        for node in ast.walk(start_server)
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "require_compatible_core"
+    start_source = ast.get_source_segment(addon_init, start_server)
+    assert start_source.index('_addon_module("_core_compat").require_compatible_core()') < start_source.index(
+        '_addon_module("host")'
     )
-    core_import_lines = [
-        node.lineno
-        for node in ast.walk(start_server)
-        if isinstance(node, ast.ImportFrom) and node.module in {"dcc_mcp_blender.host", "dcc_mcp_blender.server"}
+    assert "dcc_mcp_blender.host" not in start_source
+    assert "dcc_mcp_blender.server" not in start_source
+
+
+def test_manifest_platforms_follow_the_selected_wheel():
+    assemble_zip = _load_assemble_zip_module()
+
+    assert assemble_zip._manifest_platforms_for_wheel("core-cp38-abi3-win_amd64.whl") == ["windows-x64"]
+    assert assemble_zip._manifest_platforms_for_wheel("core-cp38-abi3-manylinux_2_17_x86_64.whl") == ["linux-x64"]
+    assert assemble_zip._manifest_platforms_for_wheel("core-cp38-abi3-macosx_11_0_universal2.whl") == [
+        "macos-x64",
+        "macos-arm64",
     ]
-    assert core_import_lines
-    assert gate_call.lineno < min(core_import_lines)
+
+
+def test_distribution_license_rejects_unexpected_download(tmp_path, monkeypatch):
+    assemble_zip = _load_assemble_zip_module()
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        @staticmethod
+        def read():
+            return b"unexpected"
+
+    monkeypatch.setattr(assemble_zip.urllib.request, "urlopen", lambda *_args, **_kwargs: Response())
+
+    with pytest.raises(RuntimeError, match="SHA-256"):
+        assemble_zip.download_gpl_distribution_license(tmp_path / "COPYING")
+
+
+def test_distribution_license_retries_incomplete_download(tmp_path, monkeypatch):
+    assemble_zip = _load_assemble_zip_module()
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        @staticmethod
+        def read():
+            return b"complete"
+
+    class IncompleteResponse(Response):
+        @staticmethod
+        def read():
+            raise IncompleteRead(b"partial", 8)
+
+    responses = iter((IncompleteResponse(), Response()))
+    monkeypatch.setattr(assemble_zip.urllib.request, "urlopen", lambda *_args, **_kwargs: next(responses))
+    monkeypatch.setattr(assemble_zip, "GPL_3_0_SHA256", hashlib.sha256(b"complete").hexdigest())
+
+    destination = tmp_path / "COPYING"
+    assemble_zip.download_gpl_distribution_license(destination)
+    assert destination.read_bytes() == b"complete"
 
 
 def test_validate_core_wheel_rejects_removed_capture_helper(tmp_path):

--- a/tests/test_skills_render_farm.py
+++ b/tests/test_skills_render_farm.py
@@ -87,6 +87,20 @@ def _load_with_urllib_mock(
 class TestFlamencoEndpoints:
     """Verify that the right Flamenco v3 API URLs and HTTP verbs are used."""
 
+    def test_flamenco_respects_blender_online_access(self):
+        urllib_mock = MagicMock()
+        disabled_bpy = types.SimpleNamespace(app=types.SimpleNamespace(online_access=False))
+
+        result = _load_with_urllib_mock(
+            "blender-render-farm/scripts/render_farm_status.py",
+            urllib_mock,
+            bpy_mock=disabled_bpy,
+        )
+
+        assert result["success"] is False
+        assert "Online access is disabled" in result["message"]
+        urllib_mock.urlopen.assert_not_called()
+
     def test_render_farm_status_hits_status_and_workers_endpoints(self):
         """GET /api/v3/status and GET /api/v3/worker-mgt/workers (not /workers)."""
         urllib_mock = MagicMock()


### PR DESCRIPTION
## Summary
- fix extension-namespace imports for Blender 5.2 policy compliance (#176)
- package GPL-3.0-or-later marketplace ZIPs with retained MIT notice and wheel-derived platforms
- guard Flamenco network calls with Blender online-access permission

## Verification
- python -m pytest -q (488 passed, 19 skipped)
- Blender 4.2.7 extension validate (Windows ZIP)