### PR TITLE
fix: preserve skill search limits with semantic recall

### DIFF
--- a/src/dcc_mcp_blender/server.py
+++ b/src/dcc_mcp_blender/server.py
@@ -604,7 +604,8 @@ class BlenderMcpServer(DccServerBase):
         # demote); vector-only hits are appended.
         if self._semantic is not None and query:
             try:
-                return self._semantic.augment(base, query, self.list_skills())
+                # Semantic recall must preserve the public search limit.
+                return self._semantic.augment(base, query, self.list_skills(), limit=limit)
             except Exception as exc:  # noqa: BLE001
                 logger.debug("BlenderMcpServer: semantic augment failed: %s", exc)
         return base

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -386,6 +386,28 @@ class TestProgressiveLoading:
         finally:
             server.stop()
 
+    def test_search_skills_semantic_augmentation_preserves_limit(self):
+        from unittest.mock import MagicMock
+
+        mock_inner = MagicMock()
+        mock_inner.search_skills.return_value = [{"name": "blender-scene"}]
+        mock_inner.list_skills.return_value = [{"name": "blender-scene"}]
+        server = self._make_server_with_mock(mock_inner)
+        semantic = MagicMock()
+        semantic.augment.return_value = [{"name": "blender-scene"}]
+        server._semantic = semantic
+        try:
+            result = server.search_skills(query="render", limit=1)
+            assert result == [{"name": "blender-scene"}]
+            semantic.augment.assert_called_once_with(
+                [{"name": "blender-scene"}],
+                "render",
+                [{"name": "blender-scene"}],
+                limit=1,
+            )
+        finally:
+            server.stop()
+
     def test_find_skills_tags_none_becomes_empty_list(self):
         """tags=None must be coerced to [] so the Rust binding doesn't crash."""
         from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary\n- preserve search_skills(limit=...) when semantic recall augments results\n- add regression coverage for the adapter/core search contract\n\n## Validation\n- PYTHONPATH=src python -m pytest -q tests/test_server.py tests/test_core_integrations.py tests/test_lint_skills.py\n- 79 passed