### PR TITLE
fix: support Blender 5 startup installs

### DIFF
--- a/install.md
+++ b/install.md
@@ -10,7 +10,7 @@ do this:
 
 1. Read `skills/dcc-mcp-blender-setup/SKILL.md`.
 2. Run the setup script from the repository root.
-3. Help the user enable the Blender add-on (or start the server in Blender).
+3. Open Blender so the installed startup script can start the server.
 4. Configure the MCP host with the generated Streamable HTTP JSON.
 5. Run the smoke prompt to prove the connection works.
 
@@ -37,11 +37,34 @@ python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py --blender-p
 Blender ships its own Python at `<blender>/<major.minor>/python/bin/python(.exe)`.
 The script discovers it via env vars (`BLENDER_PYTHON`, `DCC_MCP_BLENDER_PYTHON`),
 the `--blender-python` / `--python` argument, a `blender` launcher on `PATH`, or
-common install locations, then runs `<blender_python> -m pip install ...`.
+common install locations, then runs `<blender_python> -m pip install ...`. It
+also writes `dcc_mcp_blender_startup.py` under Blender's per-user
+`scripts/startup` directory. The startup bridge exposes Blender 5.x-compatible
+`register()` / `unregister()` hooks and starts the server once Blender loads it.
 
-## Blender Add-on Step
+## Read-only Blender Python fallback
 
-After the script finishes, the user must enable the add-on in Blender:
+If Blender's bundled `site-packages` is not writable, install to the user site:
+
+```bash
+<blender-python> -m pip install --user --upgrade dcc-mcp-blender
+python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py --source pypi --user
+```
+
+The `--user` fallback must be paired with Blender's system-environment flag so
+Blender includes the user site-packages directory:
+
+```bash
+blender --python-use-system-env
+```
+
+The setup script prints this launch command whenever `--user` is selected.
+
+## Blender Extension alternative
+
+The release ZIP is an alternative to the pip/startup-script path above. It
+bundles the matching `dcc-mcp-core` wheel in Blender's isolated extension
+environment, so do not run the manual pip setup when using the ZIP:
 
 1. Open Blender (4.2+ required).
 2. Go to `Edit > Preferences > Extensions > Install from Disk…`.
@@ -49,15 +72,6 @@ After the script finishes, the user must enable the add-on in Blender:
    format; the legacy add-on path is unsupported.)
 3. Select the release ZIP (`dcc_mcp_blender_addon_<platform>_vX.Y.Z.zip`).
 4. Enable **DCC MCP Blender** — the embedded server starts automatically.
-
-The Blender 4.2+ add-on ZIP bundles the matching `dcc-mcp-core` wheel inside the
-extension's isolated environment, so the manual pip step is only needed for
-pip / CI scenarios. For those, start the server from Blender's Python console:
-
-```python
-import dcc_mcp_blender
-dcc_mcp_blender.start_server()
-```
 
 Blender instances use OS-assigned ports and register with the stable gateway:
 

--- a/skills/dcc-mcp-blender-setup/SKILL.md
+++ b/skills/dcc-mcp-blender-setup/SKILL.md
@@ -2,9 +2,8 @@
 name: dcc-mcp-blender-setup
 description: |-
   Set up dcc-mcp-blender for an agent or operator: install Blender Python
-  dependencies with Blender's bundled interpreter, generate MCP host
-  configuration, guide the user through enabling the Blender add-on, and run a
-  first live-tool smoke prompt.
+  dependencies with Blender's bundled interpreter, install a startup bridge,
+  generate MCP host configuration, and run a first live-tool smoke prompt.
 license: MIT
 allowed-tools: Bash Read
 metadata:
@@ -37,11 +36,9 @@ root `install.md` first, then follow this skill.
 End with:
 
 - `dcc-mcp-blender` and its pip dependencies installed into the target Blender
-  bundled-Python environment (or available via the add-on ZIP's isolated
-  wheels).
+  bundled-Python environment.
 - An MCP host config snippet that points to the Blender MCP server.
-- The user guided to enable the **DCC MCP Blender** add-on so the embedded
-  server starts.
+- A Blender 5.x-compatible startup bridge that starts the embedded server.
 - A live smoke prompt that proves the agent can discover and call Blender tools.
 
 ## Fast Path
