### PR TITLE
feat: support PNG background render jobs

### DIFF
--- a/src/dcc_mcp_blender/_render_job_ops.py
+++ b/src/dcc_mcp_blender/_render_job_ops.py
@@ -10,17 +10,36 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
 
 _FRAME_TOKEN = re.compile(r"#+")
 _OPENEXR_MAGIC = b"\x76\x2f\x31\x01"
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+_OUTPUT_FORMATS = {
+    "OPEN_EXR_MULTILAYER": (".exr", _OPENEXR_MAGIC),
+    "PNG": (".png", _PNG_MAGIC),
+}
 _JOBS: Dict[str, Dict[str, Any]] = {}
 _LOCK = threading.Lock()
 
 
-def _expected_output_path(output_pattern: str, frame: int) -> Path:
+def _output_format_spec(output_format: str) -> Tuple[str, bytes]:
+    name = str(output_format).strip().upper()
+    try:
+        return _OUTPUT_FORMATS[name]
+    except KeyError as exc:
+        raise ValueError("output_format must be one of: OPEN_EXR_MULTILAYER, PNG") from exc
+
+
+def _expected_output_path(
+    output_pattern: str,
+    frame: int,
+    *,
+    output_format: str = "OPEN_EXR_MULTILAYER",
+) -> Path:
+    suffix, _magic = _output_format_spec(output_format)
     if not Path(output_pattern).is_absolute():
         raise ValueError("output_pattern must be an absolute path")
     matches = list(_FRAME_TOKEN.finditer(output_pattern))
@@ -31,7 +50,7 @@ def _expected_output_path(output_pattern: str, frame: int) -> Path:
     match = matches[0]
     value = output_pattern[: match.start()] + str(frame).zfill(len(match.group())) + output_pattern[match.end() :]
     path = Path(value)
