### PR TITLE
fix: harden Blender extension runtime lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,9 @@ The extension ZIP is assembled by `packaging/assemble_zip.py`. It resolves the l
 
 Native UI Control requires standalone `dcc-cua` 0.4.0 or newer on `PATH` (or
 `DCC_MCP_CUA_BINARY`). Core owns the `ui_control__*` contract; the Blender ZIP
-does not bundle a second capture or input helper.
+does not bundle a second capture or input helper. At startup, the extension
+binds UI Control to the current Blender process ID and refuses a conflicting
+process binding, so a request cannot widen the adapter to another window.
 
 ### Option 2 — Install via pip (for scripts / CI)
 

--- a/packaging/addon_entry/__init__.py
+++ b/packaging/addon_entry/__init__.py
@@ -36,16 +36,53 @@ bl_info = {
 
 _DEFAULT_GATEWAY_PORT = 9765
 _BACKGROUND_RENDER_ENV = "DCC_MCP_BACKGROUND_RENDER"
+_UI_CONTROL_PROCESS_ID_ENV = "DCC_MCP_UI_CONTROL_PROCESS_ID"
 
 _draw_handlers: List[Tuple[str, object]] = []
 _server_dispatcher: Any = None
 _server_host: Any = None
+_runtime_import_aliases: Any = None
 
 
 def _addon_module(name: str):
     """Import a bundled module through the active add-on package namespace."""
     package = __package__ if (__package__ or "").startswith("bl_ext.") else "dcc_mcp_blender"
     return importlib.import_module(f"{package}.{name}")
+
+
+def _install_runtime_import_aliases() -> None:
+    """Expose public skill imports without mutating Blender's ``sys.path``."""
+    global _runtime_import_aliases  # noqa: PLW0603
+    package = __package__ or ""
+    if not package.startswith("bl_ext.") or _runtime_import_aliases is not None:
+        return
+    installer = _addon_module("_extension_imports").install_extension_import_aliases
+    _runtime_import_aliases = installer(package)
+
+
+def _remove_runtime_import_aliases() -> None:
+    global _runtime_import_aliases  # noqa: PLW0603
+    aliases = _runtime_import_aliases
+    _runtime_import_aliases = None
+    if aliases is not None:
+        aliases.uninstall()
+
+
+def _bind_ui_control_to_host_process() -> None:
+    """Fail closed unless UI control is scoped to this Blender process."""
+    current_process_id = os.getpid()
+    configured = os.environ.get(_UI_CONTROL_PROCESS_ID_ENV, "").strip()
+    if configured:
+        try:
+            configured_process_id = int(configured, 10)
+        except ValueError as exc:
+            raise RuntimeError(f"Invalid {_UI_CONTROL_PROCESS_ID_ENV}={configured!r}") from exc
+        if configured_process_id != current_process_id:
+            raise RuntimeError(
+                f"{_UI_CONTROL_PROCESS_ID_ENV} must identify the current Blender process "
+                f"({current_process_id}), got {configured_process_id}"
+            )
+    os.environ[_UI_CONTROL_PROCESS_ID_ENV] = str(current_process_id)
 
 
 def _env_port(name: str, default: int) -> int:
@@ -68,41 +105,47 @@ def _start_server_with_host():
     """Start the MCP server with a Blender main-thread dispatcher attached."""
     global _server_dispatcher, _server_host  # noqa: PLW0603
 
-    # The release ZIP replaces the library package entrypoint with this Blender
-    # add-on entrypoint. Enforce the same compatibility contract here before
-    # importing host/server modules that bind dcc-mcp-core integrations.
-    _addon_module("_core_compat").require_compatible_core()
-    host = _addon_module("host")
-    server_module = _addon_module("server")
-    BlenderUiDispatcher = host.BlenderUiDispatcher
-    get_server = server_module.get_server
-    start_server = server_module.start_server
-    stop_server = server_module.stop_server
-
-    existing = get_server()
-    if existing is not None and getattr(existing, "is_running", False):
-        if _server_host is not None:
-            return existing
-        stop_server()
-
-    dispatcher = BlenderUiDispatcher()
+    _bind_ui_control_to_host_process()
+    _install_runtime_import_aliases()
     try:
-        server = start_server(
-            gateway_port=_env_port("DCC_MCP_GATEWAY_PORT", _DEFAULT_GATEWAY_PORT),
-            registry_dir=os.environ.get("DCC_MCP_REGISTRY_DIR") or None,
-            dispatcher=dispatcher,
-        )
-        dispatcher.start()
-    except Exception:
-        with suppress(Exception):
-            stop_server()
-        with suppress(Exception):
-            dispatcher.stop()
-        raise
+        # The release ZIP replaces the library package entrypoint with this
+        # Blender add-on entrypoint. Enforce the same compatibility contract
+        # before importing host/server modules that bind dcc-mcp-core.
+        _addon_module("_core_compat").require_compatible_core()
+        host = _addon_module("host")
+        server_module = _addon_module("server")
+        BlenderUiDispatcher = host.BlenderUiDispatcher
+        get_server = server_module.get_server
+        start_server = server_module.start_server
+        stop_server = server_module.stop_server
 
-    _server_dispatcher = dispatcher
-    _server_host = dispatcher
-    return server
+        existing = get_server()
+        if existing is not None and getattr(existing, "is_running", False):
+            if _server_host is not None:
+                return existing
+            stop_server()
+
+        dispatcher = BlenderUiDispatcher()
+        try:
+            server = start_server(
+                gateway_port=_env_port("DCC_MCP_GATEWAY_PORT", _DEFAULT_GATEWAY_PORT),
+                registry_dir=os.environ.get("DCC_MCP_REGISTRY_DIR") or None,
+                dispatcher=dispatcher,
+            )
+            dispatcher.start()
+        except Exception:
+            with suppress(Exception):
+                stop_server()
+            with suppress(Exception):
+                dispatcher.stop()
+            raise
+
+        _server_dispatcher = dispatcher
+        _server_host = dispatcher
+        return server
+    except Exception:
+        _remove_runtime_import_aliases()
+        raise
 
 
 def _stop_server_with_host() -> None:
@@ -518,6 +561,8 @@ def unregister() -> None:
         print("[DCC MCP Blender] Server stopped")
     except Exception as exc:  # noqa: BLE001
         print(f"[DCC MCP Blender] Failed to stop server: {exc}")
+    finally:
+        _remove_runtime_import_aliases()
 
 
 __addon_version__ = "0.2.0"  # x-release-please-version

--- a/src/dcc_mcp_blender/_extension_imports.py
+++ b/src/dcc_mcp_blender/_extension_imports.py
@@ -1,0 +1,118 @@
+"""Resolve public adapter imports inside Blender's extension namespace.
+
+Blender 4.2+ loads extensions below ``bl_ext.<repository>.<extension>`` and
+does not put the extension root on ``sys.path``.  DCC-MCP skill scripts keep
+using the distribution's public ``dcc_mcp_blender`` import contract, so an
+extension needs a namespace bridge without importing a second copy of the
+adapter or mutating ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.abc
+import importlib.util
+import sys
+from types import ModuleType
+from typing import Any, List, Optional
+
+
+class _AliasModule(ModuleType):
+    """Module facade delegating reads to one canonical extension module."""
+
+    def __init__(self, alias: str, target: ModuleType, owner: "ExtensionImportAliases") -> None:
+        super().__init__(alias, getattr(target, "__doc__", None))
+        self.__dict__["_dcc_mcp_alias_target"] = target
+        self.__dict__["_dcc_mcp_alias_owner"] = owner
+        if hasattr(target, "__path__"):
+            self.__path__ = target.__path__  # type: ignore[attr-defined]
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.__dict__["_dcc_mcp_alias_target"], name)
+
+    def __dir__(self) -> List[str]:
+        return sorted(set(super().__dir__()) | set(dir(self.__dict__["_dcc_mcp_alias_target"])))
+
+
+class _AliasLoader(importlib.abc.Loader):
+    def __init__(self, target: ModuleType, owner: "ExtensionImportAliases") -> None:
+        self._target = target
+        self._owner = owner
+
+    def create_module(self, spec: importlib.machinery.ModuleSpec) -> ModuleType:
+        return _AliasModule(spec.name, self._target, self._owner)
+
+    def exec_module(self, module: ModuleType) -> None:
+        return None
+
+
+class ExtensionImportAliases(importlib.abc.MetaPathFinder):
+    """Map one public package prefix to the already-loaded extension package."""
+
+    def __init__(self, canonical_package: str, public_package: str) -> None:
+        self.canonical_package = canonical_package
+        self.public_package = public_package
+        self._installed = False
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: Optional[object],
+        target: Optional[ModuleType] = None,
+    ) -> Optional[importlib.machinery.ModuleSpec]:
+        del path, target
+        if fullname == self.public_package:
+            suffix = ""
+        elif fullname.startswith(f"{self.public_package}."):
+            suffix = fullname[len(self.public_package) :]
+        else:
+            return None
+
+        canonical = importlib.import_module(f"{self.canonical_package}{suffix}")
+        return importlib.util.spec_from_loader(
+            fullname,
+            _AliasLoader(canonical, self),
+            is_package=hasattr(canonical, "__path__"),
+        )
+
+    def install(self) -> "ExtensionImportAliases":
+        if self._installed:
+            return self
+        canonical = importlib.import_module(self.canonical_package)
+        existing = sys.modules.get(self.public_package)
+        if existing is not None and existing is not canonical and not self.owns(existing):
+            raise RuntimeError(f"Cannot expose {self.public_package!r}: a different module is already loaded")
+        sys.meta_path.insert(0, self)
+        self._installed = True
+        return self
+
+    def uninstall(self) -> None:
+        if self in sys.meta_path:
+            sys.meta_path.remove(self)
+        for name, module in tuple(sys.modules.items()):
+            if (name == self.public_package or name.startswith(f"{self.public_package}.")) and self.owns(module):
+                sys.modules.pop(name, None)
+        self._installed = False
+
+    def owns(self, module: object) -> bool:
+        return isinstance(module, ModuleType) and getattr(module, "_dcc_mcp_alias_owner", None) is self
+
+
+def install_extension_import_aliases(
+    canonical_package: str,
+    public_package: str = "dcc_mcp_blender",
+) -> ExtensionImportAliases:
+    """Install an idempotent, removable public-import bridge."""
+    if not canonical_package or canonical_package == public_package:
+        raise ValueError("canonical_package must be a distinct extension namespace")
+    for finder in sys.meta_path:
+        if (
+            isinstance(finder, ExtensionImportAliases)
+            and finder.canonical_package == canonical_package
+            and finder.public_package == public_package
+        ):
+            return finder
+    return ExtensionImportAliases(canonical_package, public_package).install()
+
+
+__all__ = ["ExtensionImportAliases", "install_extension_import_aliases"]

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import hashlib
 import importlib.util
+import os
 import pathlib
 import re
 import sys
@@ -100,6 +101,93 @@ def test_extension_namespace_import_does_not_create_top_level_alias(monkeypatch)
     assert server.__name__ == f"{extension_name}.server"
     assert not any(name == "dcc_mcp_blender" or name.startswith("dcc_mcp_blender.") for name in sys.modules)
 
+    module._install_runtime_import_aliases()
+    try:
+        public_server = importlib.import_module("dcc_mcp_blender.server")
+        assert public_server.get_server is server.get_server
+        assert public_server is not server
+        assert public_server._dcc_mcp_alias_target is server
+
+        lifecycle_calls = []
+        fake_bpy.ops = SimpleNamespace(
+            wm=SimpleNamespace(read_factory_settings=lambda **kwargs: lifecycle_calls.append(("reset", kwargs)))
+        )
+        dispatcher = SimpleNamespace(start_pump=lambda: lifecycle_calls.append(("start_pump", None)))
+        readiness = SimpleNamespace(
+            revalidate_dispatcher=lambda: lifecycle_calls.append(("revalidate_dispatcher", None))
+        )
+        monkeypatch.setattr(
+            server,
+            "get_server",
+            lambda: SimpleNamespace(_blender_dispatcher=dispatcher, readiness=readiness),
+        )
+        script_path = source_root / "skills" / "blender-scene" / "scripts" / "new_scene.py"
+        script_spec = importlib.util.spec_from_file_location("extension_new_scene_script", script_path)
+        script = importlib.util.module_from_spec(script_spec)
+        script_spec.loader.exec_module(script)
+
+        result = script.new_scene()
+
+        assert result["success"] is True
+        assert lifecycle_calls == [
+            ("reset", {"use_empty": True}),
+            ("start_pump", None),
+            ("revalidate_dispatcher", None),
+        ]
+    finally:
+        module._remove_runtime_import_aliases()
+
+    assert not any(name == "dcc_mcp_blender" or name.startswith("dcc_mcp_blender.") for name in sys.modules)
+
+
+def test_extension_startup_failure_removes_public_import_bridge(monkeypatch):
+    """A failed enable must not leave a finder or public facade installed."""
+    extension_name = "bl_ext.user_default.dcc_mcp_blender_failure"
+    source_root = ROOT / "src" / "dcc_mcp_blender"
+    fake_bpy = SimpleNamespace(types=SimpleNamespace(Operator=object, Menu=object))
+
+    for package in ("bl_ext", "bl_ext.user_default"):
+        module = ModuleType(package)
+        module.__path__ = []
+        monkeypatch.setitem(sys.modules, package, module)
+    for name in tuple(sys.modules):
+        if name == "dcc_mcp_blender" or name.startswith("dcc_mcp_blender."):
+            monkeypatch.delitem(sys.modules, name)
+    monkeypatch.setitem(sys.modules, "bpy", fake_bpy)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_PROCESS_ID", raising=False)
+
+    spec = importlib.util.spec_from_file_location(
+        extension_name,
+        ADDON_ENTRY,
+        submodule_search_locations=[str(source_root)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, extension_name, module)
+    spec.loader.exec_module(module)
+    original_addon_module = module._addon_module
+
+    def addon_module(name):
+        if name == "_core_compat":
+
+            def reject_core():
+                raise RuntimeError("incompatible core")
+
+            return SimpleNamespace(require_compatible_core=reject_core)
+        return original_addon_module(name)
+
+    monkeypatch.setattr(module, "_addon_module", addon_module)
+
+    with pytest.raises(RuntimeError, match="incompatible core"):
+        module._start_server_with_host()
+
+    assert module._runtime_import_aliases is None
+    assert not any(
+        getattr(finder, "canonical_package", None) == extension_name
+        and getattr(finder, "public_package", None) == "dcc_mcp_blender"
+        for finder in sys.meta_path
+    )
+    assert not any(name == "dcc_mcp_blender" or name.startswith("dcc_mcp_blender.") for name in sys.modules)
+
 
 def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monkeypatch):
     """The add-on package root must directly contain ``server.py`` and skills."""
@@ -125,6 +213,7 @@ def test_assembled_addon_zip_uses_flat_importable_package_layout(tmp_path, monke
     assert "__init__.py" in names
     assert "server.py" in names
     assert "host.py" in names
+    assert "_extension_imports.py" in names
     assert "skills/blender-scene/SKILL.md" in names
     assert "COPYING" in names
     assert "LICENSE-MIT" in names
@@ -270,6 +359,7 @@ def test_addon_register_starts_server_with_core_backed_blender_ui_dispatcher(mon
     monkeypatch.setenv("DCC_MCP_BLENDER_PORT", "18765")
     monkeypatch.setenv("DCC_MCP_GATEWAY_PORT", "19765")
     monkeypatch.setenv("DCC_MCP_REGISTRY_DIR", "/tmp/dcc-mcp-registry")
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_PROCESS_ID", raising=False)
 
     mod.register()
 
@@ -281,6 +371,7 @@ def test_addon_register_starts_server_with_core_backed_blender_ui_dispatcher(mon
         "registry_dir": "/tmp/dcc-mcp-registry",
         "dispatcher": calls[1][1],
     }
+    assert os.environ["DCC_MCP_UI_CONTROL_PROCESS_ID"] == str(os.getpid())
 
     mod.unregister()
 
@@ -292,6 +383,21 @@ def test_addon_register_starts_server_with_core_backed_blender_ui_dispatcher(mon
         "stop_server",
         "dispatcher.stop",
     ]
+
+
+def test_addon_rejects_ui_control_binding_to_another_process(monkeypatch):
+    spec = importlib.util.spec_from_file_location("addon_entry_ui_scope_test", str(ADDON_ENTRY))
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(
+        sys.modules,
+        "bpy",
+        SimpleNamespace(types=SimpleNamespace(Operator=object, Menu=object)),
+    )
+    spec.loader.exec_module(mod)
+    monkeypatch.setenv("DCC_MCP_UI_CONTROL_PROCESS_ID", str(os.getpid() + 1))
+
+    with pytest.raises(RuntimeError, match="must identify the current Blender process"):
+        mod._bind_ui_control_to_host_process()
 
 
 def test_addon_register_does_not_start_server_in_background_render_worker(monkeypatch):


### PR DESCRIPTION
## Summary
- bridge public `dcc_mcp_blender.*` skill imports to Blender's canonical `bl_ext.*` extension namespace without `sys.path` mutation or a second adapter copy
- bind UI Control to the current Blender PID and reject conflicting process scope
- remove the import bridge on every startup failure and unregister path
- document the exact-process UI boundary and lock the bridge into extension ZIP tests

## Validation
- `pytest tests -m "not e2e and not packaging"` (full suite)
- `pytest tests/test_addon_packaging.py -q` (12 passed)
- Ruff check and format check across the CI paths
- Python 3.7 `py_compile` for all changed Python files
- `uv build` plus `twine check` for wheel and sdist
- fresh Python 3.11 venv install: adapter 0.2.0, Core 0.20.5, 35 skills, import bridge present
- Windows extension ZIP assembled with Core 0.20.5 and the import bridge
- isolated Blender 4.5.12 LTS: readiness 6/6; typed `get_session_info` and `list_objects` succeeded from the extension namespace
- exact Blender PID/HWND DCC-CUA JSONL snapshot succeeded with the companion fix in dcc-mcp/dcc-cua#94

## Safety
- the user's existing unsaved Blender process was not modified, saved, or closed
- no logo or public showcase assets are included in this PR