@@ -62,7 +59,10 @@ The script:
    `dcc-mcp-blender` ships no optional extras, so the package is installed
    plainly and `dcc-mcp-core` is resolved transitively.
 3. Verifies `import dcc_mcp_blender`.
-4. Writes a reusable MCP JSON snippet and smoke prompt under
+4. Writes a Blender 5.x-compatible `dcc_mcp_blender_startup.py` with
+   `register()` / `unregister()` hooks into the per-user `scripts/startup`
+   directory.
+5. Writes a reusable MCP JSON snippet and smoke prompt under
    `.dcc-mcp/agent-setup/`.
 
 Use PyPI instead of the local checkout when setting up an end-user machine:
@@ -77,10 +77,24 @@ If discovery fails, ask the user for the full Blender Python path and re-run:
 python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py --blender-python "C:\Program Files\Blender Foundation\Blender 4.2\4.2\python\bin\python.exe"
 ```
 
-> Blender 4.2+ add-on installs (Option 1 in `README.md`) bundle the
-> `dcc-mcp-core` wheel inside the extension's isolated environment, so a manual
-> pip step into Blender's Python is only required for pip/CI scenarios or older
-> Blender add-on layouts.
+If Blender's bundled `site-packages` is read-only, select the user-site fallback:
+
+```bash
+python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py --source pypi --user
+```
+
+Then launch Blender with the required matching flag:
+
+```bash
+blender --python-use-system-env
+```
+
+Do not omit `--python-use-system-env`: Blender otherwise ignores packages
+installed by pip with `--user`.
+
+> Blender 4.2+ Extension ZIP installs (Option 1 in `README.md`) are an
+> alternative path. They bundle `dcc-mcp-core` in an isolated environment and
+> must not be combined with this pip/startup-script setup.
 
 ## MCP Configuration
 
@@ -103,22 +117,17 @@ Multiple Blender instances register their exact endpoints automatically; use
 When editing an existing MCP config, preserve unrelated servers. Merge only the
 `blender` server entry unless the user asks for a different server name.
 
-## User Hand-Off: Enable the Blender Add-on
+## User Hand-Off: Start Blender
 
 After pip setup and MCP JSON generation, tell the user:
 
-1. Open Blender (4.2+ recommended).
-2. Go to `Edit > Preferences > Extensions > Install from Disk…`.
-3. Select the release ZIP
-   (`dcc_mcp_blender_addon_<platform>_vX.Y.Z.zip` from the Releases page).
-4. Enable **DCC MCP Blender**.
-5. The embedded MCP server starts automatically; use the top-bar
-   `DCC MCP > Show Server URLs…` menu to confirm the URL.
+1. Open Blender with the launch command printed by the setup script.
+2. The installed `dcc_mcp_blender_startup.py` starts the server automatically.
+3. Use `dcc-mcp-cli list` to confirm the Blender instance and exact URL.
 
 The stable gateway URL is `http://127.0.0.1:9765/mcp`.
 
-For pip/CI installs without the add-on, start the server from Blender's Python
-console instead:
+For a manual troubleshooting start from Blender's Python console:
 
 ```python
 import dcc_mcp_blender
@@ -133,8 +142,7 @@ blender --background --python src/dcc_mcp_blender/blender_bootstrap.py
 
 ## First Live Smoke Prompt
 
-Ask the MCP host to run this prompt after Blender is open and the add-on is
-enabled:
+Ask the MCP host to run this prompt after Blender is open and registered:
 
 ```text
 Use the Blender MCP server. First call dcc_capability_manifest with loaded_only=false.
@@ -162,5 +170,6 @@ Expected behavior:
   the embedded server has not started yet.
 - Tool missing: call `dcc_capability_manifest` or `search_skills`, then
   `load_skill("<skill-name>")`.
-- Add-on enabled but no server: check Blender's system console for
-  `[DCC MCP Blender]` startup lines, and verify firewall/localhost rules.
+- No server after launch: verify the startup script under the per-user
+  `scripts/startup` directory, check Blender's system console, and verify
+  firewall/localhost rules.

