### PR TITLE
feat: add agent-first install lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,19 @@ jobs:
       - name: Run unit tests
         run: pytest tests/ -v --tb=short -m "not e2e and not packaging"
 
+  lifecycle-smoke:
+    name: Install lifecycle smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install package with lifecycle test dependencies
+        run: python -m pip install -e ".[dev]"
+      - name: Exercise plan and receipt round trip
+        run: pytest tests/test_install_lifecycle.py -v --tb=short
+
   # Ensure sdist/wheel build succeeds before release (PyPI / hatchling).
   build:
     name: Build package (wheel + sdist)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,6 @@ jobs:
           python-version: "3.14"
       - name: Install skill validation dependencies
         run: python -m pip install -e ".[dev]"
-      - name: Install dcc-mcp-cli
-        run: |
-          export DCC_MCP_INSTALL_DIR="$RUNNER_TEMP/dcc-mcp-bin"
-          curl -fsSL https://raw.githubusercontent.com/loonghao/dcc-mcp-core/main/scripts/install-cli.sh | bash
-          echo "$RUNNER_TEMP/dcc-mcp-bin" >> "$GITHUB_PATH"
       - name: Validate SKILL.md and tool metadata
         run: python tools/lint_skills.py --warnings-as-errors
 

--- a/install.md
+++ b/install.md
@@ -40,6 +40,9 @@ blender --python-use-system-env
 Preflight runs `<blender> --version`, rejects unsupported hosts, and binds the
 matching versioned user profile. `--dcc-path` and `--python` always select the
 exact host and interpreter recorded in the plan and receipt.
+The lifecycle never assumes its own CLI interpreter belongs to Blender:
+`--python` is required unless `DCC_MCP_INSTALL_PYTHON` explicitly selects the
+target, and JSON reports which of those two sources was used.
 
 ## Agent quick path
 
@@ -162,6 +165,7 @@ scene data it does not own.
 | Result | Diagnosis | Action |
 |---|---|---|
 | Exit `10`, `dcc_path_required` | Blender was not selected safely | Pass the exact executable or `.app` with `--dcc-path`. |
+| Exit `10`, `python_required` | Blender's target interpreter was not selected | Pass its exact interpreter with `--python` or `DCC_MCP_INSTALL_PYTHON`. |
 | Exit `10`, `unsupported_blender_version` | Host is older than Blender 3.6 | Install a supported Blender version. |
 | Exit `10`, `python_mismatch` | Interpreter differs from the receipt | Use the exact receipted Blender Python or uninstall from the original target first. |
 | Exit `10`, `unreceipted_startup_script` | Ownership cannot be proven | Inspect the reported file; do not delete or overwrite user content. |

--- a/install.md
+++ b/install.md
@@ -1,100 +1,179 @@
-# dcc-mcp-blender Agent Install
+# Install dcc-mcp-blender
 