-    return path if path.suffix.lower() == ".exr" else Path(value + ".exr")
+    return path if path.suffix.lower() == suffix else Path(value + suffix)
 
 
 def _select_frames(
@@ -41,24 +60,33 @@ def _select_frames(
     step: int,
     *,
     resume_missing: bool,
+    output_format: str = "OPEN_EXR_MULTILAYER",
 ) -> List[int]:
     if start_frame > end_frame:
         raise ValueError("start_frame must be less than or equal to end_frame")
     if step < 1:
         raise ValueError("step must be at least 1")
     frames = list(range(start_frame, end_frame + 1, step))
-    _expected_output_path(output_pattern, frames[0])
+    _expected_output_path(output_pattern, frames[0], output_format=output_format)
     if not resume_missing:
         return frames
-    return [frame for frame in frames if not _is_valid_output(_expected_output_path(output_pattern, frame))]
+    return [
+        frame
+        for frame in frames
+        if not _is_valid_output(
+            _expected_output_path(output_pattern, frame, output_format=output_format),
+            output_format=output_format,
+        )
+    ]
 
 
-def _is_valid_output(path: Path) -> bool:
+def _is_valid_output(path: Path, *, output_format: str = "OPEN_EXR_MULTILAYER") -> bool:
+    _suffix, magic = _output_format_spec(output_format)
     try:
-        if not path.is_file() or path.stat().st_size < len(_OPENEXR_MAGIC):
+        if not path.is_file() or path.stat().st_size < len(magic):
             return False
         with path.open("rb") as stream:
-            return stream.read(len(_OPENEXR_MAGIC)) == _OPENEXR_MAGIC
+            return stream.read(len(magic)) == magic
     except OSError:
         return False
 
@@ -71,7 +99,10 @@ def _build_blender_command(
     frames: List[int],
     device: str,
     factory_startup: bool,
+    output_format: str = "OPEN_EXR_MULTILAYER",
 ) -> List[str]:
+    format_name = str(output_format).strip().upper()
+    _output_format_spec(format_name)
     command = [blender_path, "--background"]
     if factory_startup:
         command.append("--factory-startup")
@@ -81,7 +112,7 @@ def _build_blender_command(
             "--render-output",
             output_pattern,
             "--render-format",
-            "OPEN_EXR_MULTILAYER",
+            format_name,
             "--use-extension",
             "1",
         ]
@@ -102,8 +133,9 @@ def start_render_job(
     device: str = "OPTIX",
     save_before_render: bool = True,
     factory_startup: bool = False,
+    output_format: str = "OPEN_EXR_MULTILAYER",
 ) -> dict:
-    """Save the current scene and submit an isolated multi-layer EXR render."""
+    """Save the current scene and submit an isolated animation render."""
     try:
         import bpy  # Lazy import: requires Blender's embedded Python.
 
@@ -113,6 +145,7 @@ def start_render_job(
             end_frame,
             step,
             resume_missing=resume_missing,
+            output_format=output_format,
         )
         scene_path = str(getattr(bpy.data, "filepath", ""))
         if not scene_path:
@@ -120,7 +153,7 @@ def start_render_job(
         if save_before_render:
             bpy.ops.wm.save_as_mainfile(filepath=scene_path)
 
-        output_dir = _expected_output_path(output_pattern, start_frame).parent
+        output_dir = _expected_output_path(output_pattern, start_frame, output_format=output_format).parent
         output_dir.mkdir(parents=True, exist_ok=True)
         job_id = uuid.uuid4().hex
         stdout_path = output_dir / (".dcc-mcp-render-{}.out.log".format(job_id))
@@ -134,6 +167,7 @@ def start_render_job(
                 frames=frames,
                 device=device,
                 factory_startup=factory_startup,
+                output_format=output_format,
             )
             env = os.environ.copy()
             env["DCC_MCP_BACKGROUND_RENDER"] = "1"
@@ -151,6 +185,7 @@ def start_render_job(
             "status": "running" if process is not None else "completed",
             "frames": frames,
             "output_pattern": output_pattern,
+            "output_format": str(output_format).strip().upper(),
             "scene_path": scene_path,
             "stdout_path": str(stdout_path),
             "stderr_path": str(stderr_path),
@@ -193,15 +228,35 @@ def cancel_render_job(job_id: str) -> dict:
 
 def _job_context(job: Dict[str, Any]) -> Dict[str, Any]:
     process = job.get("process")
+    output_format = str(job.get("output_format", "OPEN_EXR_MULTILAYER")).strip().upper()
+    _output_format_spec(output_format)
     if job["status"] == "running" and process is not None:
         return_code = process.poll()
         if return_code is not None:
-            expected = [_expected_output_path(job["output_pattern"], frame) for frame in job["frames"]]
+            expected = [
+                _expected_output_path(
+                    job["output_pattern"],
+                    frame,
+                    output_format=output_format,
+                )
+                for frame in job["frames"]
+            ]
             job["status"] = (
-                "completed" if return_code == 0 and all(_is_valid_output(path) for path in expected) else "failed"
+                "completed"
+                if return_code == 0 and all(_is_valid_output(path, output_format=output_format) for path in expected)
+                else "failed"
             )
     written = [
-        frame for frame in job["frames"] if _is_valid_output(_expected_output_path(job["output_pattern"], frame))
+        frame
+        for frame in job["frames"]
+        if _is_valid_output(
+            _expected_output_path(
+                job["output_pattern"],
+                frame,
+                output_format=output_format,
+            ),
+            output_format=output_format,
+        )
     ]
     written_set = set(written)
     missing = [frame for frame in job["frames"] if frame not in written_set]
@@ -215,6 +270,7 @@ def _job_context(job: Dict[str, Any]) -> Dict[str, Any]:
         "progress": 1.0 if expected_count == 0 else len(written) / expected_count,
         "missing_frame_sample": missing[:32],
         "output_pattern": job["output_pattern"],
+        "output_format": output_format,
         "stdout_path": job["stdout_path"],
         "stderr_path": job["stderr_path"],
     }

--- a/src/dcc_mcp_blender/skills/blender-render/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-render/SKILL.md
@@ -36,5 +36,6 @@ metadata:
 # blender-render
 
 Use `render_scene` for short stills. Use `start_render_job` for animation or
-multi-layer EXR output so the interactive Blender process remains responsive;
-poll with `get_render_job` and cancel only through the returned job id.
+multi-layer EXR or display-ready PNG output so the interactive Blender process
+remains responsive; poll with `get_render_job` and cancel only through the
+returned job id.

--- a/src/dcc_mcp_blender/skills/blender-render/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-render/tools.yaml
@@ -102,7 +102,7 @@ tools:
     destructive: false
     idempotent: false
   - name: start_render_job
-    description: "Save the current .blend and start an isolated background animation render to multi-layer OpenEXR; optionally render only missing frames."
+    description: "Save the current .blend and start an isolated background animation render to multi-layer OpenEXR or PNG; optionally render only missing frames."
     source_file: scripts/start_render_job.py
     execution: sync
     affinity: main
@@ -117,7 +117,12 @@ tools:
         output_pattern:
           type: string
           minLength: 1
-          description: "Absolute output pattern containing # placeholders, for example C:/renders/beauty_####. Blender appends .exr."
+          description: "Absolute output pattern containing # placeholders, for example C:/renders/beauty_####. Blender appends the selected format's extension."
+        output_format:
+          type: string
+          enum: [OPEN_EXR_MULTILAYER, PNG]
+          default: OPEN_EXR_MULTILAYER
+          description: "Background render output format. PNG produces display-ready frames; multilayer EXR preserves render passes."
         start_frame:
           type: integer
           minimum: 0
@@ -131,7 +136,7 @@ tools:
         resume_missing:
           type: boolean
           default: true
-          description: "Skip existing non-empty EXR files and render only missing frames."
+          description: "Skip existing files with a valid signature for the selected output format and render only missing frames."
         device:
           type: string
           enum: [OPTIX, CUDA, HIP, ONEAPI, METAL, CPU]

--- a/tests/test_render_jobs.py
+++ b/tests/test_render_jobs.py
@@ -12,6 +12,10 @@ def _write_valid_exr(path):
     path.write_bytes(b"\x76\x2f\x31\x01payload")
 
 
+def _write_valid_png(path):
+    path.write_bytes(b"\x89PNG\r\n\x1a\npayload")
+
+
 def test_build_command_uses_multilayer_exr_and_exact_frames(tmp_path):
     command = jobs._build_blender_command(
         blender_path="blender",
@@ -43,6 +47,23 @@ def test_build_command_uses_multilayer_exr_and_exact_frames(tmp_path):
     assert factory_command[2] == "--factory-startup"
 
 
+def test_build_command_supports_png_animation_output(tmp_path):
+    pattern = str(tmp_path / "beauty_####")
+
+    command = jobs._build_blender_command(
+        blender_path="blender",
+        scene_path=str(tmp_path / "scene.blend"),
+        output_pattern=pattern,
+        output_format="PNG",
+        frames=[2],
+        device="CPU",
+        factory_startup=False,
+    )
+
+    assert command[command.index("--render-format") + 1] == "PNG"
+    assert jobs._expected_output_path(pattern, 2, output_format="PNG") == tmp_path / "beauty_0002.png"
+
+
 def test_select_frames_resumes_only_missing_nonempty_exrs(tmp_path):
     pattern = str(tmp_path / "beauty_####")
     _write_valid_exr(jobs._expected_output_path(pattern, 1))
@@ -50,6 +71,19 @@ def test_select_frames_resumes_only_missing_nonempty_exrs(tmp_path):
 
     assert jobs._select_frames(pattern, 1, 4, 1, resume_missing=True) == [2, 3, 4]
     assert jobs._select_frames(pattern, 1, 4, 2, resume_missing=False) == [1, 3]
+
+
+def test_select_frames_resumes_only_missing_valid_pngs(tmp_path):
+    pattern = str(tmp_path / "beauty_####")
+    _write_valid_png(jobs._expected_output_path(pattern, 1, output_format="PNG"))
+    jobs._expected_output_path(pattern, 3, output_format="PNG").write_bytes(b"not a png")
+
+    assert jobs._select_frames(pattern, 1, 4, 1, resume_missing=True, output_format="PNG") == [2, 3, 4]
+
+
+def test_rejects_unsupported_background_render_format(tmp_path):
+    with pytest.raises(ValueError, match="output_format"):
+        jobs._expected_output_path(str(tmp_path / "beauty_####"), 1, output_format="TIFF")
 
 
 def test_start_get_cancel_background_render_job(monkeypatch, tmp_path):

--- a/tests/test_skills_render.py
+++ b/tests/test_skills_render.py
@@ -20,6 +20,14 @@ def test_render_tools_publish_ci_safe_input_contracts():
     assert render_scene["properties"]["write_still"]["default"] is True
     assert render_scene["additionalProperties"] is False
 
+    render_job = tools["start_render_job"]["input_schema"]
+    assert render_job["properties"]["output_format"] == {
+        "type": "string",
+        "enum": ["OPEN_EXR_MULTILAYER", "PNG"],
+        "default": "OPEN_EXR_MULTILAYER",
+        "description": "Background render output format. PNG produces display-ready frames; multilayer EXR preserves render passes.",
+    }
+
     settings = tools["set_render_settings"]["input_schema"]["properties"]
     assert "CYCLES" in settings["engine"]["enum"]
     assert settings["resolution_percentage"]["maximum"] == 100


### PR DESCRIPTION
## Summary
- add a typed `output_format` for background animation jobs, retaining multilayer EXR as the default and adding PNG
- bind output extensions, resume checks, progress, and completion to the selected format
- publish the format contract while preserving legacy in-memory EXR jobs

## Validation
- render tests: 30 passed
- non-E2E suite: 579 passed, 19 skipped
- Ruff check/format, Skill lint, and Python 3.7 syntax
- package build and Twine checks

## Boundary
No live Blender, gateway, or production scene was used. Real PNG rendering and end-to-end CLI `--wait` behavior remain unverified.

Refs #188