--- a/skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py
+++ b/skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py
@@ -13,6 +13,52 @@ from pathlib import Path
 from typing import Iterable, Optional
 
 DEFAULT_MCP_URL = "http://127.0.0.1:9765/mcp"
+STARTUP_SCRIPT_NAME = "dcc_mcp_blender_startup.py"
+STARTUP_SCRIPT = '''"""Auto-start dcc-mcp-blender from Blender's startup registry."""
+
+from __future__ import annotations
+
+_server = None
+_owns_server = False
+
+
+def register():
+    """Start the MCP server once Blender has loaded this startup script."""
+    global _owns_server, _server
+    if _server is not None and getattr(_server, "is_running", True):
+        return _server
+
+    from dcc_mcp_blender import get_server, start_server
+
+    existing = get_server()
+    if existing is not None and getattr(existing, "is_running", False):
+        _server = existing
+        _owns_server = False
+        return _server
+
+    _server = start_server()
+    _owns_server = True
+    return _server
+
+
+def unregister():
+    """Stop the server started by this startup script."""
+    global _owns_server, _server
+    if _server is None:
+        return
+
+    try:
+        if not _owns_server:
+            return
+
+        from dcc_mcp_blender import get_server, stop_server
+
+        if get_server() is _server:
+            stop_server()
+    finally:
+        _server = None
+        _owns_server = False
+'''
 
 
 def run(command: list[str], cwd: Optional[Path] = None) -> None:
@@ -110,22 +156,83 @@ def find_repo_root() -> Path:
     return Path.cwd()
 
 
-def install_package(blender_python: Path, source: str, repo_root: Path, skip_install: bool) -> None:
+def install_package(
+    blender_python: Path,
+    source: str,
+    repo_root: Path,
+    skip_install: bool,
+    user_install: bool = False,
+) -> None:
     if skip_install:
         print("Skipping pip install because --skip-install was passed.")
         return
 
-    run([str(blender_python), "-m", "ensurepip", "--upgrade"])
-    run([str(blender_python), "-m", "pip", "install", "--upgrade", "pip"])
+    ensurepip_command = [str(blender_python), "-m", "ensurepip", "--upgrade"]
+    pip_upgrade_command = [str(blender_python), "-m", "pip", "install", "--upgrade", "pip"]
+    if user_install:
+        ensurepip_command.append("--user")
+        pip_upgrade_command.append("--user")
+    run(ensurepip_command)
+    run(pip_upgrade_command)
 
     # dcc-mcp-blender ships no optional install extras (no `[sidecar]`); install
     # the package plainly. The dcc-mcp-core dependency is resolved transitively.
+    install_command = [str(blender_python), "-m", "pip", "install"]
+    if user_install:
+        install_command.append("--user")
     if source == "local":
-        run([str(blender_python), "-m", "pip", "install", "-e", "."], cwd=repo_root)
+        run(install_command + ["-e", "."], cwd=repo_root)
     elif source == "pypi":
-        run([str(blender_python), "-m", "pip", "install", "--upgrade", "dcc-mcp-blender"])
+        run(install_command + ["--upgrade", "dcc-mcp-blender"])
     else:
         raise SystemExit("Unknown source: %s" % source)