-Use this page when an agent is asked to install or configure
-`dcc-mcp/dcc-mcp-blender` for Blender.
+This runbook installs, verifies, upgrades, and removes the Blender adapter under
+[DCC-MCP Adapter Install SOP v1](https://dcc-mcp.github.io/dcc-mcp-core/guide/adapter-install-sop).
+The standard lifecycle host-enables a package that is already installed in the
+selected Blender interpreter. It never controls Blender's UI.
 
-## Agent Instruction
+## Requirements
 
-If the user says "帮我参考 dcc-mcp/dcc-mcp-blender/install.md 去安装",
-do this:
+- **Blender:** 3.6 or newer for the Python/startup-hook path. The Blender
+  Extensions ZIP requires Blender 4.2 or newer.
+- **Python:** Blender's selected bundled interpreter, Python 3.7 or newer.
+- **dcc-mcp-core:** `>=0.20.0,<1.0.0` in that exact interpreter.
+- **Platforms:** Windows, macOS, and Linux.
+- **Permissions:** write access to the selected version's user `scripts/startup`
+  directory and the user receipt directory.
 
-1. Read `skills/dcc-mcp-blender-setup/SKILL.md`.
-2. Run the setup script from the repository root.
-3. Open Blender so the installed startup script can start the server.
-4. Configure the MCP host with the generated Streamable HTTP JSON.
-5. Run the smoke prompt to prove the connection works.
-
-## One Command
-
-From the repository root:
+Install the package into Blender's interpreter first. Do not substitute an
+unrelated `python` from `PATH`:
 
 ```bash
-python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py
+<blender-python> -m pip install --upgrade "dcc-mcp-blender"
 ```
 
-For an end-user install from PyPI instead of this checkout:
+If the bundled environment is read-only, the legacy setup helper supports a
+user-site install and prints the matching Blender launch command:
 
 ```bash
-python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py --source pypi
-```
-
-If Blender's bundled Python is not auto-detected:
-
-```bash
-python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py --blender-python "C:\Program Files\Blender Foundation\Blender 4.2\4.2\python\bin\python.exe"
-```
-
-Blender ships its own Python at `<blender>/<major.minor>/python/bin/python(.exe)`.
-The script discovers it via env vars (`BLENDER_PYTHON`, `DCC_MCP_BLENDER_PYTHON`),
-the `--blender-python` / `--python` argument, a `blender` launcher on `PATH`, or
-common install locations, then runs `<blender_python> -m pip install ...`. It
-also writes `dcc_mcp_blender_startup.py` under Blender's per-user
-`scripts/startup` directory. The startup bridge exposes Blender 5.x-compatible
-`register()` / `unregister()` hooks and starts the server once Blender loads it.
-
-## Read-only Blender Python fallback
-
-If Blender's bundled `site-packages` is not writable, install to the user site:
-
-```bash
-<blender-python> -m pip install --user --upgrade dcc-mcp-blender
+<blender-python> -m pip install --user --upgrade "dcc-mcp-blender"
 python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py --source pypi --user
-```
-
-The `--user` fallback must be paired with Blender's system-environment flag so
-Blender includes the user site-packages directory:
-
-```bash
 blender --python-use-system-env
 ```
 
-The setup script prints this launch command whenever `--user` is selected.
+## Supported versions
 
-## Blender Extension alternative
+| Adapter | dcc-mcp-core | Blender | Python | Platforms |
+|---|---|---|---|---|
+| Current `0.2.x` | `>=0.20.0,<1.0.0` | `3.6+` startup hook; `4.2+` Extension ZIP | `3.7+` | Windows, macOS, Linux |
 
-The release ZIP is an alternative to the pip/startup-script path above. It
-bundles the matching `dcc-mcp-core` wheel in Blender's isolated extension
-environment, so do not run the manual pip setup when using the ZIP:
+Preflight runs `<blender> --version`, rejects unsupported hosts, and binds the
+matching versioned user profile. `--dcc-path` and `--python` always select the
+exact host and interpreter recorded in the plan and receipt.
 
-1. Open Blender (4.2+ required).
-2. Go to `Edit > Preferences > Extensions > Install from Disk…`.
-   (Not `Add-ons > Install` — this ZIP uses the Blender 4.2+ Extension
-   format; the legacy add-on path is unsupported.)
-3. Select the release ZIP (`dcc_mcp_blender_addon_<platform>_vX.Y.Z.zip`).
-4. Enable **DCC MCP Blender** — the embedded server starts automatically.
+## Agent quick path
 
-Blender instances use OS-assigned ports and register with the stable gateway:
+Inspect the Core catalog plan first. Its Blender entry already resolves this
+repository's raw installation guide:
 
-```text
-http://127.0.0.1:9765/mcp
+```bash
+dcc-mcp-cli install --dcc-type blender
+dcc-mcp-cli install --dcc-type blender --execute --json
 ```
 
-## MCP Config
+Then inspect and execute the adapter-owned host-enablement plan:
 
-Use this JSON for Cursor, Claude Desktop, or any MCP Streamable HTTP host:
-
-```json
-{
-  "mcpServers": {
-    "blender": {
-      "url": "http://127.0.0.1:9765/mcp"
-    }
-  }
-}
+```bash
+dcc-mcp-blender install --dcc-path "<absolute-blender-path>" --python "<absolute-blender-python>" --json --dry-run
+dcc-mcp-blender install --dcc-path "<absolute-blender-path>" --python "<absolute-blender-python>" --json --yes
 ```
 
-The setup script also writes the config snippet and a smoke prompt under:
+The default invocation and `--dry-run` are non-mutating. All lifecycle verbs
+accept the uniform flags `--json`, `--yes`, `--dry-run`, `--dcc-path`, and
+`--python`. JSON output follows schema version 1 and includes executable
+`next_steps`, the selected host/interpreter, plan type, receipt path, and
+verification state.
+
+Stable exit codes are:
+
+| Exit | Meaning |
+|---:|---|
+| `0` | plan or operation completed |
+| `10` | host, interpreter, version, receipt, or partial-state preflight failed |
+| `20` | package acquisition or integrity failed |
+| `30` | staging, commit, uninstall, or rollback failed |
+| `40` | files are installed but verify-to-usable failed |
+| `50` | a real loaded/locked artifact requires a Blender restart |
+
+## Manual path
+
+1. Locate the exact Blender application and its matching bundled Python.
+2. Install `dcc-mcp-blender` and `dcc-mcp-core` into that interpreter.
+3. Run `dcc-mcp-blender install ... --json --dry-run` and review every path.
+4. Execute the same command with `--yes`.
+5. Launch Blender only when the returned `next_steps` asks for it.
+6. Run `dcc-mcp-blender verify ... --json`.
+
+The lifecycle writes one adapter-owned
+`scripts/startup/dcc_mcp_blender_startup.py` and a versioned receipt. It builds
+the complete startup hook in staging, moves the previous receipted state to a
+backup, atomically commits the new file and receipt, and performs rollback if a
+commit fails. Unknown unreceipted startup files are preserved and fail closed.
+Re-running the same desired version converges without duplicating hooks.
+
+The release Extension ZIP is an alternative distribution for Blender 4.2+.
+Because Blender physically owns its Extension enablement UI, install it with
+`Edit > Preferences > Extensions > Install from Disk`, then enable **DCC MCP
+Blender**. Do not combine the ZIP and startup-hook paths, and do not automate
+that UI through a generic input fallback.
+
+## Verify
+
+Read the installed state without mutation:
+
+```bash
+dcc-mcp-blender status --dcc-path "<absolute-blender-path>" --python "<absolute-blender-python>" --json
+```
+
+Verify to usable:
+
+```bash
+dcc-mcp-blender verify --dcc-path "<absolute-blender-path>" --python "<absolute-blender-python>" --json
+```
+
+Verification checks the receipt binding, startup-file digest, exact target
+interpreter imports and versions, captured bootstrap failures, one live Blender
+registry row, and the typed `host.ping` probe. Only all-green evidence produces
+`"directly_usable": true`. A closed Blender instance returns exit `40` and an
+exact launch/verify command; it is never reported as ready or as requiring a
+restart.
+
+The installed hook wraps the complete import/start operation with Core
+`capture_bootstrap_errors` and re-raises the original exception so Blender's
+console remains fail-visible.
+
+## Upgrade
+
+Upgrade the distribution in the same Blender interpreter, inspect the host
+plan, then execute it:
+
+```bash
+<blender-python> -m pip install --upgrade "dcc-mcp-blender"
+dcc-mcp-blender upgrade --dcc-path "<absolute-blender-path>" --python "<absolute-blender-python>" --json --dry-run
+dcc-mcp-blender upgrade --dcc-path "<absolute-blender-path>" --python "<absolute-blender-python>" --json --yes
+```
+
+`upgrade` requires an existing valid receipt and reuses the staged replacement
+transaction. A commit failure restores the previous startup hook and receipt.
+
+## Uninstall
+
+Review and execute receipt-only host cleanup:
+
+```bash
+dcc-mcp-blender uninstall --dcc-path "<absolute-blender-path>" --python "<absolute-blender-python>" --json --dry-run
+dcc-mcp-blender uninstall --dcc-path "<absolute-blender-path>" --python "<absolute-blender-python>" --json --yes
+```
+
+Only the file named and hashed in the receipt is removed. Modified or unknown
+files are preserved, and a second uninstall is an idempotent success. After
+host cleanup, remove the Python distribution explicitly if desired:
+
+```bash
+<blender-python> -m pip uninstall dcc-mcp-blender
+```
+
+For the Extension ZIP path, remove **DCC MCP Blender** through Blender's
+Extensions preferences. The startup-hook lifecycle never deletes extension or
+scene data it does not own.
+
+## Troubleshooting
+
+| Result | Diagnosis | Action |
+|---|---|---|
+| Exit `10`, `dcc_path_required` | Blender was not selected safely | Pass the exact executable or `.app` with `--dcc-path`. |
+| Exit `10`, `unsupported_blender_version` | Host is older than Blender 3.6 | Install a supported Blender version. |
+| Exit `10`, `python_mismatch` | Interpreter differs from the receipt | Use the exact receipted Blender Python or uninstall from the original target first. |
+| Exit `10`, `unreceipted_startup_script` | Ownership cannot be proven | Inspect the reported file; do not delete or overwrite user content. |
+| Exit `20` | Package acquisition/integrity failed | Reinstall only from the official pinned catalog or PyPI package. |
+| Exit `30` | Transaction or rollback failed | Preserve the JSON result and previous receipt; resolve the reported filesystem failure. |
+| Exit `40`, `target_import_failed` | Adapter/Core is absent from target Python | Install both packages into the exact `--python` interpreter. |
+| Exit `40`, `bootstrap_error_captured` | Blender startup raised before MCP readiness | Inspect the receipt's `bootstrap_error_dir` and Blender console; fix the original error. |
+| Exit `40`, `no_live_blender_instance` | Installed but Blender is closed or not registered | Execute the returned launch command, wait for startup, then rerun verify. |
+| Exit `50` | Windows reports a loaded/locked adapter artifact | Save work, close only the reported Blender instance, then repeat the command. |
+
+The catalog `instructions_url` is:
 
 ```text
-.dcc-mcp/agent-setup/
+https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-blender/main/install.md
 ```

--- a/packaging/addon_entry/__init__.py
+++ b/packaging/addon_entry/__init__.py
@@ -528,15 +528,24 @@ def register() -> None:
         print("[DCC MCP Blender] Background render worker detected; server autostart skipped")
         return
 
+    from dcc_mcp_core import capture_bootstrap_errors
+
     try:
-        srv = _start_server_with_host()
-        url = getattr(srv, "mcp_url", None) if srv is not None else None
-        if url:
-            print("[DCC MCP Blender] Server started —", url)
-        else:
-            print("[DCC MCP Blender] Server start requested (URL not yet available)")
+        with capture_bootstrap_errors(
+            "blender",
+            adapter_version=__addon_version__,
+            min_core_version="0.20.0",
+            phase="startup",
+        ):
+            srv = _start_server_with_host()
+            url = getattr(srv, "mcp_url", None) if srv is not None else None
+            if url:
+                print("[DCC MCP Blender] Server started —", url)
+            else:
+                print("[DCC MCP Blender] Server start requested (URL not yet available)")
     except Exception as exc:  # noqa: BLE001
         print(f"[DCC MCP Blender] Failed to start server: {exc}")
+        raise
 
 
 def unregister() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ Repository = "https://github.com/dcc-mcp/dcc-mcp-blender"
 Issues = "https://github.com/dcc-mcp/dcc-mcp-blender/issues"
 Changelog = "https://github.com/dcc-mcp/dcc-mcp-blender/releases"
 
+[project.scripts]
+dcc-mcp-blender = "dcc_mcp_blender.install:main"
+
 [project.entry-points."dcc_mcp.adapters"]
 blender = "dcc_mcp_blender:BlenderMcpServer"
 

--- a/skills/dcc-mcp-blender-setup/SKILL.md
+++ b/skills/dcc-mcp-blender-setup/SKILL.md
@@ -43,13 +43,51 @@ End with:
 
 ## Fast Path
 
-From the repository root, run:
+Use the installed adapter lifecycle as the canonical agent path. First resolve
+the exact Blender executable/application and its target Python interpreter,
+then inspect the non-mutating plan:
+
+```bash
+dcc-mcp-blender install --json --dry-run --dcc-path <absolute-blender-path> --python <absolute-python-path>
+```
+
+Review the resolved host, version, profile, interpreter, file steps, and
+machine-executable `next_steps`. If they are correct, execute the same plan and
+verify typed readiness:
+
+```bash
+dcc-mcp-blender install --json --yes --dcc-path <absolute-blender-path> --python <absolute-python-path>
+dcc-mcp-blender verify --json --dcc-path <absolute-blender-path> --python <absolute-python-path>
+```
+
+Exit `40` after install means the staged, receipted host integration was
+written but `host.ping` could not yet prove a live Blender instance. Follow the
+returned `next_steps`; do not report the adapter as directly usable yet.
+
+The lifecycle command:
+
+1. Probes Blender 3.6+ and the exact target Python before writing.
+2. Resolves the per-user Blender scripts profile without changing the host
+   installation directory.
+3. Stages and atomically replaces the owned startup script with rollback.
+4. Writes an ownership receipt used by `status`, `verify`, `upgrade`, and
+   receipt-only `uninstall`.
+5. Captures bootstrap failures and verifies a live instance with typed
+   `host.ping` rather than a process or port-only check.
+
+See the repository root `install.md` for all platforms, stable exit codes, and
+repair/troubleshooting flows.
+
+## Legacy compatibility path
+
+The checkout-local script remains available for operators that still need the
+pre-SOP pip/setup flow:
 
 ```bash
 python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py
 ```
 
-The script:
+This compatibility script:
 
 1. Finds Blender's bundled Python from `--blender-python` / `--python`,
    `BLENDER_PYTHON`, `DCC_MCP_BLENDER_PYTHON`, a `blender` launcher on `PATH`,
@@ -65,7 +103,7 @@ The script:
 5. Writes a reusable MCP JSON snippet and smoke prompt under
    `.dcc-mcp/agent-setup/`.
 
-Use PyPI instead of the local checkout when setting up an end-user machine:
+Use PyPI instead of the local checkout with that legacy path:
 
 ```bash
 python skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py --source pypi

--- a/skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py
+++ b/skills/dcc-mcp-blender-setup/scripts/setup_dcc_mcp_blender.py
@@ -28,17 +28,24 @@ def register():
     if _server is not None and getattr(_server, "is_running", True):
         return _server
 
-    from dcc_mcp_blender import get_server, start_server
+    from dcc_mcp_core import capture_bootstrap_errors
 
-    existing = get_server()
-    if existing is not None and getattr(existing, "is_running", False):
-        _server = existing
-        _owns_server = False
+    with capture_bootstrap_errors(
+        "blender",
+        min_core_version="0.20.0",
+        phase="startup",
+    ):
+        from dcc_mcp_blender import get_server, start_server
+
+        existing = get_server()
+        if existing is not None and getattr(existing, "is_running", False):
+            _server = existing
+            _owns_server = False
+            return _server
+
+        _server = start_server()
+        _owns_server = True
         return _server
-
-    _server = start_server()
-    _owns_server = True
-    return _server
 
 
 def unregister():

--- a/src/dcc_mcp_blender/install.py
+++ b/src/dcc_mcp_blender/install.py
@@ -91,6 +91,7 @@ class InstallContext:
     host_version: str
     profile: Path
     python_path: Path
+    python_selection_source: str
     python_version: str
     site_packages: Path
     core_version: str
@@ -265,7 +266,19 @@ def _resolve_context(dcc_path, python_path, environ):
     # type: (Optional[str], Optional[str], Mapping[str, str]) -> InstallContext
     host_path = _resolve_host_path(dcc_path)
     host_version = _resolve_host_version(host_path, environ)
-    selected_python = python_path or environ.get("DCC_MCP_INSTALL_PYTHON") or sys.executable
+    if python_path:
+        selected_python = python_path
+        python_selection_source = "--python"
+    else:
+        selected_python = environ.get("DCC_MCP_INSTALL_PYTHON", "").strip()
+        if not selected_python:
+            raise LifecycleError(
+                INSTALL_EXIT_PREFLIGHT,
+                "python",
+                "python_required",
+                "Pass Blender's exact target interpreter with --python or DCC_MCP_INSTALL_PYTHON.",
+            )
+        python_selection_source = "DCC_MCP_INSTALL_PYTHON"
     interpreter = Path(selected_python).expanduser().resolve()
     python = _probe_python(interpreter)
     profile = (
@@ -364,6 +377,7 @@ def _resolve_context(dcc_path, python_path, environ):
         host_version=host_version,
         profile=profile,
         python_path=interpreter,
+        python_selection_source=python_selection_source,
         python_version=python["python_version"],
         site_packages=Path(python["site_packages"]).resolve(),
         core_version=python["core_version"],
@@ -402,7 +416,7 @@ def _base_report(ctx, command, status):
             "path": str(ctx.python_path),
             "version": ctx.python_version,
             "site_packages": str(ctx.site_packages),
-            "selection_source": "--python",
+            "selection_source": ctx.python_selection_source,
         },
         "install_state": ctx.state,
     }
@@ -836,7 +850,7 @@ def _execute_install(ctx, environ, command="install"):
                 "unreceipted_startup_script",
                 "The unreceipted Blender startup script cannot be inspected: %s" % exc,
             ) from exc
-        if "Auto-start dcc-mcp-blender" not in legacy:
+        if legacy != _render_startup_script(ctx):
             raise LifecycleError(
                 INSTALL_EXIT_PREFLIGHT,
                 "partial",
@@ -985,7 +999,7 @@ def _failure_report(command, dcc_path, python_path, environ, exc):
                     "--dcc-path",
                     dcc_path or "<absolute-blender-path>",
                     "--python",
-                    python_path or environ.get("DCC_MCP_INSTALL_PYTHON") or sys.executable,
+                    python_path or environ.get("DCC_MCP_INSTALL_PYTHON") or "<absolute-blender-python>",
                     "--json",
                     "--dry-run",
                 ],

--- a/src/dcc_mcp_blender/install.py
+++ b/src/dcc_mcp_blender/install.py
@@ -1,0 +1,1104 @@
+"""Agent-first Install SOP v1 lifecycle for the Blender adapter."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import dcc_mcp_core
+
+try:
+    from dcc_mcp_core.deployment import inspect_install_root, probe_sidecar_tool, query_runtime_state
+except ImportError:
+    # Core releases before #2320 expose the same lifecycle API from this owner.
+    from dcc_mcp_core.install_lifecycle import (
+        inspect_install_root,
+        probe_sidecar_tool,
+        query_runtime_state,
+    )
+
+from .__version__ import __version__
+
+try:
+    from dcc_mcp_core.deployment import (
+        INSTALL_EXIT_ACQUIRE,
+        INSTALL_EXIT_CODES,
+        INSTALL_EXIT_INSTALL,
+        INSTALL_EXIT_OK,
+        INSTALL_EXIT_PREFLIGHT,
+        INSTALL_EXIT_REQUIRES_RESTART,
+        INSTALL_EXIT_VERIFY,
+        INSTALL_SOP_SCHEMA_VERSION,
+        load_install_sop_schema,
+    )
+except ImportError:
+    # Remove this compatibility boundary after dcc-mcp-core#2320 is released.
+    INSTALL_SOP_SCHEMA_VERSION = 1
+    INSTALL_EXIT_OK = 0
+    INSTALL_EXIT_PREFLIGHT = 10
+    INSTALL_EXIT_ACQUIRE = 20
+    INSTALL_EXIT_INSTALL = 30
+    INSTALL_EXIT_VERIFY = 40
+    INSTALL_EXIT_REQUIRES_RESTART = 50
+    INSTALL_EXIT_CODES = {
+        "ok": INSTALL_EXIT_OK,
+        "preflight": INSTALL_EXIT_PREFLIGHT,
+        "acquire": INSTALL_EXIT_ACQUIRE,
+        "install": INSTALL_EXIT_INSTALL,
+        "verify": INSTALL_EXIT_VERIFY,
+        "requires_restart": INSTALL_EXIT_REQUIRES_RESTART,
+    }
+
+    def load_install_sop_schema():
+        # type: () -> Dict[str, Any]
+        schema_path = Path(__file__).resolve().parent / "schemas" / "adapter-install-sop-v1.schema.json"
+        return json.loads(schema_path.read_text(encoding="utf-8"))
+
+
+DCC_TYPE = "blender"
+COMMAND = "dcc-mcp-blender"
+MIN_BLENDER_VERSION = (3, 6)
+MIN_CORE_VERSION = "0.20.0"
+STARTUP_SCRIPT_NAME = "dcc_mcp_blender_startup.py"
+DEFAULT_RECEIPT_PATH = Path.home() / ".dcc-mcp" / "receipts" / "blender.json"
+LIFECYCLE_COMMANDS = ("install", "status", "verify", "uninstall", "upgrade")
+
+
+class LifecycleError(RuntimeError):
+    """A stable, classified Install SOP failure."""
+
+    def __init__(self, exit_code, stage, reason, message):
+        # type: (int, str, str, str) -> None
+        super().__init__(message)
+        self.exit_code = exit_code
+        self.stage = stage
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class InstallContext:
+    host_path: Path
+    host_version: str
+    profile: Path
+    python_path: Path
+    python_version: str
+    site_packages: Path
+    core_version: str
+    state: str
+    state_stage: str
+    state_reason: str
+    receipt_path: Path
+    startup_path: Path
+    bootstrap_log_dir: Path
+
+
+def _version_tuple(value):
+    # type: (str) -> Tuple[int, ...]
+    match = re.search(r"\d+(?:\.\d+)+", value)
+    if match is None:
+        return ()
+    return tuple(int(part) for part in match.group(0).split("."))
+
+
+def _resolve_host_path(explicit):
+    # type: (Optional[str]) -> Path
+    value = explicit or os.environ.get("DCC_MCP_BLENDER_DCC_PATH")
+    if not value:
+        raise LifecycleError(
+            INSTALL_EXIT_PREFLIGHT,
+            "host",
+            "dcc_path_required",
+            "Pass the exact Blender executable or application with --dcc-path.",
+        )
+    path = Path(value).expanduser().resolve()
+    if not path.exists():
+        raise LifecycleError(
+            INSTALL_EXIT_PREFLIGHT,
+            "host",
+            "dcc_path_missing",
+            "Blender path does not exist: %s" % path,
+        )
+    return path
+
+
+def _resolve_host_version(host_path, environ):
+    # type: (Path, Mapping[str, str]) -> str
+    configured = environ.get("DCC_MCP_BLENDER_VERSION", "").strip()
+    if configured:
+        version = configured
+    else:
+        command_path = host_path
+        if host_path.is_dir() and host_path.suffix.lower() == ".app":
+            command_path = host_path / "Contents" / "MacOS" / "Blender"
+        try:
+            completed = subprocess.run(
+                [str(command_path), "--version"],
+                check=False,
+                capture_output=True,
+                universal_newlines=True,
+                timeout=15,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise LifecycleError(
+                INSTALL_EXIT_PREFLIGHT,
+                "host",
+                "host_version_probe_failed",
+                "Could not query the Blender version: %s" % exc,
+            ) from exc
+        output = (completed.stdout or completed.stderr).strip()
+        version_match = re.search(r"Blender\s+(\d+(?:\.\d+){1,2})", output)
+        if completed.returncode != 0 or version_match is None:
+            raise LifecycleError(
+                INSTALL_EXIT_PREFLIGHT,
+                "host",
+                "host_version_unavailable",
+                "Blender did not return a supported version from --version.",
+            )
+        version = version_match.group(1)
+    if _version_tuple(version) < MIN_BLENDER_VERSION:
+        raise LifecycleError(
+            INSTALL_EXIT_PREFLIGHT,
+            "host",
+            "unsupported_blender_version",
+            "Blender %s is unsupported; Blender 3.6 or newer is required." % version,
+        )
+    return version
+
+
+def _probe_python(python_path):
+    # type: (Path) -> Dict[str, str]
+    if not python_path.is_file():
+        raise LifecycleError(
+            INSTALL_EXIT_PREFLIGHT,
+            "python",
+            "python_missing",
+            "Target interpreter does not exist: %s" % python_path,
+        )
+    script = (
+        "import json,sys,sysconfig; "
+        "import dcc_mcp_core,dcc_mcp_blender; "
+        "print(json.dumps({"
+        "'python_version':'.'.join(map(str,sys.version_info[:3])),"
+        "'site_packages':sysconfig.get_path('purelib'),"
+        "'core_version':dcc_mcp_core.__version__,"
+        "'adapter_version':dcc_mcp_blender.__version__}))"
+    )
+    try:
+        completed = subprocess.run(
+            [str(python_path), "-c", script],
+            check=False,
+            capture_output=True,
+            universal_newlines=True,
+            timeout=20,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise LifecycleError(
+            INSTALL_EXIT_PREFLIGHT,
+            "python",
+            "python_probe_failed",
+            "Could not run the target interpreter: %s" % exc,
+        ) from exc
+    if completed.returncode != 0:
+        diagnostic = (completed.stderr or completed.stdout).strip()[-2000:]
+        raise LifecycleError(
+            INSTALL_EXIT_PREFLIGHT,
+            "python",
+            "target_import_failed",
+            "Target Python cannot import the adapter and Core: %s" % diagnostic,
+        )
+    try:
+        payload = json.loads(completed.stdout.strip().splitlines()[-1])
+    except (IndexError, ValueError) as exc:
+        raise LifecycleError(
+            INSTALL_EXIT_PREFLIGHT,
+            "python",
+            "python_probe_invalid",
+            "Target Python returned invalid version metadata.",
+        ) from exc
+    if payload.get("adapter_version") != __version__:
+        raise LifecycleError(
+            INSTALL_EXIT_PREFLIGHT,
+            "python",
+            "adapter_version_mismatch",
+            "Target Python has adapter %r; expected %r." % (payload.get("adapter_version"), __version__),
+        )
+    if _version_tuple(str(payload.get("core_version", ""))) < _version_tuple(MIN_CORE_VERSION):
+        raise LifecycleError(
+            INSTALL_EXIT_PREFLIGHT,
+            "core_version",
+            "core_version_unsupported",
+            "dcc-mcp-core>=%s is required in the target interpreter." % MIN_CORE_VERSION,
+        )
+    return {str(key): str(value) for key, value in payload.items()}
+
+
+def _default_user_scripts(version):
+    # type: (str) -> Path
+    major_minor = ".".join(str(part) for part in _version_tuple(version)[:2])
+    if os.name == "nt":
+        appdata = os.environ.get("APPDATA")
+        if not appdata:
+            raise LifecycleError(
+                INSTALL_EXIT_PREFLIGHT,
+                "profile",
+                "profile_unavailable",
+                "APPDATA is unavailable; set DCC_MCP_BLENDER_USER_SCRIPTS.",
+            )
+        return Path(appdata) / "Blender Foundation" / "Blender" / major_minor / "scripts"
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "Blender" / major_minor / "scripts"
+    config_home = Path(os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config")))
+    return config_home / "blender" / major_minor / "scripts"
+
+
+def _resolve_context(dcc_path, python_path, environ):
+    # type: (Optional[str], Optional[str], Mapping[str, str]) -> InstallContext
+    host_path = _resolve_host_path(dcc_path)
+    host_version = _resolve_host_version(host_path, environ)
+    selected_python = python_path or environ.get("DCC_MCP_INSTALL_PYTHON") or sys.executable
+    interpreter = Path(selected_python).expanduser().resolve()
+    python = _probe_python(interpreter)
+    profile = (
+        Path(environ.get("DCC_MCP_BLENDER_USER_SCRIPTS") or _default_user_scripts(host_version)).expanduser().resolve()
+    )
+    receipt_path = Path(environ.get("DCC_MCP_BLENDER_RECEIPT", str(DEFAULT_RECEIPT_PATH))).expanduser().resolve()
+    startup_path = profile / "startup" / STARTUP_SCRIPT_NAME
+    state_stage = ""
+    state_reason = ""
+    if receipt_path.is_file():
+        try:
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            state = "partial"
+            state_stage = "receipt"
+            state_reason = "receipt_invalid"
+        else:
+            receipt_python = receipt.get("python") if isinstance(receipt, dict) else None
+            receipt_host = receipt.get("host") if isinstance(receipt, dict) else None
+            valid_receipt = (
+                isinstance(receipt, dict)
+                and receipt.get("receipt_version") == 1
+                and receipt.get("dcc_type") == DCC_TYPE
+                and isinstance(receipt_python, dict)
+                and isinstance(receipt_host, dict)
+            )
+            if not valid_receipt:
+                state = "partial"
+                state_stage = "receipt"
+                state_reason = "receipt_invalid"
+            else:
+                recorded_python = str(receipt_python.get("path", ""))
+                if not recorded_python:
+                    state = "partial"
+                    state_stage = "receipt"
+                    state_reason = "receipt_invalid"
+                elif Path(recorded_python).expanduser().resolve() != interpreter:
+                    raise LifecycleError(
+                        INSTALL_EXIT_PREFLIGHT,
+                        "python",
+                        "python_mismatch",
+                        "Selected interpreter does not match the Blender install receipt.",
+                    )
+                else:
+                    recorded_host = str(receipt_host.get("path", ""))
+                    recorded_profile = str(receipt_host.get("profile", ""))
+                    if (
+                        not recorded_host
+                        or not recorded_profile
+                        or Path(recorded_host).expanduser().resolve() != host_path
+                        or Path(recorded_profile).expanduser().resolve() != profile
+                    ):
+                        raise LifecycleError(
+                            INSTALL_EXIT_PREFLIGHT,
+                            "receipt",
+                            "receipt_target_mismatch",
+                            "The receipt belongs to a different Blender host or profile.",
+                        )
+                    files = receipt.get("files")
+                    owned_file = files[0] if isinstance(files, list) and len(files) == 1 else None
+                    if not isinstance(owned_file, dict):
+                        state = "partial"
+                        state_stage = "receipt"
+                        state_reason = "receipt_invalid"
+                    else:
+                        recorded_path = str(owned_file.get("path", ""))
+                        recorded_digest = owned_file.get("sha256")
+                        try:
+                            artifact_current = (
+                                bool(recorded_path)
+                                and Path(recorded_path).expanduser().resolve() == startup_path.resolve()
+                                and startup_path.is_file()
+                                and bool(recorded_digest)
+                                and _sha256(startup_path) == recorded_digest
+                            )
+                        except OSError:
+                            artifact_current = False
+                        if not artifact_current:
+                            state = "partial"
+                            state_stage = "artifact"
+                            state_reason = (
+                                "startup_script_missing"
+                                if not startup_path.is_file()
+                                else "startup_script_digest_mismatch"
+                            )
+                        else:
+                            state = "current" if receipt.get("adapter_version") == __version__ else "upgrade"
+    elif startup_path.exists():
+        state = "partial"
+        state_stage = "receipt"
+        state_reason = "unreceipted_startup_script"
+    else:
+        state = "fresh"
+    return InstallContext(
+        host_path=host_path,
+        host_version=host_version,
+        profile=profile,
+        python_path=interpreter,
+        python_version=python["python_version"],
+        site_packages=Path(python["site_packages"]).resolve(),
+        core_version=python["core_version"],
+        state=state,
+        state_stage=state_stage,
+        state_reason=state_reason,
+        receipt_path=receipt_path,
+        startup_path=startup_path,
+        bootstrap_log_dir=profile / ".dcc-mcp" / "logs",
+    )
+
+
+def _base_report(ctx, command, status):
+    # type: (InstallContext, str, str) -> Dict[str, Any]
+    return {
+        "schema_version": INSTALL_SOP_SCHEMA_VERSION,
+        "status": status,
+        "dcc_type": DCC_TYPE,
+        "command": command,
+        "adapter_version": __version__,
+        "core_version": ctx.core_version,
+        "steps": [],
+        "next_steps": [],
+        "receipt_path": str(ctx.receipt_path),
+        "verify": {
+            "directly_usable": False,
+            "failure_stage": None,
+            "failure_reason": None,
+        },
+        "host": {
+            "path": str(ctx.host_path),
+            "version": ctx.host_version,
+            "profile": str(ctx.profile),
+        },
+        "python": {
+            "path": str(ctx.python_path),
+            "version": ctx.python_version,
+            "site_packages": str(ctx.site_packages),
+            "selection_source": "--python",
+        },
+        "install_state": ctx.state,
+    }
+
+
+def _command_for(ctx, command, execute=False):
+    # type: (InstallContext, str, bool) -> Sequence[str]
+    result = [
+        COMMAND,
+        command,
+        "--dcc-path",
+        str(ctx.host_path),
+        "--python",
+        str(ctx.python_path),
+        "--json",
+    ]
+    if execute:
+        result.append("--yes")
+    return result
+
+
+def _plan(ctx, command):
+    # type: (InstallContext, str) -> Dict[str, Any]
+    report = _base_report(ctx, command, "planned")
+    if command == "upgrade":
+        plan_type = "upgrade"
+    elif ctx.state == "partial":
+        plan_type = "repair"
+    else:
+        plan_type = ctx.state
+    report["plan_type"] = plan_type
+    if command == "uninstall":
+        report["steps"] = [
+            {"id": "preflight", "status": "ok"},
+            {"id": "receipt", "status": "planned"},
+            {"id": "uninstall", "status": "planned"},
+        ]
+    else:
+        report["steps"] = [
+            {"id": "preflight", "status": "ok"},
+            {"id": "stage", "status": "planned"},
+            {"id": "commit", "status": "planned"},
+            {"id": "verify", "status": "planned"},
+        ]
+    report["next_steps"] = [
+        {
+            "id": "execute_%s" % command,
+            "description": "Execute the validated Blender %s plan." % command,
+            "command": list(_command_for(ctx, command, execute=True)),
+            "why": "Planning and dry-run modes do not modify Blender's user scripts.",
+        }
+    ]
+    return report
+
+
+def _sha256(path):
+    # type: (Path) -> str
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _read_receipt(path, required=False):
+    # type: (Path, bool) -> Optional[Dict[str, Any]]
+    if not path.is_file():
+        if required:
+            raise LifecycleError(
+                INSTALL_EXIT_PREFLIGHT,
+                "receipt",
+                "receipt_missing",
+                "No Blender install receipt exists at %s." % path,
+            )
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise LifecycleError(
+            INSTALL_EXIT_PREFLIGHT,
+            "receipt",
+            "receipt_invalid",
+            "The Blender install receipt is unreadable: %s" % exc,
+        ) from exc
+    if not isinstance(value, dict) or value.get("receipt_version") != 1:
+        raise LifecycleError(
+            INSTALL_EXIT_PREFLIGHT,
+            "receipt",
+            "receipt_invalid",
+            "The Blender install receipt has an unsupported schema.",
+        )
+    if value.get("dcc_type") != DCC_TYPE:
+        raise LifecycleError(
+            INSTALL_EXIT_PREFLIGHT,
+            "receipt",
+            "receipt_wrong_adapter",
+            "The receipt does not belong to the Blender adapter.",
+        )
+    return value
+
+
+def _render_startup_script(ctx):
+    # type: (InstallContext) -> str
+    site_packages = json.dumps(str(ctx.site_packages))
+    log_dir = json.dumps(str(ctx.bootstrap_log_dir))
+    adapter_version = json.dumps(__version__)
+    min_core_version = json.dumps(MIN_CORE_VERSION)
+    return '''"""Auto-start dcc-mcp-blender from Blender's startup registry."""
+
+from __future__ import annotations
+
+import site
+
+site.addsitedir(%s)
+
+_server = None
+_owns_server = False
+
+
+def register():
+    """Start the MCP server once Blender has loaded this startup script."""
+    global _owns_server, _server
+    if _server is not None and getattr(_server, "is_running", True):
+        return _server
+
+    from dcc_mcp_core import capture_bootstrap_errors
+
+    with capture_bootstrap_errors(
+        "blender",
+        adapter_version=%s,
+        min_core_version=%s,
+        phase="startup",
+        log_dir=%s,
+    ):
+        from dcc_mcp_blender import get_server, start_server
+
+        existing = get_server()
+        if existing is not None and getattr(existing, "is_running", False):
+            _server = existing
+            _owns_server = False
+            return _server
+
+        _server = start_server()
+        _owns_server = True
+        return _server
+
+
+def unregister():
+    """Stop only the server owned by this startup script."""
+    global _owns_server, _server
+    if _server is None:
+        return
+    try:
+        if not _owns_server:
+            return
+        from dcc_mcp_blender import get_server, stop_server
+        if get_server() is _server:
+            stop_server()
+    finally:
+        _server = None
+        _owns_server = False
+''' % (site_packages, adapter_version, min_core_version, log_dir)
+
+
+def _write_text(path, content):
+    # type: (Path, str) -> None
+    path.write_text(content, encoding="utf-8")
+
+
+def _replace_path(source, destination):
+    # type: (Path, Path) -> None
+    os.replace(str(source), str(destination))
+
+
+def _unlink_file(path):
+    # type: (Path) -> None
+    path.unlink()
+
+
+def _is_windows_lock(exc):
+    # type: (OSError) -> bool
+    return os.name == "nt" and (isinstance(exc, PermissionError) or getattr(exc, "winerror", None) in {5, 32, 33})
+
+
+def _receipt_payload(ctx, startup_path, installed_at, previous_version):
+    # type: (InstallContext, Path, float, Optional[str]) -> Dict[str, Any]
+    return {
+        "receipt_version": 1,
+        "schema_version": INSTALL_SOP_SCHEMA_VERSION,
+        "dcc_type": DCC_TYPE,
+        "adapter_version": __version__,
+        "core_version": ctx.core_version,
+        "host": {
+            "path": str(ctx.host_path),
+            "version": ctx.host_version,
+            "profile": str(ctx.profile),
+        },
+        "python": {
+            "path": str(ctx.python_path),
+            "version": ctx.python_version,
+            "site_packages": str(ctx.site_packages),
+        },
+        "files": [{"path": str(startup_path.resolve()), "sha256": _sha256(startup_path)}],
+        "bootstrap_error_dir": str(ctx.bootstrap_log_dir),
+        "installed_at": datetime.fromtimestamp(installed_at, timezone.utc).isoformat(),
+        "installed_at_epoch": installed_at,
+        "previous_adapter_version": previous_version,
+    }
+
+
+def _rollback_file(current, backup, existed_before):
+    # type: (Path, Path, bool) -> None
+    if current.exists():
+        _unlink_file(current)
+    if existed_before and backup.exists():
+        _replace_path(backup, current)
+
+
+def _install_transaction(ctx):
+    # type: (InstallContext) -> None
+    previous = _read_receipt(ctx.receipt_path)
+    previous_version = str(previous.get("adapter_version")) if previous else None
+    token = uuid.uuid4().hex
+    ctx.startup_path.parent.mkdir(parents=True, exist_ok=True)
+    ctx.receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    startup_stage = ctx.startup_path.with_name(".%s.stage-%s" % (ctx.startup_path.name, token))
+    startup_backup = ctx.startup_path.with_name(".%s.backup-%s" % (ctx.startup_path.name, token))
+    receipt_stage = ctx.receipt_path.with_name(".%s.stage-%s" % (ctx.receipt_path.name, token))
+    receipt_backup = ctx.receipt_path.with_name(".%s.backup-%s" % (ctx.receipt_path.name, token))
+    startup_existed = ctx.startup_path.exists()
+    receipt_existed = ctx.receipt_path.exists()
+    installed_at = time.time()
+    startup_committed = False
+    receipt_committed = False
+    try:
+        _write_text(startup_stage, _render_startup_script(ctx))
+        receipt = _receipt_payload(ctx, startup_stage, installed_at, previous_version)
+        receipt["files"][0]["path"] = str(ctx.startup_path.resolve())
+        _write_text(receipt_stage, json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+
+        inspection = inspect_install_root(ctx.startup_path.parent)
+        if inspection.get("requires_restart"):
+            raise LifecycleError(
+                INSTALL_EXIT_REQUIRES_RESTART,
+                "install",
+                "native_artifact_loaded",
+                str(inspection.get("recommended_next_action") or "Blender must restart."),
+            )
+
+        if startup_existed:
+            _replace_path(ctx.startup_path, startup_backup)
+        _replace_path(startup_stage, ctx.startup_path)
+        startup_committed = True
+        if receipt_existed:
+            _replace_path(ctx.receipt_path, receipt_backup)
+        _replace_path(receipt_stage, ctx.receipt_path)
+        receipt_committed = True
+    except BaseException:
+        try:
+            if startup_committed or startup_backup.exists():
+                _rollback_file(ctx.startup_path, startup_backup, startup_existed)
+            if receipt_committed or receipt_backup.exists():
+                _rollback_file(ctx.receipt_path, receipt_backup, receipt_existed)
+        finally:
+            for temporary in (startup_stage, receipt_stage):
+                if temporary.exists():
+                    _unlink_file(temporary)
+        raise
+    else:
+        for backup in (startup_backup, receipt_backup):
+            if backup.exists():
+                _unlink_file(backup)
+
+
+def _readiness_next_steps(ctx):
+    # type: (InstallContext) -> Sequence[Dict[str, Any]]
+    return [
+        {
+            "id": "launch_blender",
+            "description": "Launch the selected Blender installation.",
+            "command": [str(ctx.host_path)],
+            "why": "The typed host.ping probe requires a running Blender instance.",
+        },
+        {
+            "id": "verify_install",
+            "description": "Verify the adapter after Blender finishes starting.",
+            "command": list(_command_for(ctx, "verify")),
+            "why": "Direct usability is not proven until the typed readiness probe succeeds.",
+        },
+    ]
+
+
+def _verify(ctx, environ):
+    # type: (InstallContext, Mapping[str, str]) -> Tuple[Dict[str, Any], Sequence[Dict[str, Any]]]
+    try:
+        receipt = _read_receipt(ctx.receipt_path, required=True)
+    except LifecycleError as exc:
+        return (
+            {
+                "directly_usable": False,
+                "failure_stage": "receipt",
+                "failure_reason": exc.reason,
+            },
+            (),
+        )
+    assert receipt is not None
+    files = receipt.get("files")
+    if not isinstance(files, list) or len(files) != 1 or not isinstance(files[0], dict):
+        return (
+            {
+                "directly_usable": False,
+                "failure_stage": "receipt",
+                "failure_reason": "receipt_ownership_invalid",
+            },
+            (),
+        )
+    recorded_path = Path(str(files[0].get("path", ""))).expanduser().resolve()
+    if recorded_path != ctx.startup_path.resolve():
+        return (
+            {
+                "directly_usable": False,
+                "failure_stage": "receipt",
+                "failure_reason": "receipt_target_mismatch",
+            },
+            (),
+        )
+    if not recorded_path.is_file():
+        return (
+            {
+                "directly_usable": False,
+                "failure_stage": "artifact",
+                "failure_reason": "startup_script_missing",
+            },
+            (),
+        )
+    if _sha256(recorded_path) != files[0].get("sha256"):
+        return (
+            {
+                "directly_usable": False,
+                "failure_stage": "artifact",
+                "failure_reason": "startup_script_digest_mismatch",
+            },
+            (),
+        )
+    try:
+        _probe_python(ctx.python_path)
+    except LifecycleError as exc:
+        return (
+            {
+                "directly_usable": False,
+                "failure_stage": "import",
+                "failure_reason": exc.reason,
+            },
+            (),
+        )
+
+    try:
+        installed_at = float(receipt.get("installed_at_epoch", 0.0))
+    except (TypeError, ValueError):
+        return (
+            {
+                "directly_usable": False,
+                "failure_stage": "receipt",
+                "failure_reason": "receipt_invalid",
+            },
+            (),
+        )
+    recent_errors = []
+    if ctx.bootstrap_log_dir.is_dir():
+        recent_errors = [
+            path
+            for path in ctx.bootstrap_log_dir.glob("dcc-mcp-blender.*.host-errors.log")
+            if path.stat().st_mtime >= installed_at
+        ]
+    if recent_errors:
+        return (
+            {
+                "directly_usable": False,
+                "failure_stage": "bootstrap",
+                "failure_reason": "bootstrap_error_captured",
+                "diagnostic_path": str(recent_errors[-1]),
+            },
+            (),
+        )
+
+    state = query_runtime_state(environ.get("DCC_MCP_REGISTRY_DIR"), dcc_type=DCC_TYPE, include_dead=False)
+    entries = [entry for entry in state.get("entries", []) if entry.get("mcp_url")]
+    if len(entries) != 1:
+        reason = "no_live_blender_instance" if not entries else "multiple_live_blender_instances"
+        return (
+            {
+                "directly_usable": False,
+                "failure_stage": "readiness",
+                "failure_reason": reason,
+                "probe_tool": "host.ping",
+            },
+            _readiness_next_steps(ctx),
+        )
+    timeout = max(0.1, float(environ.get("DCC_MCP_INSTALL_VERIFY_TIMEOUT", "2.0")))
+    probe = probe_sidecar_tool(str(entries[0]["mcp_url"]), "host.ping", timeout_secs=timeout)
+    if not probe.get("success"):
+        return (
+            {
+                "directly_usable": False,
+                "failure_stage": "readiness",
+                "failure_reason": str(probe.get("reason") or probe.get("status") or "host_ping_failed"),
+                "probe_tool": "host.ping",
+            },
+            _readiness_next_steps(ctx),
+        )
+    return (
+        {
+            "directly_usable": True,
+            "failure_stage": None,
+            "failure_reason": None,
+            "probe_tool": "host.ping",
+        },
+        (),
+    )
+
+
+def _execute_install(ctx, environ, command="install"):
+    # type: (InstallContext, Mapping[str, str], str) -> Tuple[Dict[str, Any], int]
+    if ctx.state == "partial" and ctx.startup_path.exists() and not ctx.receipt_path.exists():
+        try:
+            legacy = ctx.startup_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise LifecycleError(
+                INSTALL_EXIT_PREFLIGHT,
+                "partial",
+                "unreceipted_startup_script",
+                "The unreceipted Blender startup script cannot be inspected: %s" % exc,
+            ) from exc
+        if "Auto-start dcc-mcp-blender" not in legacy:
+            raise LifecycleError(
+                INSTALL_EXIT_PREFLIGHT,
+                "partial",
+                "unreceipted_startup_script",
+                "An unknown unreceipted startup script exists; refusing to overwrite it.",
+            )
+    try:
+        _install_transaction(ctx)
+    except LifecycleError:
+        raise
+    except OSError as exc:
+        exit_code = INSTALL_EXIT_REQUIRES_RESTART if _is_windows_lock(exc) else INSTALL_EXIT_INSTALL
+        reason = "windows_file_lock" if exit_code == INSTALL_EXIT_REQUIRES_RESTART else "commit_failed"
+        raise LifecycleError(exit_code, "install", reason, "Install transaction failed: %s" % exc) from exc
+
+    verify, next_steps = _verify(ctx, environ)
+    usable = bool(verify["directly_usable"])
+    report = _base_report(ctx, command, "ok" if usable else "partial")
+    report["plan_type"] = "upgrade" if command == "upgrade" else ctx.state
+    report["steps"] = [
+        {"id": "preflight", "status": "ok"},
+        {"id": "stage", "status": "ok"},
+        {"id": "commit", "status": "ok"},
+        {"id": "verify", "status": "ok" if usable else "failed"},
+    ]
+    report["next_steps"] = list(next_steps)
+    report["verify"] = verify
+    return report, INSTALL_EXIT_OK if usable else INSTALL_EXIT_VERIFY
+
+
+def _status(ctx):
+    # type: (InstallContext) -> Tuple[Dict[str, Any], int]
+    report = _base_report(ctx, "status", "partial" if ctx.state == "partial" else "ok")
+    report["steps"] = [
+        {"id": "receipt", "status": "present" if ctx.receipt_path.is_file() else "absent"},
+        {"id": "startup", "status": "present" if ctx.startup_path.is_file() else "absent"},
+    ]
+    if ctx.state == "partial":
+        report["verify"] = {
+            "directly_usable": False,
+            "failure_stage": ctx.state_stage or "state",
+            "failure_reason": ctx.state_reason or "partial_install",
+        }
+    exit_code = INSTALL_EXIT_PREFLIGHT if ctx.state == "partial" else INSTALL_EXIT_OK
+    return report, exit_code
+
+
+def _execute_uninstall(ctx):
+    # type: (InstallContext) -> Tuple[Dict[str, Any], int]
+    receipt = _read_receipt(ctx.receipt_path)
+    if receipt is None:
+        if ctx.startup_path.exists():
+            raise LifecycleError(
+                INSTALL_EXIT_PREFLIGHT,
+                "partial",
+                "unreceipted_startup_script",
+                "The Blender startup script has no receipt; refusing ambiguous removal.",
+            )
+        report = _base_report(ctx, "uninstall", "ok")
+        report["steps"] = [{"id": "uninstall", "status": "already_absent"}]
+        return report, INSTALL_EXIT_OK
+
+    files = receipt.get("files")
+    expected = ctx.startup_path.resolve()
+    if not isinstance(files, list) or len(files) != 1 or not isinstance(files[0], dict):
+        raise LifecycleError(
+            INSTALL_EXIT_INSTALL,
+            "receipt",
+            "receipt_ownership_invalid",
+            "Receipt ownership is incomplete; refusing removal.",
+        )
+    recorded = Path(str(files[0].get("path", ""))).expanduser().resolve()
+    if recorded != expected:
+        raise LifecycleError(
+            INSTALL_EXIT_INSTALL,
+            "receipt",
+            "receipt_target_mismatch",
+            "Receipt target does not match the selected Blender profile.",
+        )
+    if recorded.exists() and _sha256(recorded) != files[0].get("sha256"):
+        raise LifecycleError(
+            INSTALL_EXIT_INSTALL,
+            "receipt",
+            "startup_script_modified",
+            "The receipted startup script was modified; preserving it.",
+        )
+
+    inspection = inspect_install_root(ctx.startup_path.parent)
+    if inspection.get("requires_restart"):
+        raise LifecycleError(
+            INSTALL_EXIT_REQUIRES_RESTART,
+            "uninstall",
+            "native_artifact_loaded",
+            str(inspection.get("recommended_next_action") or "Blender must restart."),
+        )
+
+    token = uuid.uuid4().hex
+    startup_tombstone = ctx.startup_path.with_name(".%s.uninstall-%s" % (ctx.startup_path.name, token))
+    receipt_tombstone = ctx.receipt_path.with_name(".%s.uninstall-%s" % (ctx.receipt_path.name, token))
+    receipt_bytes = ctx.receipt_path.read_bytes()
+    try:
+        if ctx.startup_path.exists():
+            _replace_path(ctx.startup_path, startup_tombstone)
+        _replace_path(ctx.receipt_path, receipt_tombstone)
+        _unlink_file(receipt_tombstone)
+        if startup_tombstone.exists():
+            _unlink_file(startup_tombstone)
+    except OSError as exc:
+        if startup_tombstone.exists() and not ctx.startup_path.exists():
+            _replace_path(startup_tombstone, ctx.startup_path)
+        if receipt_tombstone.exists() and not ctx.receipt_path.exists():
+            _replace_path(receipt_tombstone, ctx.receipt_path)
+        elif not ctx.receipt_path.exists():
+            _write_text(ctx.receipt_path, receipt_bytes.decode("utf-8"))
+        exit_code = INSTALL_EXIT_REQUIRES_RESTART if _is_windows_lock(exc) else INSTALL_EXIT_INSTALL
+        reason = "windows_file_lock" if exit_code == INSTALL_EXIT_REQUIRES_RESTART else "uninstall_failed"
+        raise LifecycleError(exit_code, "uninstall", reason, "Uninstall transaction failed: %s" % exc) from exc
+
+    report = _base_report(ctx, "uninstall", "ok")
+    report["install_state"] = "fresh"
+    report["steps"] = [
+        {"id": "receipt", "status": "consumed"},
+        {"id": "uninstall", "status": "ok"},
+    ]
+    return report, INSTALL_EXIT_OK
+
+
+def _failure_report(command, dcc_path, python_path, environ, exc):
+    # type: (str, Optional[str], Optional[str], Mapping[str, str], LifecycleError) -> Dict[str, Any]
+    receipt_path = Path(environ.get("DCC_MCP_BLENDER_RECEIPT", str(DEFAULT_RECEIPT_PATH))).expanduser().resolve()
+    return {
+        "schema_version": INSTALL_SOP_SCHEMA_VERSION,
+        "status": "requires_restart" if exc.exit_code == INSTALL_EXIT_REQUIRES_RESTART else "failed",
+        "dcc_type": DCC_TYPE,
+        "command": command,
+        "adapter_version": __version__,
+        "core_version": str(getattr(dcc_mcp_core, "__version__", "unknown")),
+        "steps": [{"id": exc.stage, "status": "failed", "message": str(exc)}],
+        "next_steps": [
+            {
+                "id": "retry_preflight",
+                "description": "Repeat preflight with the exact Blender host and interpreter.",
+                "command": [
+                    COMMAND,
+                    command,
+                    "--dcc-path",
+                    dcc_path or "<absolute-blender-path>",
+                    "--python",
+                    python_path or environ.get("DCC_MCP_INSTALL_PYTHON") or sys.executable,
+                    "--json",
+                    "--dry-run",
+                ],
+                "why": str(exc),
+            }
+        ],
+        "receipt_path": str(receipt_path),
+        "verify": {
+            "directly_usable": False,
+            "failure_stage": exc.stage,
+            "failure_reason": exc.reason,
+        },
+        "failure_message": str(exc),
+    }
+
+
+def _parser():
+    # type: () -> argparse.ArgumentParser
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=LIFECYCLE_COMMANDS)
+    parser.add_argument("--json", action="store_true", help="Emit one SOP v1 JSON document.")
+    parser.add_argument("--yes", action="store_true", help="Execute a mutating plan.")
+    parser.add_argument("--dry-run", action="store_true", help="Resolve without writing files.")
+    parser.add_argument("--dcc-path", help="Exact Blender executable or .app path.")
+    parser.add_argument("--python", help="Exact Blender target interpreter.")
+    return parser
+
+
+def main(argv=None):
+    # type: (Optional[Sequence[str]]) -> int
+    args = _parser().parse_args(argv)
+    environ = os.environ
+    try:
+        ctx = _resolve_context(args.dcc_path, args.python, environ)
+        if args.command == "install":
+            if args.dry_run or not args.yes:
+                report = _plan(ctx, args.command)
+                exit_code = INSTALL_EXIT_OK
+            else:
+                report, exit_code = _execute_install(ctx, environ)
+        elif args.command == "upgrade":
+            if not ctx.receipt_path.is_file():
+                raise LifecycleError(
+                    INSTALL_EXIT_PREFLIGHT,
+                    "receipt",
+                    "receipt_missing",
+                    "Upgrade requires an existing Blender install receipt.",
+                )
+            if args.dry_run or not args.yes:
+                report = _plan(ctx, args.command)
+                exit_code = INSTALL_EXIT_OK
+            else:
+                report, exit_code = _execute_install(ctx, environ, command="upgrade")
+        elif args.command == "status":
+            report, exit_code = _status(ctx)
+        elif args.command == "verify":
+            verify, next_steps = _verify(ctx, environ)
+            usable = bool(verify["directly_usable"])
+            report = _base_report(ctx, args.command, "ok" if usable else "failed")
+            report["steps"] = [{"id": "verify", "status": "ok" if usable else "failed"}]
+            report["next_steps"] = list(next_steps)
+            report["verify"] = verify
+            exit_code = INSTALL_EXIT_OK if usable else INSTALL_EXIT_VERIFY
+        elif args.command == "uninstall":
+            if args.dry_run or not args.yes:
+                report = _plan(ctx, args.command)
+                exit_code = INSTALL_EXIT_OK
+            else:
+                report, exit_code = _execute_uninstall(ctx)
+        else:
+            raise LifecycleError(
+                INSTALL_EXIT_PREFLIGHT,
+                "command",
+                "command_not_implemented",
+                "The %s lifecycle path is not implemented yet." % args.command,
+            )
+    except LifecycleError as exc:
+        report = _failure_report(args.command, args.dcc_path, args.python, environ, exc)
+        exit_code = exc.exit_code
+    except BaseException as exc:
+        failure = LifecycleError(
+            INSTALL_EXIT_INSTALL,
+            "install",
+            "lifecycle_failed",
+            "Lifecycle operation failed: %s" % exc,
+        )
+        report = _failure_report(args.command, args.dcc_path, args.python, environ, failure)
+        exit_code = failure.exit_code
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print("%s: %s" % (args.command, report["status"]))
+        if report.get("failure_message"):
+            print(report["failure_message"])
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "COMMAND",
+    "DCC_TYPE",
+    "INSTALL_EXIT_ACQUIRE",
+    "INSTALL_EXIT_CODES",
+    "INSTALL_EXIT_INSTALL",
+    "INSTALL_EXIT_OK",
+    "INSTALL_EXIT_PREFLIGHT",
+    "INSTALL_EXIT_REQUIRES_RESTART",
+    "INSTALL_EXIT_VERIFY",
+    "INSTALL_SOP_SCHEMA_VERSION",
+    "LIFECYCLE_COMMANDS",
+    "load_install_sop_schema",
+    "main",
+]

--- a/src/dcc_mcp_blender/schemas/adapter-install-sop-v1.schema.json
+++ b/src/dcc_mcp_blender/schemas/adapter-install-sop-v1.schema.json
@@ -1,0 +1,73 @@
+{
+  "$id": "https://dcc-mcp.github.io/schemas/adapter-install-sop-v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "file_edit": {
+      "properties": {
+        "action": {"enum": ["create", "update", "remove"], "type": "string"},
+        "content": {"type": "string"},
+        "path": {"minLength": 1, "type": "string"}
+      },
+      "required": ["path", "action"],
+      "type": "object"
+    },
+    "next_step": {
+      "oneOf": [{"required": ["command"]}, {"required": ["file_edit"]}],
+      "properties": {
+        "command": {"items": {"type": "string"}, "minItems": 1, "type": "array"},
+        "description": {"minLength": 1, "type": "string"},
+        "file_edit": {"$ref": "#/$defs/file_edit"},
+        "id": {"minLength": 1, "type": "string"},
+        "why": {"minLength": 1, "type": "string"}
+      },
+      "required": ["id", "description", "why"],
+      "type": "object"
+    },
+    "step": {
+      "properties": {
+        "description": {"type": "string"},
+        "id": {"minLength": 1, "type": "string"},
+        "message": {"type": "string"},
+        "status": {"minLength": 1, "type": "string"}
+      },
+      "required": ["id", "status"],
+      "type": "object"
+    },
+    "verify": {
+      "properties": {
+        "directly_usable": {"type": "boolean"},
+        "failure_reason": {"type": ["string", "null"]},
+        "failure_stage": {"type": ["string", "null"]}
+      },
+      "required": ["directly_usable", "failure_stage", "failure_reason"],
+      "type": "object"
+    }
+  },
+  "properties": {
+    "adapter_version": {"minLength": 1, "type": "string"},
+    "core_version": {"minLength": 1, "type": "string"},
+    "dcc_type": {"minLength": 1, "type": "string"},
+    "next_steps": {"items": {"$ref": "#/$defs/next_step"}, "type": "array"},
+    "receipt_path": {"type": ["string", "null"]},
+    "schema_version": {"const": 1, "type": "integer"},
+    "status": {
+      "enum": ["planned", "running", "ok", "failed", "partial", "requires_restart"],
+      "type": "string"
+    },
+    "steps": {"items": {"$ref": "#/$defs/step"}, "type": "array"},
+    "verify": {"$ref": "#/$defs/verify"}
+  },
+  "required": [
+    "schema_version",
+    "status",
+    "dcc_type",
+    "adapter_version",
+    "core_version",
+    "steps",
+    "next_steps",
+    "receipt_path",
+    "verify"
+  ],
+  "title": "DCC-MCP Adapter Install SOP v1 Result",
+  "type": "object"
+}

--- a/tests/test_addon_packaging.py
+++ b/tests/test_addon_packaging.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import contextlib
 import hashlib
 import importlib.util
 import os
@@ -383,6 +384,49 @@ def test_addon_register_starts_server_with_core_backed_blender_ui_dispatcher(mon
         "stop_server",
         "dispatcher.stop",
     ]
+
+
+def test_addon_register_captures_and_reraises_server_start_failure(monkeypatch):
+    """Extension enable failures must remain machine-readable and host-visible."""
+
+    class _Menu:
+        @staticmethod
+        def append(_fn):
+            pass
+
+    fake_bpy = SimpleNamespace(
+        types=SimpleNamespace(Operator=object, Menu=object, TOPBAR_MT_blender=_Menu),
+        utils=SimpleNamespace(register_class=lambda _cls: None),
+    )
+    spec = importlib.util.spec_from_file_location("addon_entry_bootstrap_test", str(ADDON_ENTRY))
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "bpy", fake_bpy)
+    spec.loader.exec_module(mod)
+    captured = []
+
+    @contextlib.contextmanager
+    def capture_bootstrap_errors(dcc_name, **kwargs):
+        try:
+            yield
+        except BaseException as exc:
+            captured.append((dcc_name, kwargs, exc))
+            raise
+
+    import dcc_mcp_core
+
+    monkeypatch.setattr(dcc_mcp_core, "capture_bootstrap_errors", capture_bootstrap_errors)
+    monkeypatch.setattr(
+        mod,
+        "_start_server_with_host",
+        lambda: (_ for _ in ()).throw(RuntimeError("extension startup exploded")),
+    )
+
+    with pytest.raises(RuntimeError, match="extension startup exploded"):
+        mod.register()
+
+    assert captured[0][0] == "blender"
+    assert captured[0][1]["phase"] == "startup"
+    assert captured[0][2].args == ("extension startup exploded",)
 
 
 def test_addon_rejects_ui_control_binding_to_another_process(monkeypatch):

--- a/tests/test_install_lifecycle.py
+++ b/tests/test_install_lifecycle.py
@@ -104,6 +104,43 @@ def test_install_dry_run_emits_a_complete_non_mutating_plan(tmp_path, monkeypatc
     assert not receipt.exists()
 
 
+def test_install_requires_an_explicit_target_interpreter(tmp_path, monkeypatch, capsys):
+    """The agent CLI interpreter is not implicitly a Blender-owned interpreter."""
+    from dcc_mcp_blender import install
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.delenv("DCC_MCP_INSTALL_PYTHON", raising=False)
+
+    exit_code = install.main(["install", "--json", "--dry-run", "--dcc-path", str(blender)])
+
+    report = json.loads(capsys.readouterr().out)
+    assert exit_code == install.INSTALL_EXIT_PREFLIGHT
+    assert report["verify"]["failure_stage"] == "python"
+    assert report["verify"]["failure_reason"] == "python_required"
+    assert report["next_steps"][0]["command"][5] == "<absolute-blender-python>"
+
+
+def test_environment_selected_interpreter_reports_its_real_source(tmp_path, monkeypatch, capsys):
+    """Machine-provided interpreter selection must not be mislabeled as --python."""
+    from dcc_mcp_blender import install
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.setenv("DCC_MCP_INSTALL_PYTHON", sys.executable)
+    monkeypatch.setenv("DCC_MCP_BLENDER_USER_SCRIPTS", str(tmp_path / "scripts"))
+    monkeypatch.setenv("DCC_MCP_BLENDER_RECEIPT", str(tmp_path / "receipt.json"))
+
+    exit_code = install.main(["install", "--json", "--dry-run", "--dcc-path", str(blender)])
+
+    report = json.loads(capsys.readouterr().out)
+    assert exit_code == install.INSTALL_EXIT_OK
+    assert report["python"]["path"] == str(Path(sys.executable).resolve())
+    assert report["python"]["selection_source"] == "DCC_MCP_INSTALL_PYTHON"
+
+
 def test_receipt_round_trip_is_convergent_and_uninstall_is_idempotent(tmp_path, monkeypatch, capsys):
     """Host enablement remains installed when only live readiness is unavailable."""
     from dcc_mcp_blender import install
@@ -153,6 +190,66 @@ def test_receipt_round_trip_is_convergent_and_uninstall_is_idempotent(tmp_path, 
 
     assert install.main(["uninstall", "--yes", *common]) == install.INSTALL_EXIT_OK
     assert json.loads(capsys.readouterr().out)["steps"][0]["status"] == "already_absent"
+
+
+def test_install_preserves_unreceipted_marker_spoof(tmp_path, monkeypatch, capsys):
+    """A comment containing the legacy marker is not proof of adapter ownership."""
+    from dcc_mcp_blender import install
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    startup_path = tmp_path / "scripts" / "startup" / install.STARTUP_SCRIPT_NAME
+    startup_path.parent.mkdir(parents=True)
+    spoof = '# Auto-start dcc-mcp-blender\nraise RuntimeError("operator owned")\n'
+    startup_path.write_text(spoof, encoding="utf-8")
+    receipt_path = tmp_path / "receipt.json"
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.setenv("DCC_MCP_BLENDER_USER_SCRIPTS", str(tmp_path / "scripts"))
+    monkeypatch.setenv("DCC_MCP_BLENDER_RECEIPT", str(receipt_path))
+
+    exit_code = install.main(
+        [
+            "install",
+            "--yes",
+            "--json",
+            "--dcc-path",
+            str(blender),
+            "--python",
+            sys.executable,
+        ]
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert exit_code == install.INSTALL_EXIT_PREFLIGHT
+    assert report["verify"]["failure_reason"] == "unreceipted_startup_script"
+    assert startup_path.read_text(encoding="utf-8") == spoof
+    assert not receipt_path.exists()
+
+
+def test_install_repairs_only_exact_generated_unreceipted_startup(tmp_path, monkeypatch, capsys):
+    """Losing a receipt is repairable only for exact known generated content."""
+    from dcc_mcp_blender import install
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    startup_path = tmp_path / "scripts" / "startup" / install.STARTUP_SCRIPT_NAME
+    receipt_path = tmp_path / "receipt.json"
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.setenv("DCC_MCP_BLENDER_USER_SCRIPTS", str(tmp_path / "scripts"))
+    monkeypatch.setenv("DCC_MCP_BLENDER_RECEIPT", str(receipt_path))
+    monkeypatch.setenv("DCC_MCP_REGISTRY_DIR", str(tmp_path / "registry"))
+    common = ["--json", "--dcc-path", str(blender), "--python", sys.executable]
+
+    assert install.main(["install", "--yes", *common]) == install.INSTALL_EXIT_VERIFY
+    capsys.readouterr()
+    known_content = startup_path.read_text(encoding="utf-8")
+    receipt_path.unlink()
+
+    assert install.main(["install", "--yes", *common]) == install.INSTALL_EXIT_VERIFY
+    report = json.loads(capsys.readouterr().out)
+    assert report["install_state"] == "partial"
+    assert startup_path.read_text(encoding="utf-8") == known_content
+    assert receipt_path.is_file()
 
 
 def test_upgrade_requires_a_receipt_and_reuses_the_install_transaction(tmp_path, monkeypatch, capsys):

--- a/tests/test_install_lifecycle.py
+++ b/tests/test_install_lifecycle.py
@@ -1,0 +1,483 @@
+"""Install SOP v1 contract tests for the Blender adapter."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+
+def test_package_exposes_the_standard_lifecycle_console_entrypoint():
+    """Agents discover one standard adapter command from installed metadata."""
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert "[project.scripts]" in pyproject
+    assert 'dcc-mcp-blender = "dcc_mcp_blender.install:main"' in pyproject
+
+
+def test_install_runbook_covers_the_public_lifecycle_and_catalog_route():
+    """The owning repository documents the exact executable SOP contract."""
+    guide = (ROOT / "install.md").read_text(encoding="utf-8")
+
+    for heading in (
+        "## Requirements",
+        "## Supported versions",
+        "## Agent quick path",
+        "## Manual path",
+        "## Verify",
+        "## Upgrade",
+        "## Uninstall",
+        "## Troubleshooting",
+    ):
+        assert heading in guide
+    for platform in ("Windows", "macOS", "Linux"):
+        assert platform in guide
+    for verb in ("install", "status", "verify", "uninstall", "upgrade"):
+        assert "dcc-mcp-blender %s" % verb in guide
+    for flag in ("--json", "--yes", "--dry-run", "--dcc-path", "--python"):
+        assert flag in guide
+    for code in ("`0`", "`10`", "`20`", "`30`", "`40`", "`50`"):
+        assert code in guide
+    for term in (
+        "directly_usable",
+        "receipt",
+        "rollback",
+        "capture_bootstrap_errors",
+        "host.ping",
+        "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-blender/main/install.md",
+    ):
+        assert term in guide
+
+
+def test_setup_skill_routes_agents_to_the_standard_lifecycle_first():
+    """The discoverable setup skill must not present the legacy script as canonical."""
+    skill = (ROOT / "skills" / "dcc-mcp-blender-setup" / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "dcc-mcp-blender install --json --dry-run" in skill
+    assert "dcc-mcp-blender verify --json" in skill
+    assert "Legacy compatibility path" in skill
+
+
+def test_install_dry_run_emits_a_complete_non_mutating_plan(tmp_path, monkeypatch, capsys):
+    """The public CLI must plan the exact Blender target without writing it."""
+    from dcc_mcp_blender import install
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    user_scripts = tmp_path / "user-scripts"
+    receipt = tmp_path / "receipts" / "blender.json"
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.setenv("DCC_MCP_BLENDER_USER_SCRIPTS", str(user_scripts))
+    monkeypatch.setenv("DCC_MCP_BLENDER_RECEIPT", str(receipt))
+
+    exit_code = install.main(
+        [
+            "install",
+            "--json",
+            "--dry-run",
+            "--dcc-path",
+            str(blender),
+            "--python",
+            sys.executable,
+        ]
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert report["schema_version"] == 1
+    assert report["status"] == "planned"
+    assert report["dcc_type"] == "blender"
+    assert report["install_state"] == "fresh"
+    assert report["host"]["path"] == str(blender.resolve())
+    assert report["host"]["version"] == "4.2.0"
+    assert report["python"]["path"] == str(Path(sys.executable).resolve())
+    assert [step["id"] for step in report["steps"]] == [
+        "preflight",
+        "stage",
+        "commit",
+        "verify",
+    ]
+    assert "--yes" in report["next_steps"][0]["command"]
+    assert not (user_scripts / "startup" / "dcc_mcp_blender_startup.py").exists()
+    assert not receipt.exists()
+
+
+def test_receipt_round_trip_is_convergent_and_uninstall_is_idempotent(tmp_path, monkeypatch, capsys):
+    """Host enablement remains installed when only live readiness is unavailable."""
+    from dcc_mcp_blender import install
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    user_scripts = tmp_path / "user-scripts"
+    receipt_path = tmp_path / "receipts" / "blender.json"
+    registry = tmp_path / "registry"
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.setenv("DCC_MCP_BLENDER_USER_SCRIPTS", str(user_scripts))
+    monkeypatch.setenv("DCC_MCP_BLENDER_RECEIPT", str(receipt_path))
+    monkeypatch.setenv("DCC_MCP_REGISTRY_DIR", str(registry))
+    common = [
+        "--json",
+        "--dcc-path",
+        str(blender),
+        "--python",
+        sys.executable,
+    ]
+
+    assert install.main(["install", "--yes", *common]) == install.INSTALL_EXIT_VERIFY
+    first = json.loads(capsys.readouterr().out)
+    startup_path = user_scripts / "startup" / install.STARTUP_SCRIPT_NAME
+    assert first["status"] == "partial"
+    assert first["verify"]["directly_usable"] is False
+    assert first["verify"]["failure_stage"] == "readiness"
+    assert startup_path.is_file()
+    assert "capture_bootstrap_errors" in startup_path.read_text(encoding="utf-8")
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["files"][0]["path"] == str(startup_path.resolve())
+    assert receipt["files"][0]["sha256"]
+
+    assert install.main(["install", "--yes", *common]) == install.INSTALL_EXIT_VERIFY
+    second = json.loads(capsys.readouterr().out)
+    assert second["install_state"] == "current"
+    assert not list(user_scripts.rglob("*.backup-*"))
+    assert not list(user_scripts.rglob("*.stage-*"))
+
+    assert install.main(["status", *common]) == install.INSTALL_EXIT_OK
+    assert json.loads(capsys.readouterr().out)["install_state"] == "current"
+
+    assert install.main(["uninstall", "--yes", *common]) == install.INSTALL_EXIT_OK
+    assert json.loads(capsys.readouterr().out)["status"] == "ok"
+    assert not startup_path.exists()
+    assert not receipt_path.exists()
+
+    assert install.main(["uninstall", "--yes", *common]) == install.INSTALL_EXIT_OK
+    assert json.loads(capsys.readouterr().out)["steps"][0]["status"] == "already_absent"
+
+
+def test_upgrade_requires_a_receipt_and_reuses_the_install_transaction(tmp_path, monkeypatch, capsys):
+    """Upgrade is distinct from fresh install but shares its safe commit path."""
+    from dcc_mcp_blender import install
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.setenv("DCC_MCP_BLENDER_USER_SCRIPTS", str(tmp_path / "scripts"))
+    monkeypatch.setenv("DCC_MCP_BLENDER_RECEIPT", str(tmp_path / "receipt.json"))
+    monkeypatch.setenv("DCC_MCP_REGISTRY_DIR", str(tmp_path / "registry"))
+    common = [
+        "--json",
+        "--dcc-path",
+        str(blender),
+        "--python",
+        sys.executable,
+    ]
+
+    assert install.main(["upgrade", "--dry-run", *common]) == install.INSTALL_EXIT_PREFLIGHT
+    assert json.loads(capsys.readouterr().out)["verify"]["failure_reason"] == "receipt_missing"
+
+    assert install.main(["install", "--yes", *common]) == install.INSTALL_EXIT_VERIFY
+    capsys.readouterr()
+
+    assert install.main(["upgrade", "--dry-run", *common]) == install.INSTALL_EXIT_OK
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["status"] == "planned"
+    assert plan["plan_type"] == "upgrade"
+
+    assert install.main(["upgrade", "--yes", *common]) == install.INSTALL_EXIT_VERIFY
+    result = json.loads(capsys.readouterr().out)
+    assert result["command"] == "upgrade"
+    assert result["verify"]["failure_stage"] == "readiness"
+
+
+def test_verify_refuses_interpreter_drift_from_the_receipt(tmp_path, monkeypatch, capsys):
+    """Verification must stay bound to the exact interpreter selected at install time."""
+    from dcc_mcp_blender import install
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    receipt_path = tmp_path / "receipt.json"
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.setenv("DCC_MCP_BLENDER_USER_SCRIPTS", str(tmp_path / "scripts"))
+    monkeypatch.setenv("DCC_MCP_BLENDER_RECEIPT", str(receipt_path))
+    monkeypatch.setenv("DCC_MCP_REGISTRY_DIR", str(tmp_path / "registry"))
+    common = [
+        "--json",
+        "--dcc-path",
+        str(blender),
+        "--python",
+        sys.executable,
+    ]
+
+    assert install.main(["install", "--yes", *common]) == install.INSTALL_EXIT_VERIFY
+    capsys.readouterr()
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["python"]["path"] = str((tmp_path / "old-python").resolve())
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    assert install.main(["verify", *common]) == install.INSTALL_EXIT_PREFLIGHT
+    report = json.loads(capsys.readouterr().out)
+    assert report["verify"]["failure_stage"] == "python"
+    assert report["verify"]["failure_reason"] == "python_mismatch"
+
+
+def test_public_reports_satisfy_the_shared_install_sop_schema(tmp_path, monkeypatch, capsys):
+    """Every lifecycle verb emits the required shared result envelope."""
+    from dcc_mcp_blender import install
+
+    schema = install.load_install_sop_schema()
+    assert schema["$id"] == "https://dcc-mcp.github.io/schemas/adapter-install-sop-v1.schema.json"
+    required = set(schema["required"])
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.setenv("DCC_MCP_BLENDER_USER_SCRIPTS", str(tmp_path / "scripts"))
+    monkeypatch.setenv("DCC_MCP_BLENDER_RECEIPT", str(tmp_path / "receipt.json"))
+    common = [
+        "--json",
+        "--dcc-path",
+        str(blender),
+        "--python",
+        sys.executable,
+    ]
+
+    for verb in install.LIFECYCLE_COMMANDS:
+        arguments = [verb, "--dry-run", *common] if verb != "status" else [verb, *common]
+        install.main(arguments)
+        report = json.loads(capsys.readouterr().out)
+        assert required <= set(report), verb
+        assert report["schema_version"] == install.INSTALL_SOP_SCHEMA_VERSION
+
+
+def test_missing_receipted_startup_is_reported_as_partial(tmp_path, monkeypatch, capsys):
+    """Status must diagnose stale receipts instead of claiming a current install."""
+    from dcc_mcp_blender import install
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    user_scripts = tmp_path / "scripts"
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.setenv("DCC_MCP_BLENDER_USER_SCRIPTS", str(user_scripts))
+    monkeypatch.setenv("DCC_MCP_BLENDER_RECEIPT", str(tmp_path / "receipt.json"))
+    monkeypatch.setenv("DCC_MCP_REGISTRY_DIR", str(tmp_path / "registry"))
+    common = [
+        "--json",
+        "--dcc-path",
+        str(blender),
+        "--python",
+        sys.executable,
+    ]
+
+    assert install.main(["install", "--yes", *common]) == install.INSTALL_EXIT_VERIFY
+    capsys.readouterr()
+    (user_scripts / "startup" / install.STARTUP_SCRIPT_NAME).unlink()
+
+    assert install.main(["status", *common]) == install.INSTALL_EXIT_PREFLIGHT
+    report = json.loads(capsys.readouterr().out)
+    assert report["install_state"] == "partial"
+    assert report["steps"] == [
+        {"id": "receipt", "status": "present"},
+        {"id": "startup", "status": "absent"},
+    ]
+
+
+def test_malformed_receipt_status_is_typed_partial_not_internal_failure(tmp_path, monkeypatch, capsys):
+    """Corrupt ownership metadata remains a repairable, classified preflight state."""
+    from dcc_mcp_blender import install
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    receipt_path = tmp_path / "receipt.json"
+    receipt_path.write_text("[]", encoding="utf-8")
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.setenv("DCC_MCP_BLENDER_USER_SCRIPTS", str(tmp_path / "scripts"))
+    monkeypatch.setenv("DCC_MCP_BLENDER_RECEIPT", str(receipt_path))
+
+    assert (
+        install.main(
+            [
+                "status",
+                "--json",
+                "--dcc-path",
+                str(blender),
+                "--python",
+                sys.executable,
+            ]
+        )
+        == install.INSTALL_EXIT_PREFLIGHT
+    )
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "partial"
+    assert report["install_state"] == "partial"
+    assert report["verify"]["failure_stage"] == "receipt"
+    assert report["verify"]["failure_reason"] == "receipt_invalid"
+
+
+def test_verify_rejects_malformed_receipt_ownership_as_a_typed_failure(tmp_path, monkeypatch, capsys):
+    """Malformed file ownership cannot escape the verify exit-code boundary."""
+    from dcc_mcp_blender import install
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    receipt_path = tmp_path / "receipt.json"
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.setenv("DCC_MCP_BLENDER_USER_SCRIPTS", str(tmp_path / "scripts"))
+    monkeypatch.setenv("DCC_MCP_BLENDER_RECEIPT", str(receipt_path))
+    monkeypatch.setenv("DCC_MCP_REGISTRY_DIR", str(tmp_path / "registry"))
+    common = [
+        "--json",
+        "--dcc-path",
+        str(blender),
+        "--python",
+        sys.executable,
+    ]
+
+    assert install.main(["install", "--yes", *common]) == install.INSTALL_EXIT_VERIFY
+    capsys.readouterr()
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["files"] = [42]
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    assert install.main(["verify", *common]) == install.INSTALL_EXIT_VERIFY
+    report = json.loads(capsys.readouterr().out)
+    assert report["verify"]["failure_stage"] == "receipt"
+    assert report["verify"]["failure_reason"] == "receipt_ownership_invalid"
+
+
+def test_typed_host_ping_is_required_for_direct_usability(tmp_path, monkeypatch, capsys):
+    """A successful typed probe is the only path to directly_usable=true."""
+    from dcc_mcp_blender import install
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.setenv("DCC_MCP_BLENDER_USER_SCRIPTS", str(tmp_path / "scripts"))
+    monkeypatch.setenv("DCC_MCP_BLENDER_RECEIPT", str(tmp_path / "receipt.json"))
+    monkeypatch.setattr(
+        install,
+        "query_runtime_state",
+        lambda *_args, **_kwargs: {"entries": [{"mcp_url": "http://127.0.0.1:49152/mcp"}]},
+    )
+    probes = []
+
+    def probe(url, tool_name, timeout_secs):
+        probes.append((url, tool_name, timeout_secs))
+        return {"success": True, "status": "probe_ok"}
+
+    monkeypatch.setattr(install, "probe_sidecar_tool", probe)
+
+    assert (
+        install.main(
+            [
+                "install",
+                "--yes",
+                "--json",
+                "--dcc-path",
+                str(blender),
+                "--python",
+                sys.executable,
+            ]
+        )
+        == install.INSTALL_EXIT_OK
+    )
+    report = json.loads(capsys.readouterr().out)
+    assert report["verify"]["directly_usable"] is True
+    assert probes == [("http://127.0.0.1:49152/mcp", "host.ping", 2.0)]
+
+
+def test_uninstall_dry_run_describes_receipt_owned_removal(tmp_path, monkeypatch, capsys):
+    """An uninstall plan must describe removal rather than installation stages."""
+    from dcc_mcp_blender import install
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.setenv("DCC_MCP_BLENDER_USER_SCRIPTS", str(tmp_path / "scripts"))
+    monkeypatch.setenv("DCC_MCP_BLENDER_RECEIPT", str(tmp_path / "receipt.json"))
+    common = [
+        "--json",
+        "--dcc-path",
+        str(blender),
+        "--python",
+        sys.executable,
+    ]
+
+    assert install.main(["uninstall", "--dry-run", *common]) == install.INSTALL_EXIT_OK
+    report = json.loads(capsys.readouterr().out)
+    assert [step["id"] for step in report["steps"]] == [
+        "preflight",
+        "receipt",
+        "uninstall",
+    ]
+    assert report["next_steps"][0]["command"][1] == "uninstall"
+    assert "--yes" in report["next_steps"][0]["command"]
+
+
+def test_receipt_commit_failure_rolls_back_the_previous_install(tmp_path, monkeypatch, capsys):
+    """A failed receipt commit must restore both previously owned artifacts."""
+    from dcc_mcp_blender import install
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    startup_path = tmp_path / "scripts" / "startup" / install.STARTUP_SCRIPT_NAME
+    receipt_path = tmp_path / "receipt.json"
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.setenv("DCC_MCP_BLENDER_USER_SCRIPTS", str(tmp_path / "scripts"))
+    monkeypatch.setenv("DCC_MCP_BLENDER_RECEIPT", str(receipt_path))
+    monkeypatch.setenv("DCC_MCP_REGISTRY_DIR", str(tmp_path / "registry"))
+    common = [
+        "--json",
+        "--dcc-path",
+        str(blender),
+        "--python",
+        sys.executable,
+    ]
+
+    assert install.main(["install", "--yes", *common]) == install.INSTALL_EXIT_VERIFY
+    capsys.readouterr()
+    old_startup = startup_path.read_bytes()
+    old_receipt = receipt_path.read_bytes()
+    real_replace = install._replace_path
+
+    def fail_receipt_commit(source, destination):
+        if destination == receipt_path and ".stage-" in source.name:
+            raise OSError("simulated receipt commit failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(install, "_replace_path", fail_receipt_commit)
+
+    assert install.main(["install", "--yes", *common]) == install.INSTALL_EXIT_INSTALL
+    report = json.loads(capsys.readouterr().out)
+    assert report["verify"]["failure_reason"] == "commit_failed"
+    assert startup_path.read_bytes() == old_startup
+    assert receipt_path.read_bytes() == old_receipt
+    assert not list(tmp_path.rglob("*.stage-*"))
+    assert not list(tmp_path.rglob("*.backup-*"))
+
+
+def test_windows_lock_is_a_restart_boundary_not_a_clean_install_failure(tmp_path, monkeypatch, capsys):
+    """Locked owned files produce stable exit 50 and a restart-shaped result."""
+    from dcc_mcp_blender import install
+
+    blender = tmp_path / "blender"
+    blender.write_bytes(b"")
+    monkeypatch.setenv("DCC_MCP_BLENDER_VERSION", "4.2.0")
+    monkeypatch.setenv("DCC_MCP_BLENDER_USER_SCRIPTS", str(tmp_path / "scripts"))
+    monkeypatch.setenv("DCC_MCP_BLENDER_RECEIPT", str(tmp_path / "receipt.json"))
+    common = [
+        "--json",
+        "--dcc-path",
+        str(blender),
+        "--python",
+        sys.executable,
+    ]
+
+    monkeypatch.setattr(install, "_install_transaction", lambda _ctx: (_ for _ in ()).throw(PermissionError("locked")))
+    monkeypatch.setattr(install, "_is_windows_lock", lambda _exc: True)
+
+    assert install.main(["install", "--yes", *common]) == install.INSTALL_EXIT_REQUIRES_RESTART
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "requires_restart"
+    assert report["verify"]["failure_stage"] == "install"
+    assert report["verify"]["failure_reason"] == "windows_file_lock"

--- a/tests/test_startup_install.py
+++ b/tests/test_startup_install.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import builtins
+import contextlib
 import importlib.util
 import pathlib
 import sys
 from types import ModuleType, SimpleNamespace
+
+import pytest
 
 ROOT = pathlib.Path(__file__).parent.parent
 SETUP_SCRIPT = ROOT / "skills" / "dcc-mcp-blender-setup" / "scripts" / "setup_dcc_mcp_blender.py"
@@ -118,3 +121,37 @@ def test_user_install_pairs_pip_user_with_blender_system_environment(monkeypatch
     install_guide = (ROOT / "install.md").read_text(encoding="utf-8")
     assert "-m pip install --user" in install_guide
     assert "blender --python-use-system-env" in install_guide
+
+
+def test_startup_bridge_captures_and_reraises_bootstrap_failures(monkeypatch, tmp_path):
+    """Early startup failures must remain visible both to Core and Blender."""
+    setup = _load_setup_module()
+    blender_python = tmp_path / "Blender 5.2" / "5.2" / "python" / "bin" / "python.exe"
+    blender_python.parent.mkdir(parents=True)
+    blender_python.touch()
+    startup_path = setup.install_startup_script(blender_python, str(tmp_path / "scripts"))
+    startup = _load_startup_module(startup_path, monkeypatch)
+    captured = []
+
+    @contextlib.contextmanager
+    def capture_bootstrap_errors(dcc_name, **kwargs):
+        try:
+            yield
+        except BaseException as exc:
+            captured.append((dcc_name, kwargs, exc))
+            raise
+
+    fake_core = ModuleType("dcc_mcp_core")
+    fake_core.capture_bootstrap_errors = capture_bootstrap_errors
+    fake_package = ModuleType("dcc_mcp_blender")
+    fake_package.get_server = lambda: (_ for _ in ()).throw(RuntimeError("startup exploded"))
+    fake_package.start_server = lambda: None
+    monkeypatch.setitem(sys.modules, "dcc_mcp_core", fake_core)
+    monkeypatch.setitem(sys.modules, "dcc_mcp_blender", fake_package)
+
+    with pytest.raises(RuntimeError, match="startup exploded"):
+        startup.register()
+
+    assert captured[0][0] == "blender"
+    assert captured[0][1]["phase"] == "startup"
+    assert captured[0][2].args == ("startup exploded",)

--- a/tests/test_workflow_ci.py
+++ b/tests/test_workflow_ci.py
@@ -6,6 +6,7 @@ import pathlib
 import re
 
 ROOT = pathlib.Path(__file__).parent.parent
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 E2E_WORKFLOW = ROOT / ".github" / "workflows" / "e2e.yml"
 SCRIPTS_DIR = ROOT / ".github" / "scripts"
 RUN_BLENDER_E2E = SCRIPTS_DIR / "run_blender_e2e.py"
@@ -129,3 +130,11 @@ def test_windows_e2e_targets_vs2026_runner_explicitly():
 
     assert "runner: windows-2025-vs2026" in text
     assert "runner: windows-latest" not in text
+
+
+def test_ci_has_an_explicit_install_lifecycle_round_trip():
+    text = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "lifecycle-smoke:" in text
+    assert "Install lifecycle smoke" in text
+    assert "tests/test_install_lifecycle.py" in text

--- a/tests/test_workflow_ci.py
+++ b/tests/test_workflow_ci.py
@@ -138,3 +138,11 @@ def test_ci_has_an_explicit_install_lifecycle_round_trip():
     assert "lifecycle-smoke:" in text
     assert "Install lifecycle smoke" in text
     assert "tests/test_install_lifecycle.py" in text
+
+
+def test_skill_lint_does_not_depend_on_a_mutable_unused_cli_download():
+    text = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "releases/latest" not in text
+    assert "Install dcc-mcp-cli" not in text
+    assert "python tools/lint_skills.py --warnings-as-errors" in text


### PR DESCRIPTION
## Summary
- add the standard `install|status|verify|uninstall|upgrade` lifecycle with shared-schema JSON, stable exits, version/interpreter preflight, staged receipts, rollback, and receipt-only cleanup
- require an explicitly selected Blender interpreter and protect unknown unreceipted startup files
- make both startup paths capture and re-raise bootstrap failures, then verify usability through typed `host.ping`
- publish the owning install runbook, route the setup skill to the lifecycle first, and add an explicit CI receipt round trip

## Validation
- `python -m pytest tests/ -q --tb=short -m "not e2e and not packaging"` (515 passed, 19 skipped)
- `python -m ruff check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py packaging/addon_entry/__init__.py`
- `python -m ruff format --check src/ tests/ tools/lint_skills.py packaging/assemble_zip.py packaging/addon_entry/__init__.py`
- `python tools/check_py37_syntax.py` (Python 3.7.9; 365 files)
- `python tools/lint_skills.py --warnings-as-errors`
- `python -m build` and `python -m twine check dist/*.whl dist/*.tar.gz`
- addon ZIP assembly for Windows, Linux, and macOS
- Blender 5.2 lifecycle smoke for explicit interpreter selection, dry-run, install/status/verify, and receipt-only uninstall

## Boundaries
- Uses the Core #2320 SOP schema exports when available and ships a compatible schema fallback for the current Core release.
- The Core catalog already targets `https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-blender/main/install.md`.
- No registered live Blender instance was available; typed readiness remained fail-closed, so no full rendering benchmark is claimed.

Refs #189