### PR TITLE
fix: capture viewport at requested dimensions

### DIFF
--- a/src/dcc_mcp_blender/skills/blender-render/scripts/capture_viewport.py
+++ b/src/dcc_mcp_blender/skills/blender-render/scripts/capture_viewport.py
@@ -2,9 +2,75 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Optional
 
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def _view3d_override(context):
+    """Return a complete VIEW_3D operator context without changing UI state."""
+    current_window = getattr(context, "window", None)
+    windows = []
+    if current_window is not None:
+        windows.append(current_window)
+    window_manager = getattr(context, "window_manager", None)
+    for window in getattr(window_manager, "windows", ()) if window_manager is not None else ():
+        windows.append(window)
+
+    for window in windows:
+        screen = getattr(window, "screen", None)
+        for area in getattr(screen, "areas", ()) if screen is not None else ():
+            if getattr(area, "type", None) != "VIEW_3D":
+                continue
+            region = next(
+                (
+                    candidate
+                    for candidate in getattr(area, "regions", ())
+                    if getattr(candidate, "type", None) == "WINDOW"
+                ),
+                None,
+            )
+            if region is None:
+                continue
+            spaces = getattr(area, "spaces", None)
+            space = getattr(spaces, "active", None)
+            if space is None or getattr(space, "type", "VIEW_3D") != "VIEW_3D":
+                continue
+            return {
+                "window": window,
+                "screen": screen,
+                "area": area,
+                "region": region,
+                "space_data": space,
+            }
+    return None
+
+
+def _image_format(filepath: str, current: str) -> str:
+    formats = {
+        ".bmp": "BMP",
+        ".exr": "OPEN_EXR",
+        ".jpeg": "JPEG",
+        ".jpg": "JPEG",
+        ".png": "PNG",
+        ".tga": "TARGA",
+        ".tif": "TIFF",
+        ".tiff": "TIFF",
+    }
+    return formats.get(Path(filepath).suffix.lower(), current)
+
+
+def _output_dimensions(bpy, filepath: str) -> tuple[int, int]:
+    image = None
+    try:
+        image = bpy.data.images.load(filepath, check_existing=False)
+        if image is None:
+            raise RuntimeError("Blender could not load the viewport output")
+        return int(image.size[0]), int(image.size[1])
+    finally:
+        if image is not None:
+            bpy.data.images.remove(image)
 
 
 def capture_viewport(
@@ -28,39 +94,85 @@ def capture_viewport(
         if not filepath:
             return skill_error("Missing filepath", "Provide a filepath for the viewport image.")
 
+        override = _view3d_override(bpy.context)
+        if override is None:
+            return skill_error(
+                "VIEW_3D context unavailable",
+                "Open a Blender 3D Viewport and retry; no full-window screenshot fallback is used.",
+            )
+        temp_override = getattr(bpy.context, "temp_override", None)
+        if not callable(temp_override):
+            return skill_error(
+                "VIEW_3D context override unavailable",
+                "This Blender runtime cannot safely isolate a 3D Viewport capture.",
+            )
+
         scene = bpy.context.scene
         old_filepath = scene.render.filepath
         old_x = scene.render.resolution_x
         old_y = scene.render.resolution_y
+        old_percentage = scene.render.resolution_percentage
+        old_format = scene.render.image_settings.file_format
+        old_use_extension = scene.render.use_file_extension
+
+        percentage = max(1, int(old_percentage))
+        current_x = max(1, int(old_x) * percentage // 100)
+        current_y = max(1, int(old_y) * percentage // 100)
+        target_x = int(resolution_x) if resolution_x is not None else current_x
+        target_y = int(resolution_y) if resolution_y is not None else current_y
+        if target_x < 1 or target_y < 1:
+            return skill_error(
+                "Invalid viewport resolution",
+                "resolution_x and resolution_y must each be at least 1 pixel.",
+            )
 
         try:
             scene.render.filepath = filepath
-            if resolution_x is not None:
-                scene.render.resolution_x = int(resolution_x)
-            if resolution_y is not None:
-                scene.render.resolution_y = int(resolution_y)
+            scene.render.resolution_x = target_x
+            scene.render.resolution_y = target_y
+            scene.render.resolution_percentage = 100
+            scene.render.image_settings.file_format = _image_format(filepath, old_format)
+            scene.render.use_file_extension = False
 
-            try:
-                bpy.ops.screen.screenshot(filepath=filepath)
-                method = "screen"
-            except Exception:
-                bpy.ops.render.opengl(write_still=True, view_context=True)
-                method = "opengl"
+            with temp_override(**override):
+                if not bpy.ops.render.opengl.poll():
+                    raise RuntimeError("OpenGL viewport render is unavailable in the selected VIEW_3D")
+                operator_result = bpy.ops.render.opengl(write_still=True, view_context=True)
+            if "FINISHED" not in operator_result:
+                raise RuntimeError(
+                    f"OpenGL viewport render did not finish (operator result: {sorted(operator_result)})"
+                )
+            width, height = _output_dimensions(bpy, filepath)
+            if (width, height) != (target_x, target_y):
+                raise RuntimeError(
+                    f"Viewport output dimensions {width}x{height} do not match requested {target_x}x{target_y}"
+                )
         finally:
             scene.render.filepath = old_filepath
             scene.render.resolution_x = old_x
             scene.render.resolution_y = old_y
+            scene.render.resolution_percentage = old_percentage
+            scene.render.image_settings.file_format = old_format
+            scene.render.use_file_extension = old_use_extension
 
         return skill_success(
             "Viewport captured",
             filepath=filepath,
-            method=method,
+            method="viewport_opengl",
+            width=width,
+            height=height,
             prompt="Viewport image saved. Use the file path to inspect the current view.",
         )
     except ImportError:
         return skill_error("Blender not available", "bpy could not be imported")
     except Exception as exc:
-        return skill_exception(exc, message="Failed to capture viewport")
+        return skill_exception(
+            exc,
+            message=f"Failed to capture viewport: {exc}",
+            possible_solutions=["Ensure a non-temporary VIEW_3D area is available, then retry."],
+            failure_stage="viewport_capture",
+            method="viewport_opengl",
+        )
 
 
 @skill_entry

--- a/src/dcc_mcp_blender/skills/blender-render/scripts/capture_viewport.py
+++ b/src/dcc_mcp_blender/skills/blender-render/scripts/capture_viewport.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import tempfile
 from pathlib import Path
 from typing import Optional
 
@@ -37,12 +39,16 @@ def _view3d_override(context):
             space = getattr(spaces, "active", None)
             if space is None or getattr(space, "type", "VIEW_3D") != "VIEW_3D":
                 continue
+            scene = getattr(window, "scene", None)
+            if scene is None:
+                continue
             return {
                 "window": window,
                 "screen": screen,
                 "area": area,
                 "region": region,
                 "space_data": space,
+                "scene": scene,
             }
     return None
 
@@ -71,6 +77,27 @@ def _output_dimensions(bpy, filepath: str) -> tuple[int, int]:
     finally:
         if image is not None:
             bpy.data.images.remove(image)
+
+
+def _destination_path(bpy, filepath: str) -> Path:
+    """Resolve Blender-relative paths while remaining testable without Blender."""
+    abspath = getattr(getattr(bpy, "path", None), "abspath", None)
+    resolved = abspath(filepath) if callable(abspath) else filepath
+    if not isinstance(resolved, (str, bytes)):
+        resolved = filepath
+    return Path(resolved).expanduser().resolve()
+
+
+def _staging_path(destination: Path) -> Path:
+    """Reserve a unique sibling name without leaving stale content to validate."""
+    descriptor, staged = tempfile.mkstemp(
+        prefix=f".{destination.stem}-",
+        suffix=destination.suffix,
+        dir=str(destination.parent),
+    )
+    os.close(descriptor)
+    os.unlink(staged)
+    return Path(staged)
 
 
 def capture_viewport(
@@ -107,53 +134,66 @@ def capture_viewport(
                 "This Blender runtime cannot safely isolate a 3D Viewport capture.",
             )
 
-        scene = bpy.context.scene
-        old_filepath = scene.render.filepath
-        old_x = scene.render.resolution_x
-        old_y = scene.render.resolution_y
-        old_percentage = scene.render.resolution_percentage
-        old_format = scene.render.image_settings.file_format
-        old_use_extension = scene.render.use_file_extension
-
-        percentage = max(1, int(old_percentage))
-        current_x = max(1, int(old_x) * percentage // 100)
-        current_y = max(1, int(old_y) * percentage // 100)
-        target_x = int(resolution_x) if resolution_x is not None else current_x
-        target_y = int(resolution_y) if resolution_y is not None else current_y
-        if target_x < 1 or target_y < 1:
-            return skill_error(
-                "Invalid viewport resolution",
-                "resolution_x and resolution_y must each be at least 1 pixel.",
-            )
-
+        staged_path = None
         try:
-            scene.render.filepath = filepath
-            scene.render.resolution_x = target_x
-            scene.render.resolution_y = target_y
-            scene.render.resolution_percentage = 100
-            scene.render.image_settings.file_format = _image_format(filepath, old_format)
-            scene.render.use_file_extension = False
-
             with temp_override(**override):
-                if not bpy.ops.render.opengl.poll():
-                    raise RuntimeError("OpenGL viewport render is unavailable in the selected VIEW_3D")
-                operator_result = bpy.ops.render.opengl(write_still=True, view_context=True)
-            if "FINISHED" not in operator_result:
-                raise RuntimeError(
-                    f"OpenGL viewport render did not finish (operator result: {sorted(operator_result)})"
-                )
-            width, height = _output_dimensions(bpy, filepath)
-            if (width, height) != (target_x, target_y):
-                raise RuntimeError(
-                    f"Viewport output dimensions {width}x{height} do not match requested {target_x}x{target_y}"
-                )
+                scene = override["scene"]
+                old_filepath = scene.render.filepath
+                old_x = scene.render.resolution_x
+                old_y = scene.render.resolution_y
+                old_percentage = scene.render.resolution_percentage
+                old_format = scene.render.image_settings.file_format
+                old_use_extension = scene.render.use_file_extension
+
+                percentage = max(1, int(old_percentage))
+                current_x = max(1, int(old_x) * percentage // 100)
+                current_y = max(1, int(old_y) * percentage // 100)
+                target_x = int(resolution_x) if resolution_x is not None else current_x
+                target_y = int(resolution_y) if resolution_y is not None else current_y
+                if target_x < 1 or target_y < 1:
+                    return skill_error(
+                        "Invalid viewport resolution",
+                        "resolution_x and resolution_y must each be at least 1 pixel.",
+                    )
+
+                destination = _destination_path(bpy, filepath)
+                staged_path = _staging_path(destination)
+                try:
+                    scene.render.filepath = str(staged_path)
+                    scene.render.resolution_x = target_x
+                    scene.render.resolution_y = target_y
+                    scene.render.resolution_percentage = 100
+                    scene.render.image_settings.file_format = _image_format(filepath, old_format)
+                    scene.render.use_file_extension = False
+
+                    if not bpy.ops.render.opengl.poll():
+                        raise RuntimeError("OpenGL viewport render is unavailable in the selected VIEW_3D")
+                    operator_result = bpy.ops.render.opengl(write_still=True, view_context=True)
+                    if "FINISHED" not in operator_result:
+                        raise RuntimeError(
+                            f"OpenGL viewport render did not finish (operator result: {sorted(operator_result)})"
+                        )
+                    if not staged_path.is_file():
+                        raise RuntimeError("OpenGL viewport render did not write a fresh output")
+                    width, height = _output_dimensions(bpy, str(staged_path))
+                    if (width, height) != (target_x, target_y):
+                        raise RuntimeError(
+                            f"Viewport output dimensions {width}x{height} do not match requested {target_x}x{target_y}"
+                        )
+                    os.replace(staged_path, destination)
+                finally:
+                    scene.render.filepath = old_filepath
+                    scene.render.resolution_x = old_x
+                    scene.render.resolution_y = old_y
+                    scene.render.resolution_percentage = old_percentage
+                    scene.render.image_settings.file_format = old_format
+                    scene.render.use_file_extension = old_use_extension
         finally:
-            scene.render.filepath = old_filepath
-            scene.render.resolution_x = old_x
-            scene.render.resolution_y = old_y
-            scene.render.resolution_percentage = old_percentage
-            scene.render.image_settings.file_format = old_format
-            scene.render.use_file_extension = old_use_extension
+            if staged_path is not None:
+                try:
+                    staged_path.unlink()
+                except FileNotFoundError:
+                    pass
 
         return skill_success(
             "Viewport captured",

--- a/tests/test_skills_render.py
+++ b/tests/test_skills_render.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -125,7 +125,7 @@ class TestRenderScene:
 
 class TestCaptureViewport:
     @staticmethod
-    def _with_view3d(bpy):
+    def _with_view3d(bpy, scene=None):
         region = SimpleNamespace(type="WINDOW")
         space = SimpleNamespace(type="VIEW_3D")
         area = SimpleNamespace(
@@ -134,7 +134,7 @@ class TestCaptureViewport:
             spaces=SimpleNamespace(active=space),
         )
         screen = SimpleNamespace(areas=[area])
-        window = SimpleNamespace(screen=screen)
+        window = SimpleNamespace(screen=screen, scene=scene or bpy.context.scene)
         bpy.context.window = window
         bpy.context.screen = screen
         bpy.context.temp_override = MagicMock(return_value=nullcontext())
@@ -164,7 +164,7 @@ class TestCaptureViewport:
                     render.use_file_extension,
                 )
             )
-            output.write_bytes(b"viewport render")
+            Path(render.filepath).write_bytes(b"viewport render")
             return {"FINISHED"}
 
         bpy.ops.render.opengl.side_effect = render_viewport
@@ -191,11 +191,18 @@ class TestCaptureViewport:
             area=area,
             region=region,
             space_data=space,
+            scene=bpy.context.scene,
         )
         bpy.ops.render.opengl.assert_called_once_with(write_still=True, view_context=True)
-        assert rendered_settings == [(str(output), 800, 600, 100, "PNG", False)]
-        bpy.data.images.load.assert_called_once_with(str(output), check_existing=False)
+        assert len(rendered_settings) == 1
+        staged_path, *settings = rendered_settings[0]
+        assert Path(staged_path).parent == output.parent
+        assert Path(staged_path).name.startswith(".viewport-")
+        assert settings == [800, 600, 100, "PNG", False]
+        bpy.data.images.load.assert_called_once_with(staged_path, check_existing=False)
         bpy.data.images.remove.assert_called_once_with(image)
+        assert output.read_bytes() == b"viewport render"
+        assert not Path(staged_path).exists()
         assert bpy.context.scene.render.filepath == "//original.png"
         assert bpy.context.scene.render.resolution_x == 1920
         assert bpy.context.scene.render.resolution_y == 1080
@@ -253,6 +260,8 @@ class TestCaptureViewport:
     def test_capture_viewport_restores_settings_when_viewport_render_raises(self, tmp_path):
         bpy = make_mock_bpy()
         self._with_view3d(bpy)
+        output = tmp_path / "viewport.png"
+        output.write_bytes(b"existing viewport")
         render = bpy.context.scene.render
         render.filepath = "//original.exr"
         render.resolution_x = 2048
@@ -264,7 +273,7 @@ class TestCaptureViewport:
         result = load_and_call(
             "blender-render/scripts/capture_viewport.py",
             bpy,
-            filepath=str(tmp_path / "viewport.png"),
+            filepath=str(output),
             resolution_x=640,
             resolution_y=360,
         )
@@ -275,6 +284,8 @@ class TestCaptureViewport:
         assert render.resolution_y == 1024
         assert render.resolution_percentage == 50
         assert render.image_settings.file_format == "OPEN_EXR"
+        assert output.read_bytes() == b"existing viewport"
+        assert list(tmp_path.glob(".viewport-*.png")) == []
         bpy.ops.screen.screenshot.assert_not_called()
 
     def test_capture_viewport_rejects_wrong_output_dimensions(self, tmp_path):
@@ -283,7 +294,7 @@ class TestCaptureViewport:
         output = tmp_path / "viewport.png"
 
         def render_viewport(**_kwargs):
-            output.write_bytes(b"viewport render")
+            Path(bpy.context.scene.render.filepath).write_bytes(b"viewport render")
             return {"FINISHED"}
 
         bpy.ops.render.opengl.side_effect = render_viewport
@@ -303,6 +314,8 @@ class TestCaptureViewport:
         assert "800x600" in result["message"]
         bpy.data.images.remove.assert_called_once_with(image)
         bpy.ops.screen.screenshot.assert_not_called()
+        assert not output.exists()
+        assert list(tmp_path.glob(".viewport-*.png")) == []
 
     def test_capture_viewport_uses_window_manager_view3d_when_current_window_is_missing(self, tmp_path):
         bpy = make_mock_bpy()
@@ -312,7 +325,7 @@ class TestCaptureViewport:
         output = tmp_path / "viewport.png"
 
         def render_viewport(**_kwargs):
-            output.write_bytes(b"viewport render")
+            Path(bpy.context.scene.render.filepath).write_bytes(b"viewport render")
             return {"FINISHED"}
 
         bpy.ops.render.opengl.side_effect = render_viewport
@@ -332,6 +345,99 @@ class TestCaptureViewport:
             area=area,
             region=region,
             space_data=space,
+            scene=window.scene,
+        )
+
+    def test_capture_viewport_rejects_same_size_stale_destination_when_write_is_missing(self, tmp_path):
+        bpy = make_mock_bpy()
+        self._with_view3d(bpy)
+        output = tmp_path / "viewport.png"
+        output.write_bytes(b"stale image")
+        bpy.ops.render.opengl.return_value = {"FINISHED"}
+        bpy.data.images.load.return_value = SimpleNamespace(size=(800, 600))
+
+        result = load_and_call(
+            "blender-render/scripts/capture_viewport.py",
+            bpy,
+            filepath=str(output),
+            resolution_x=800,
+            resolution_y=600,
+        )
+
+        assert result["success"] is False
+        assert output.read_bytes() == b"stale image"
+        bpy.data.images.load.assert_not_called()
+        assert list(tmp_path.glob(".viewport-*.png")) == []
+
+    def test_capture_viewport_configures_and_restores_the_overridden_window_scene(self, tmp_path):
+        bpy = make_mock_bpy()
+        scene_a = bpy.context.scene
+        scene_a.render.filepath = "//scene-a.png"
+        scene_a.render.resolution_x = 320
+        scene_a.render.resolution_y = 200
+        scene_b = MagicMock()
+        scene_b.render.filepath = "//scene-b.exr"
+        scene_b.render.resolution_x = 2048
+        scene_b.render.resolution_y = 1024
+        scene_b.render.resolution_percentage = 50
+        scene_b.render.image_settings.file_format = "OPEN_EXR"
+        scene_b.render.use_file_extension = True
+
+        bpy.context.window = SimpleNamespace(screen=SimpleNamespace(areas=[]), scene=scene_a)
+        window, screen, area, region, space = self._with_view3d(bpy, scene=scene_b)
+        bpy.context.window = SimpleNamespace(screen=SimpleNamespace(areas=[]), scene=scene_a)
+        bpy.context.window_manager.windows = [window]
+        output = tmp_path / "viewport.png"
+        observed = []
+
+        @contextmanager
+        def switch_scene(**_override):
+            previous = bpy.context.scene
+            bpy.context.scene = scene_b
+            try:
+                yield
+            finally:
+                bpy.context.scene = previous
+
+        bpy.context.temp_override = MagicMock(side_effect=switch_scene)
+
+        def render_viewport(**_kwargs):
+            render = bpy.context.scene.render
+            observed.append((bpy.context.scene, render.resolution_x, render.resolution_y, render.filepath))
+            Path(render.filepath).write_bytes(b"viewport render")
+            return {"FINISHED"}
+
+        bpy.ops.render.opengl.side_effect = render_viewport
+        bpy.data.images.load.return_value = SimpleNamespace(size=(640, 360))
+
+        result = load_and_call(
+            "blender-render/scripts/capture_viewport.py",
+            bpy,
+            filepath=str(output),
+            resolution_x=640,
+            resolution_y=360,
+        )
+
+        assert result["success"] is True
+        assert observed[0][0] is scene_b
+        assert observed[0][1:3] == (640, 360)
+        assert Path(observed[0][3]).name.startswith(".viewport-")
+        assert scene_a.render.filepath == "//scene-a.png"
+        assert scene_a.render.resolution_x == 320
+        assert scene_a.render.resolution_y == 200
+        assert scene_b.render.filepath == "//scene-b.exr"
+        assert scene_b.render.resolution_x == 2048
+        assert scene_b.render.resolution_y == 1024
+        assert scene_b.render.resolution_percentage == 50
+        assert scene_b.render.image_settings.file_format == "OPEN_EXR"
+        assert scene_b.render.use_file_extension is True
+        bpy.context.temp_override.assert_called_once_with(
+            window=window,
+            screen=screen,
+            area=area,
+            region=region,
+            space_data=space,
+            scene=scene_b,
         )
 
     def test_capture_viewport_rejects_cancelled_operator_without_using_stale_output(self, tmp_path):

--- a/tests/test_skills_render.py
+++ b/tests/test_skills_render.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import yaml
@@ -122,37 +124,234 @@ class TestRenderScene:
 
 
 class TestCaptureViewport:
-    def test_capture_viewport_uses_screen_screenshot_and_restores_settings(self):
+    @staticmethod
+    def _with_view3d(bpy):
+        region = SimpleNamespace(type="WINDOW")
+        space = SimpleNamespace(type="VIEW_3D")
+        area = SimpleNamespace(
+            type="VIEW_3D",
+            regions=[region],
+            spaces=SimpleNamespace(active=space),
+        )
+        screen = SimpleNamespace(areas=[area])
+        window = SimpleNamespace(screen=screen)
+        bpy.context.window = window
+        bpy.context.screen = screen
+        bpy.context.temp_override = MagicMock(return_value=nullcontext())
+        return window, screen, area, region, space
+
+    def test_capture_viewport_renders_only_view3d_at_requested_size_and_restores_settings(self, tmp_path):
         bpy = make_mock_bpy()
-        bpy.context.scene.render.filepath = "/tmp/original.png"
+        window, screen, area, region, space = self._with_view3d(bpy)
+        output = tmp_path / "viewport.png"
+        bpy.context.scene.render.filepath = "//original.png"
         bpy.context.scene.render.resolution_x = 1920
         bpy.context.scene.render.resolution_y = 1080
+        bpy.context.scene.render.resolution_percentage = 75
+        bpy.context.scene.render.image_settings.file_format = "JPEG"
+        bpy.context.scene.render.use_file_extension = True
+        rendered_settings = []
+
+        def render_viewport(**_kwargs):
+            render = bpy.context.scene.render
+            rendered_settings.append(
+                (
+                    render.filepath,
+                    render.resolution_x,
+                    render.resolution_y,
+                    render.resolution_percentage,
+                    render.image_settings.file_format,
+                    render.use_file_extension,
+                )
+            )
+            output.write_bytes(b"viewport render")
+            return {"FINISHED"}
+
+        bpy.ops.render.opengl.side_effect = render_viewport
+        image = SimpleNamespace(size=(800, 600))
+        bpy.data.images.load.return_value = image
 
         result = load_and_call(
             "blender-render/scripts/capture_viewport.py",
             bpy,
-            filepath="/tmp/viewport.png",
+            filepath=str(output),
             resolution_x=800,
             resolution_y=600,
         )
 
         assert result["success"] is True
-        assert result["context"]["filepath"] == "/tmp/viewport.png"
-        assert result["context"]["method"] == "screen"
-        bpy.ops.screen.screenshot.assert_called_once_with(filepath="/tmp/viewport.png")
-        assert bpy.context.scene.render.filepath == "/tmp/original.png"
+        assert result["context"]["filepath"] == str(output)
+        assert result["context"]["method"] == "viewport_opengl"
+        assert result["context"]["width"] == 800
+        assert result["context"]["height"] == 600
+        bpy.ops.screen.screenshot.assert_not_called()
+        bpy.context.temp_override.assert_called_once_with(
+            window=window,
+            screen=screen,
+            area=area,
+            region=region,
+            space_data=space,
+        )
+        bpy.ops.render.opengl.assert_called_once_with(write_still=True, view_context=True)
+        assert rendered_settings == [(str(output), 800, 600, 100, "PNG", False)]
+        bpy.data.images.load.assert_called_once_with(str(output), check_existing=False)
+        bpy.data.images.remove.assert_called_once_with(image)
+        assert bpy.context.scene.render.filepath == "//original.png"
         assert bpy.context.scene.render.resolution_x == 1920
         assert bpy.context.scene.render.resolution_y == 1080
+        assert bpy.context.scene.render.resolution_percentage == 75
+        assert bpy.context.scene.render.image_settings.file_format == "JPEG"
+        assert bpy.context.scene.render.use_file_extension is True
 
-    def test_capture_viewport_falls_back_to_opengl(self):
+    def test_capture_viewport_fails_closed_without_view3d(self, tmp_path):
         bpy = make_mock_bpy()
-        bpy.ops.screen.screenshot.side_effect = RuntimeError("no screen area")
+        bpy.context.window = SimpleNamespace(screen=SimpleNamespace(areas=[]))
+        bpy.context.screen = bpy.context.window.screen
 
-        result = load_and_call("blender-render/scripts/capture_viewport.py", bpy, filepath="/tmp/viewport.png")
+        result = load_and_call(
+            "blender-render/scripts/capture_viewport.py",
+            bpy,
+            filepath=str(tmp_path / "viewport.png"),
+        )
+
+        assert result["success"] is False
+        assert "VIEW_3D" in result["message"]
+        bpy.ops.screen.screenshot.assert_not_called()
+        bpy.ops.render.opengl.assert_not_called()
+
+    def test_capture_viewport_modal_override_failure_does_not_fall_back_to_screen(self, tmp_path):
+        bpy = make_mock_bpy()
+        self._with_view3d(bpy)
+        bpy.context.temp_override.side_effect = RuntimeError("modal context is unavailable")
+
+        result = load_and_call(
+            "blender-render/scripts/capture_viewport.py",
+            bpy,
+            filepath=str(tmp_path / "viewport.png"),
+        )
+
+        assert result["success"] is False
+        assert "modal context is unavailable" in result["message"]
+        bpy.ops.screen.screenshot.assert_not_called()
+
+    def test_capture_viewport_fails_closed_when_context_override_api_is_unavailable(self, tmp_path):
+        bpy = make_mock_bpy()
+        self._with_view3d(bpy)
+        bpy.context.temp_override = None
+
+        result = load_and_call(
+            "blender-render/scripts/capture_viewport.py",
+            bpy,
+            filepath=str(tmp_path / "viewport.png"),
+        )
+
+        assert result["success"] is False
+        assert "context override unavailable" in result["message"]
+        bpy.ops.render.opengl.assert_not_called()
+        bpy.ops.screen.screenshot.assert_not_called()
+
+    def test_capture_viewport_restores_settings_when_viewport_render_raises(self, tmp_path):
+        bpy = make_mock_bpy()
+        self._with_view3d(bpy)
+        render = bpy.context.scene.render
+        render.filepath = "//original.exr"
+        render.resolution_x = 2048
+        render.resolution_y = 1024
+        render.resolution_percentage = 50
+        render.image_settings.file_format = "OPEN_EXR"
+        bpy.ops.render.opengl.side_effect = RuntimeError("viewport render failed")
+
+        result = load_and_call(
+            "blender-render/scripts/capture_viewport.py",
+            bpy,
+            filepath=str(tmp_path / "viewport.png"),
+            resolution_x=640,
+            resolution_y=360,
+        )
+
+        assert result["success"] is False
+        assert render.filepath == "//original.exr"
+        assert render.resolution_x == 2048
+        assert render.resolution_y == 1024
+        assert render.resolution_percentage == 50
+        assert render.image_settings.file_format == "OPEN_EXR"
+        bpy.ops.screen.screenshot.assert_not_called()
+
+    def test_capture_viewport_rejects_wrong_output_dimensions(self, tmp_path):
+        bpy = make_mock_bpy()
+        self._with_view3d(bpy)
+        output = tmp_path / "viewport.png"
+
+        def render_viewport(**_kwargs):
+            output.write_bytes(b"viewport render")
+            return {"FINISHED"}
+
+        bpy.ops.render.opengl.side_effect = render_viewport
+        image = SimpleNamespace(size=(1024, 768))
+        bpy.data.images.load.return_value = image
+
+        result = load_and_call(
+            "blender-render/scripts/capture_viewport.py",
+            bpy,
+            filepath=str(output),
+            resolution_x=800,
+            resolution_y=600,
+        )
+
+        assert result["success"] is False
+        assert "1024x768" in result["message"]
+        assert "800x600" in result["message"]
+        bpy.data.images.remove.assert_called_once_with(image)
+        bpy.ops.screen.screenshot.assert_not_called()
+
+    def test_capture_viewport_uses_window_manager_view3d_when_current_window_is_missing(self, tmp_path):
+        bpy = make_mock_bpy()
+        window, screen, area, region, space = self._with_view3d(bpy)
+        bpy.context.window = None
+        bpy.context.window_manager.windows = [window]
+        output = tmp_path / "viewport.png"
+
+        def render_viewport(**_kwargs):
+            output.write_bytes(b"viewport render")
+            return {"FINISHED"}
+
+        bpy.ops.render.opengl.side_effect = render_viewport
+        image = SimpleNamespace(size=(1920, 1080))
+        bpy.data.images.load.return_value = image
+
+        result = load_and_call(
+            "blender-render/scripts/capture_viewport.py",
+            bpy,
+            filepath=str(output),
+        )
 
         assert result["success"] is True
-        assert result["context"]["method"] == "opengl"
-        bpy.ops.render.opengl.assert_called_once_with(write_still=True, view_context=True)
+        bpy.context.temp_override.assert_called_once_with(
+            window=window,
+            screen=screen,
+            area=area,
+            region=region,
+            space_data=space,
+        )
+
+    def test_capture_viewport_rejects_cancelled_operator_without_using_stale_output(self, tmp_path):
+        bpy = make_mock_bpy()
+        self._with_view3d(bpy)
+        output = tmp_path / "viewport.png"
+        output.write_bytes(b"stale image")
+        bpy.ops.render.opengl.return_value = {"CANCELLED"}
+        bpy.data.images.load.return_value = SimpleNamespace(size=(1920, 1080))
+
+        result = load_and_call(
+            "blender-render/scripts/capture_viewport.py",
+            bpy,
+            filepath=str(output),
+        )
+
+        assert result["success"] is False
+        assert "did not finish" in result["message"]
+        bpy.data.images.load.assert_not_called()
+        bpy.ops.screen.screenshot.assert_not_called()
 
     def test_capture_viewport_requires_filepath(self):
         bpy = make_mock_bpy()


### PR DESCRIPTION
## Summary
- replace app-window screenshots with Blender's `VIEW_3D` OpenGL viewport render
- render to a unique sibling staging file, validate exact dimensions, then atomically replace the destination
- bind render settings and restoration to the exact overridden window scene
- fail closed without a valid viewport, fresh output, or completed operator result

## Verification
- `python -m pytest tests/test_skills_render.py -q` (22 passed)
- isolated environment with `dcc-mcp-core 0.20.11`: `python -m pytest tests/ -q -m "not e2e and not packaging"` (523 passed, 19 skipped)
- `python tools/check_py37_syntax.py` under CPython 3.7.9 (365 files)
- Ruff check/format and Skill lint
- `python -m build`, Twine check, and `git diff --check`

Regression coverage proves a same-size stale destination is not accepted, failed/wrong-size staging files are cleaned without replacing the destination, and cross-window capture configures and restores the selected scene.

Interactive Blender viewport capture was not available locally; CI and mocked operator contracts retain that live-host boundary.

Fixes #187