### PR TITLE
test: add MCP protocol compatibility contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ observe [NASA media usage guidelines](https://www.nasa.gov/nasa-brand-center/ima
 
 `dcc-mcp-blender` turns Blender into a first-class MCP server. Once the addon is enabled, any MCP client (Claude Desktop, custom agents, etc.) can call Blender tools over HTTP without any external gateway.
 
+See [MCP protocol compatibility](docs/protocol-compatibility.md) for the
+adapter-facing negotiation matrix and contract test command.
+
 ```
 ┌─────────────────────────────────┐
 │  Blender (Python 3.10+)         │

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -1,0 +1,38 @@
+# MCP protocol compatibility
+
+`dcc-mcp-blender` delegates MCP HTTP negotiation to `dcc-mcp-core`. The
+adapter's released dependency range is `dcc-mcp-core>=0.20.0,<1.0.0`; the
+adapter must not copy Core's negotiation logic or require a development wheel.
+
+## Compatibility matrix
+
+| Client request | Wire mode | Adapter status | Negotiated version | Contract test |
+| --- | --- | --- | --- | --- |
+| `2025-03-26` | Session (`initialize`) | Supported for legacy clients | `2025-03-26` | `test_initialize_protocol_matrix` |
+| `2025-06-18` | Session (`initialize`) | Supported and preferred | `2025-06-18` | `test_initialize_protocol_matrix` |
+| `2026-07-28` | Stateless (`server/discover`) | Not claimed by this release | `2025-06-18` fallback | `test_initialize_protocol_matrix` |
+| Unknown or omitted | Session (`initialize`) | Supported via Core fallback | `2025-06-18` | `test_initialize_protocol_matrix` |
+
+The 2026 row is intentionally explicit: current dcc-mcp-core `main` contains
+an opt-in stateless implementation, but this adapter release is built and
+tested against released Core wheels with the session default. A future
+adapter release can claim stateless support only after a released Core wheel,
+an add-on packaging smoke, and a live Blender HTTP check cover that path.
+
+## HTTP boundary
+
+- Endpoint: `POST /mcp` (the URL is returned by `BlenderMcpServer.mcp_url`).
+- Requests use JSON-RPC 2.0 with `Content-Type: application/json`.
+- Clients may advertise `Accept: application/json, text/event-stream`.
+- Core owns transport envelopes, session state, and version negotiation.
+- Blender owns `serverInfo.name` (`dcc-mcp-blender`) and the adapter version.
+
+Run the adapter-facing contract checks with:
+
+```text
+python -m pytest tests/test_protocol_compatibility.py
+```
+
+The checks use an OS-assigned loopback port and only the released dependency
+range, so they do not require a Core `main` checkout or unreleased wheel.
+

--- a/tests/test_protocol_compatibility.py
+++ b/tests/test_protocol_compatibility.py
@@ -1,0 +1,79 @@
+"""Adapter-facing MCP protocol compatibility checks.
+
+These tests intentionally exercise the HTTP boundary through the public
+``BlenderMcpServer`` rather than importing dcc-mcp-core implementation
+details. The matrix is the contract this adapter ships against:
+
+* 2025-03-26 remains supported for legacy MCP clients;
+* 2025-06-18 is the current session-based default;
+* newer/unknown protocol versions fail closed to Core's session default.
+
+The 2026 stateless protocol is tracked in ``docs/protocol-compatibility.md``
+but is not claimed by this adapter until a released Core wheel enables it.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+
+import pytest
+
+
+@pytest.fixture()
+def running_server():
+    """Start an isolated adapter HTTP server for one compatibility check."""
+    from dcc_mcp_blender.server import BlenderMcpServer
+
+    server = BlenderMcpServer(port=0, gateway_port=0, enable_gateway_failover=False)
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+def _initialize(server, requested_version=None):
+    params = {
+        "capabilities": {},
+        "clientInfo": {"name": "dcc-mcp-blender-contract-test", "version": "1"},
+    }
+    if requested_version is not None:
+        params["protocolVersion"] = requested_version
+    payload = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": params}).encode("utf-8")
+    request = urllib.request.Request(
+        server.mcp_url,
+        data=payload,
+        headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        assert response.status == 200
+        return json.loads(response.read().decode("utf-8"))
+
+
+@pytest.mark.parametrize(
+    ("requested_version", "negotiated_version"),
+    (
+        ("2025-03-26", "2025-03-26"),
+        ("2025-06-18", "2025-06-18"),
+        ("2026-07-28", "2025-06-18"),
+        ("2099-01-01", "2025-06-18"),
+        (None, "2025-06-18"),
+    ),
+)
+def test_initialize_protocol_matrix(running_server, requested_version, negotiated_version):
+    """The adapter preserves legacy negotiation and Core's default fallback."""
+    response = _initialize(running_server, requested_version)
+
+    assert response["jsonrpc"] == "2.0"
+    assert response["result"]["protocolVersion"] == negotiated_version
+
+
+def test_initialize_identity_is_adapter_owned(running_server):
+    """Core owns the envelope; Blender owns the server identity fields."""
+    result = _initialize(running_server, "2025-06-18")["result"]
+
+    from dcc_mcp_blender.server import SERVER_NAME, SERVER_VERSION
+
+    assert result["serverInfo"] == {"name": SERVER_NAME, "version": SERVER_VERSION}


### PR DESCRIPTION
## Summary\n- document the adapter-facing MCP session protocol matrix\n- add loopback HTTP contract tests for supported and fallback negotiation\n- link the matrix from README without changing the Core dependency floor\n\n## Validation\n- 586 passed, 19 skipped\n- ruff check and format check passed\n\nCore main audit reference: 7074e3f (0.20.22). No unreleased wheel is required.