+
+
+def _blender_version_from_python(blender_python: Path) -> str:
+    """Return ``major.minor`` from Blender's ``<version>/python/bin`` layout."""
+    version = blender_python.parent.parent.parent.name
+    if not version or not version[0].isdigit():
+        raise SystemExit("Could not infer Blender version from %s; pass --startup-scripts-dir." % blender_python)
+    return version
+
+
+def resolve_blender_scripts_dir(blender_python: Path, explicit: Optional[str]) -> Path:
+    """Resolve Blender's writable per-user scripts directory."""
+    if explicit:
+        return Path(explicit).expanduser()
+
+    configured = os.environ.get("BLENDER_USER_SCRIPTS")
+    if configured:
+        return Path(configured).expanduser()
+
+    version = _blender_version_from_python(blender_python)
+    if os.name == "nt":
+        appdata = os.environ.get("APPDATA")
+        if not appdata:
+            raise SystemExit("APPDATA is unavailable; pass --startup-scripts-dir.")
+        return Path(appdata) / "Blender Foundation" / "Blender" / version / "scripts"
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "Blender" / version / "scripts"
+    config_home = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    return config_home / "blender" / version / "scripts"
+
+
+def install_startup_script(blender_python: Path, explicit_scripts_dir: Optional[str] = None) -> Path:
+    """Install the Blender 5.x-registerable bridge into the user startup directory."""
+    startup_dir = resolve_blender_scripts_dir(blender_python, explicit_scripts_dir) / "startup"
+    startup_dir.mkdir(parents=True, exist_ok=True)
+    startup_path = startup_dir / STARTUP_SCRIPT_NAME
+    startup_path.write_text(STARTUP_SCRIPT, encoding="utf-8")
+    print("Wrote %s" % startup_path)
+    return startup_path
+
+
+def blender_launch_command(executable: str, user_install: bool = False) -> list[str]:
+    """Return the launch command required for the selected pip install scope."""
+    command = [executable]
+    if user_install:
+        command.append("--python-use-system-env")
+    return command
 
 
 def verify_import(blender_python: Path) -> None:
@@ -192,6 +299,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Only verify imports and write MCP snippets.",
     )
+    parser.add_argument(
+        "--user",
+        dest="user_install",
+        action="store_true",
+        help="Install into the user site; launch Blender with --python-use-system-env.",
+    )
+    parser.add_argument(
+        "--startup-scripts-dir",
+        help="Override Blender's per-user scripts directory (the parent of startup/).",
+    )
     return parser.parse_args(argv)
 
 
@@ -205,17 +322,26 @@ def main(argv: list[str]) -> int:
     print("Blender Python: %s" % blender_python)
     print("MCP URL: %s" % args.mcp_url)
 
-    install_package(blender_python, args.source, repo_root, args.skip_install)
+    install_package(
+        blender_python,
+        args.source,
+        repo_root,
+        args.skip_install,
+        user_install=args.user_install,
+    )
     if not args.skip_install:
         verify_import(blender_python)
+    startup_path = install_startup_script(blender_python, args.startup_scripts_dir)
     write_mcp_snippets(out_dir, args.server_name, args.mcp_url)
 
     print("")
     print("Next:")
-    print("1. Open Blender.")
-    print("2. Edit > Preferences > Extensions > Install from Disk (the release ZIP), then enable 'DCC MCP Blender'.")
+    launch_command = " ".join(blender_launch_command("blender", user_install=args.user_install))
+    print("1. Open Blender with: %s" % launch_command)
+    print("2. The installed startup script starts DCC MCP Blender automatically.")
     print("3. Configure the MCP host with %s." % (out_dir / "mcp-streamable-http.json"))
     print("4. Run the smoke prompt in %s." % (out_dir / "smoke-prompt.txt"))
+    print("Startup script: %s" % startup_path)
     return 0
 
 

