### PR TITLE
feat!: migrate UI Control to dcc-cua 0.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ a running server.
 `dcc-mcp-blender` embeds a standards-compliant MCP Streamable HTTP server directly inside Blender. It exposes 200+ Blender operations as MCP tools that any AI agent (Claude, Gemini, Cursor, etc.) can call over HTTP — no external gateway, no subprocess bridge.
 
 **Current version:** 0.1.20 <!-- x-release-please-version -->
-**Core dependency:** `dcc-mcp-core>=0.19.63,<1.0.0`
+**Core dependency:** `dcc-mcp-core>=0.20.0,<1.0.0`
 **Python:** 3.10+ (bundled with Blender)
 **Blender:** 3.6 LTS, 4.2 LTS, 4.3, 4.4
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Download the platform-specific ZIP from the GitHub Release and install it with
 [![GitHub release downloads](https://img.shields.io/github/downloads/dcc-mcp/dcc-mcp-blender/total.svg?label=release%20downloads)](https://github.com/dcc-mcp/dcc-mcp-blender/releases)
 [![GitHub Release](https://img.shields.io/github/v/release/dcc-mcp/dcc-mcp-blender.svg)](https://github.com/dcc-mcp/dcc-mcp-blender/releases)
 [![Coverage](https://img.shields.io/badge/coverage-pytest--cov-blue.svg)](https://github.com/dcc-mcp/dcc-mcp-blender/blob/main/pyproject.toml)
-[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.19.63-blue.svg)](https://github.com/dcc-mcp/dcc-mcp-core)
+[![dcc-mcp-core](https://img.shields.io/badge/dcc--mcp--core-%3E%3D0.20.0-blue.svg)](https://github.com/dcc-mcp/dcc-mcp-core)
 [![Blender](https://img.shields.io/badge/Blender-3.6%20LTS%20%7C%204.2%20LTS%20%7C%204.3%20%7C%204.4-orange.svg)](https://www.blender.org/download/releases/)
 [![MCP](https://img.shields.io/badge/MCP-2025--03--26-purple.svg)](https://modelcontextprotocol.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -219,6 +219,10 @@ options below are for manual installation.
 Release ZIPs are Blender 4.2+ Extension packages. They include `blender_manifest.toml` and the matching `dcc-mcp-core` wheel under `wheels/`, so Blender installs the Python dependency into the extension's isolated environment.
 
 The extension ZIP is assembled by `packaging/assemble_zip.py`. It resolves the latest compatible `dcc-mcp-core` wheel, places it under `wheels/`, and injects that wheel into `blender_manifest.toml`; Blender 4.2+ then installs it through the extension wheel mechanism instead of relying on global `pip` packages or `sys.path` edits. Build locally with `just blender-addon-zip` for the host platform, or `just blender-addon-zip win64 dist_addon` (replace `win64` with `linux` or `macos`) for an explicit target. See [`packaging/release_smoke_checklist.md`](packaging/release_smoke_checklist.md) for the manual smoke test procedure.
+
+Native UI Control requires standalone `dcc-cua` 0.4.0 or newer on `PATH` (or
+`DCC_MCP_CUA_BINARY`). Core owns the `ui_control__*` contract; the Blender ZIP
+does not bundle a second capture or input helper.
 
 ### Option 2 — Install via pip (for scripts / CI)
 

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@
 **Repo:** https://github.com/dcc-mcp/dcc-mcp-blender
 **Python:** >=3.10 (bundled with Blender)
 **Blender:** 3.6 LTS, 4.2 LTS, 4.3, 4.4
-**Core dep:** `dcc-mcp-core>=0.19.45,<1.0.0`
+**Core dep:** `dcc-mcp-core>=0.20.0,<1.0.0`
 
 ---
 

--- a/packaging/assemble_zip.py
+++ b/packaging/assemble_zip.py
@@ -48,10 +48,9 @@ ADDON_ENTRY_DIR = PACKAGE_ROOT / "packaging" / "addon_entry"
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 
 # Must stay in sync with ``pyproject.toml`` dependency floor.
-MIN_CORE_VERSION = "0.19.63"
+MIN_CORE_VERSION = "0.20.0"
 CORE_PACKAGE = "dcc-mcp-core"
 ADDON_PLATFORMS = ("win64", "linux", "macos")
-REMOVED_CAPTURE_HELPER = "dcc-mcp-capture-helper.exe"
 
 # PyPI ships ``cp38-abi3-*`` wheels (stable ABI) for win/linux/macos — not cp311-tagged wheels.
 # Match platform first, then prefer stable abi3 builds.
@@ -213,23 +212,6 @@ def download_core_wheel(version: str, platform: str, dest_dir: pathlib.Path) -> 
     return dest
 
 
-def validate_core_wheel(wheel_path: pathlib.Path) -> None:
-    """Reject Core wheels containing the retired standalone capture helper."""
-    try:
-        with zipfile.ZipFile(wheel_path) as archive:
-            removed_members = [
-                name
-                for name in archive.namelist()
-                if pathlib.PurePosixPath(name.replace("\\", "/")).name.lower() == REMOVED_CAPTURE_HELPER
-            ]
-    except zipfile.BadZipFile as exc:
-        raise RuntimeError(f"Invalid dcc-mcp-core wheel: {wheel_path.name}") from exc
-
-    if removed_members:
-        members = ", ".join(sorted(removed_members))
-        raise RuntimeError(f"Refusing to bundle dcc-mcp-core wheel containing the removed capture helper ({members})")
-
-
 def _manifest_platforms_for_wheel(filename: str) -> list[str]:
     """Return the Blender Extension platforms supported by a wheel filename."""
     if "win_amd64" in filename:
@@ -330,7 +312,6 @@ def assemble(platform: str, output_dir: pathlib.Path) -> pathlib.Path:
         core_version = resolve_core_version()
         wheels_dir = tmp_dir / "wheels"
         wheel = download_core_wheel(core_version, platform, wheels_dir)
-        validate_core_wheel(wheel)
         wheels_out = addon_dir / "wheels"
         wheels_out.mkdir(parents=True, exist_ok=True)
         staged_wheel = wheels_out / wheel.name

--- a/packaging/release_smoke_checklist.md
+++ b/packaging/release_smoke_checklist.md
@@ -18,9 +18,8 @@ This checklist validates the GUI Extension install path for Blender 4.2+.
 
 ## 0. Windows Security Gate
 
-- [ ] Confirm the nested Core wheel does not contain the retired
-  `dcc-mcp-capture-helper.exe`. The package assembler enforces this
-  automatically and must fail closed if the file is present.
+- [ ] Confirm native UI Control resolves standalone `dcc-cua` 0.4.0 or newer;
+  the Blender ZIP must not bundle a separate capture or input helper.
 - [ ] Scan the final Windows release ZIP on a clean, Defender-enabled Windows
   host and record the Defender engine/signature versions with the result.
 - [ ] Do not publish when Defender reports a detection. Preserve the exact ZIP

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
 ]
 
 dependencies = [
-    # v0.19.63: the retired standalone capture helper is no longer bundled.
-    "dcc-mcp-core>=0.19.63,<1.0.0",
+    # v0.20.0: native UI Control is provided by standalone dcc-cua 0.4.0+.
+    "dcc-mcp-core>=0.20.0,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_blender/_core_compat.py
+++ b/src/dcc_mcp_blender/_core_compat.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from typing import Optional
 
-MIN_CORE_VERSION = "0.19.45"
+MIN_CORE_VERSION = "0.20.0"
 
 
 def _release_tuple(version: str) -> tuple[int, int, int]:

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -218,47 +218,6 @@ def test_distribution_license_retries_incomplete_download(tmp_path, monkeypatch)
     assert destination.read_bytes() == b"complete"
 
 
-def test_validate_core_wheel_rejects_removed_capture_helper(tmp_path):
-    assemble_zip = _load_assemble_zip_module()
-    wheel = tmp_path / "dcc_mcp_core-0.19.63-cp38-abi3-win_amd64.whl"
-    _write_fake_core_wheel(
-        wheel,
-        ("dcc_mcp_core/bin/dcc-mcp-capture-helper.exe",),
-    )
-
-    with pytest.raises(RuntimeError, match="removed capture helper"):
-        assemble_zip.validate_core_wheel(wheel)
-
-
-def test_validate_core_wheel_accepts_current_ui_control_host(tmp_path):
-    assemble_zip = _load_assemble_zip_module()
-    wheel = tmp_path / "dcc_mcp_core-0.19.69-cp38-abi3-win_amd64.whl"
-    _write_fake_core_wheel(
-        wheel,
-        ("dcc_mcp_core/bin/dcc-mcp-ui-control-host.exe",),
-    )
-
-    assemble_zip.validate_core_wheel(wheel)
-
-
-def test_assemble_rejects_core_wheel_with_removed_capture_helper(tmp_path, monkeypatch):
-    assemble_zip = _load_assemble_zip_module()
-    wheel = tmp_path / "dcc_mcp_core-0.19.63-cp38-abi3-win_amd64.whl"
-    _write_fake_core_wheel(
-        wheel,
-        ("dcc_mcp_core/bin/dcc-mcp-capture-helper.exe",),
-    )
-    monkeypatch.setattr(assemble_zip, "resolve_core_version", lambda: "0.19.63")
-    monkeypatch.setattr(
-        assemble_zip,
-        "download_core_wheel",
-        lambda version, platform, dest_dir: wheel,
-    )
-
-    with pytest.raises(RuntimeError, match="removed capture helper"):
-        assemble_zip.assemble(platform="win64", output_dir=tmp_path)
-
-
 def test_addon_register_starts_server_with_core_backed_blender_ui_dispatcher(monkeypatch):
     """GUI add-on enable must wire the core-backed UI dispatcher before serving tools."""
     registered_classes = []

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -19,10 +19,10 @@ def _load_assemble_zip_module():
     return mod
 
 
-def test_core_dependency_floor_is_01963():
+def test_core_dependency_floor_is_0200():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert '"dcc-mcp-core>=0.19.63,<1.0.0"' in pyproject
+    assert '"dcc-mcp-core>=0.20.0,<1.0.0"' in pyproject
 
 
 def test_packaging_core_floor_matches_pyproject():
@@ -36,11 +36,11 @@ def test_packaging_core_floor_matches_pyproject():
 def test_preloaded_core_below_floor_is_rejected():
     from dcc_mcp_blender._core_compat import require_compatible_core
 
-    with pytest.raises(RuntimeError, match="preloaded dcc-mcp-core 0.19.21"):
-        require_compatible_core("0.19.21", module_path="/host/site-packages/dcc_mcp_core")
+    with pytest.raises(RuntimeError, match="preloaded dcc-mcp-core 0.19.94"):
+        require_compatible_core("0.19.94", module_path="/host/site-packages/dcc_mcp_core")
 
 
 def test_preloaded_core_at_floor_is_accepted():
     from dcc_mcp_blender._core_compat import require_compatible_core
 
-    require_compatible_core("0.19.63", module_path="/extension/site-packages/dcc_mcp_core")
+    require_compatible_core("0.20.0", module_path="/extension/site-packages/dcc_mcp_core")


### PR DESCRIPTION
Requires dcc-mcp-core 0.20.0, removes the retired capture-helper packaging contract, and delegates screenshot/input ownership to dcc-cua 0.4.

Validation: 14 targeted tests passed; Ruff and git diff checks passed.