--- a/tests/test_startup_install.py
+++ b/tests/test_startup_install.py
@@ -1,0 +1,120 @@
+"""Regression tests for Blender startup and read-only install fallbacks."""
+
+from __future__ import annotations
+
+import builtins
+import importlib.util
+import pathlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+ROOT = pathlib.Path(__file__).parent.parent
+SETUP_SCRIPT = ROOT / "skills" / "dcc-mcp-blender-setup" / "scripts" / "setup_dcc_mcp_blender.py"
+
+
+def _load_setup_module():
+    spec = importlib.util.spec_from_file_location("setup_dcc_mcp_blender_for_tests", SETUP_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_startup_module(path: pathlib.Path, monkeypatch):
+    """Import the generated startup script while Blender dependencies are unavailable."""
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "dcc_mcp_blender" or name.startswith("dcc_mcp_blender."):
+            raise AssertionError("startup discovery imported dcc_mcp_blender eagerly")
+        return real_import(name, *args, **kwargs)
+
+    spec = importlib.util.spec_from_file_location("dcc_mcp_blender_startup_for_tests", path)
+    module = importlib.util.module_from_spec(spec)
+    with monkeypatch.context() as context:
+        context.setattr(builtins, "__import__", guarded_import)
+        spec.loader.exec_module(module)
+    return module
+
+
+def test_setup_installs_blender5_registerable_idempotent_startup_script(monkeypatch, tmp_path):
+    """The real setup entrypoint must install a Blender 5.x registerable script."""
+    setup = _load_setup_module()
+    blender_python = tmp_path / "Blender 5.2" / "5.2" / "python" / "bin" / "python.exe"
+    blender_python.parent.mkdir(parents=True)
+    blender_python.touch()
+    user_scripts = tmp_path / "user-scripts"
+
+    monkeypatch.setattr(setup, "find_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(setup, "resolve_blender_python", lambda _explicit: blender_python)
+    monkeypatch.setattr(setup, "install_package", lambda *args, **kwargs: None)
+    monkeypatch.setattr(setup, "verify_import", lambda _python: None)
+    monkeypatch.setattr(setup, "write_mcp_snippets", lambda *args, **kwargs: None)
+    monkeypatch.setenv("BLENDER_USER_SCRIPTS", str(user_scripts))
+
+    assert setup.main([]) == 0
+
+    startup_path = user_scripts / "startup" / "dcc_mcp_blender_startup.py"
+    assert startup_path.is_file()
+    startup = _load_startup_module(startup_path, monkeypatch)
+    assert callable(startup.register)
+    assert callable(startup.unregister)
+
+    calls = []
+    state = {"server": None}
+    running_server = SimpleNamespace(is_running=True)
+    fake_package = ModuleType("dcc_mcp_blender")
+
+    def start_server():
+        calls.append("start")
+        state["server"] = running_server
+        return running_server
+
+    def stop_server():
+        calls.append("stop")
+        state["server"] = None
+
+    fake_package.get_server = lambda: state["server"]
+    fake_package.start_server = start_server
+    fake_package.stop_server = stop_server
+    monkeypatch.setitem(sys.modules, "dcc_mcp_blender", fake_package)
+
+    assert startup.register() is running_server
+    assert startup.register() is running_server
+    assert calls == ["start"]
+
+    startup.unregister()
+    startup.unregister()
+    assert calls == ["start", "stop"]
+
+    existing_server = SimpleNamespace(is_running=True)
+    state["server"] = existing_server
+    assert startup.register() is existing_server
+    startup.unregister()
+    assert calls == ["start", "stop"]
+    assert state["server"] is existing_server
+
+
+def test_user_install_pairs_pip_user_with_blender_system_environment(monkeypatch):
+    """The fallback must install to user site and surface Blender's matching launch flag."""
+    setup = _load_setup_module()
+    args = setup.parse_args(["--user"])
+    commands = []
+    monkeypatch.setattr(setup, "run", lambda command, cwd=None: commands.append((command, cwd)))
+
+    setup.install_package(
+        pathlib.Path("blender-python"),
+        "pypi",
+        ROOT,
+        skip_install=False,
+        user_install=args.user_install,
+    )
+
+    assert all("--user" in command for command, _cwd in commands)
+    assert setup.blender_launch_command("blender", user_install=args.user_install) == [
+        "blender",
+        "--python-use-system-env",
+    ]
+
+    install_guide = (ROOT / "install.md").read_text(encoding="utf-8")
+    assert "-m pip install --user" in install_guide
+    assert "blender --python-use-system-env" in install_guide


### PR DESCRIPTION
## Summary
- install a lazy, ownership-safe Blender 5.x startup bridge with idempotent register/unregister hooks
- add the paired pip --user and Blender --python-use-system-env fallback to setup and install guidance

## Validation
- python -m pytest tests -q -m "not e2e and not packaging"
- python -m pytest tests/test_startup_install.py tests/test_addon_packaging.py -q
- python -m ruff check src tests tools/lint_skills.py packaging/assemble_zip.py packaging/addon_entry/__init__.py
- python tools/lint_skills.py --warnings-as-errors
- dcc-mcp-cli lint --warnings-as-errors skills src/dcc_mcp_blender/skills
- vx python@3.7 tools/check_py37_syntax.py
- python -m build; python -m twine check dist/*
- python packaging/assemble_zip.py --platform <win64|linux|macos> --output-dir <output>

Fixes #186