### PR TITLE
fix: scope simulation cache operations

### DIFF
--- a/src/dcc_mcp_blender/_physics_ops.py
+++ b/src/dcc_mcp_blender/_physics_ops.py
@@ -478,9 +478,14 @@ def list_simulation_modifiers(object_name: Optional[str] = None) -> dict:
 def _target_simulation_modifiers(
     bpy, object_name: Optional[str], modifier_name: Optional[str]
 ) -> Tuple[List[Tuple[Any, Any]], Optional[dict]]:
-    objects, error = _matching_objects(bpy, object_name)
-    if error:
-        return [], error
+    scene_objects = bpy.context.scene.objects
+    if object_name is not None:
+        obj = scene_objects.get(object_name)
+        if obj is None:
+            return [], skill_error("Object not in current scene", "Choose an object in the active scene.")
+        objects = [obj]
+    else:
+        objects = list(scene_objects)
     targets: List[Tuple[Any, Any]] = []
     for obj in objects:
         for modifier in _simulation_modifiers_for_object(obj, modifier_name):
@@ -492,58 +497,28 @@ def _target_simulation_modifiers(
     return targets, None
 
 
-def bake_simulation(
-    object_name: Optional[str] = None,
-    modifier_name: Optional[str] = None,
+def _simulation_cache_operation(
+    operation: str,
+    object_name: Optional[str],
+    modifier_name: Optional[str],
+    dry_run: bool,
     frame_start: Optional[int] = None,
     frame_end: Optional[int] = None,
-    dry_run: bool = False,
 ) -> dict:
-    """Bake simulation caches for matching modifiers."""
-    try:
-        import bpy
-
-        targets, error = _target_simulation_modifiers(bpy, object_name, modifier_name)
-        if error:
-            return error
-        if not targets:
+    """Preflight all targets, then operate only on explicitly scoped point caches."""
+    for label, name in (("object_name", object_name), ("modifier_name", modifier_name)):
+        if name is not None and (not isinstance(name, str) or not name.strip() or len(name) > 256):
             return skill_error(
-                "No simulation modifiers found", "Add cloth, collision, soft-body, fluid, or particle modifiers first."
+                "Invalid simulation target", f"{label} must be a nonempty name of at most 256 characters."
             )
+    if type(dry_run) is not bool:
+        return skill_error("Invalid dry_run", "dry_run must be a boolean.")
+    for value in (frame_start, frame_end):
+        if value is not None and (type(value) is not int or not 1 <= value <= 1048574):
+            return skill_error("Invalid cache frame", "Cache frames must be integers between 1 and 1048574.")
 
-        cache_updates = []
-        for obj, modifier in targets:
-            cache = _modifier_point_cache(modifier)
-            cache_updates.append(
-                {
-                    "object_name": getattr(obj, "name", ""),
-                    "modifier": _modifier_context(modifier),
-                    "applied": _set_cache_frames(cache, frame_start, frame_end),
-                }
-            )
-        _set_scene_frames(bpy.context.scene, frame_start, frame_end)
-        if not dry_run:
-            first_obj = targets[0][0]
-            _activate_object(bpy, first_obj)
-            bpy.ops.ptcache.bake_all(bake=True)
-        return skill_success(
-            "Simulation bake prepared" if dry_run else "Baked simulation caches",
-            dry_run=bool(dry_run),
-            targets=cache_updates,
-            count=len(cache_updates),
-        )
-    except ImportError:
-        return skill_error("Blender not available", "bpy could not be imported")
-    except Exception as exc:
-        return skill_exception(exc, message="Failed to bake simulation")
-
-
-def clear_simulation_cache(
-    object_name: Optional[str] = None,
-    modifier_name: Optional[str] = None,
-    dry_run: bool = False,
-) -> dict:
-    """Clear simulation caches for matching modifiers."""
+    records = []
+    mutation_started = False
     try:
         import bpy
 
@@ -553,27 +528,148 @@ def clear_simulation_cache(
         if not targets:
             return skill_error("No simulation modifiers found", "No matching simulation caches were found.")
 
-        cleared = []
+        entries = []
         for obj, modifier in targets:
-            cleared.append(
-                {
-                    "object_name": getattr(obj, "name", ""),
-                    "modifier": _modifier_context(modifier),
-                }
+            cache = _modifier_point_cache(modifier)
+            if modifier.type not in {"CLOTH", "SOFT_BODY", "PARTICLE_SYSTEM"} or cache is None:
+                return skill_error(
+                    "Unsupported simulation cache",
+                    "Scoped point-cache operations support cloth, soft-body and particle caches only; no global fallback.",
+                    object_name=obj.name,
+                    modifier_name=modifier.name,
+                    modifier_type=modifier.type,
+                    mutation_state="none",
+                )
+            before = _cache_context(cache)
+            start = frame_start if frame_start is not None else before["frame_start"]
+            end = frame_end if frame_end is not None else before["frame_end"]
+            if operation == "bake" and (
+                type(start) is not int or type(end) is not int or not 1 <= start <= end <= 1048574
+            ):
+                return skill_error(
+                    "Invalid cache range",
+                    "Each target needs frame_start <= frame_end within valid cache bounds.",
+                    mutation_state="none",
+                )
+            if operation == "bake" and before["is_baked"]:
+                return skill_error(
+                    "Cache already baked",
+                    "Clear the exact target cache before changing or rebaking it.",
+                    object_name=obj.name,
+                    modifier_name=modifier.name,
+                    mutation_state="none",
+                )
+            planned = {
+                key: value
+                for key, value in (("frame_start", frame_start), ("frame_end", frame_end))
+                if value is not None
+            }
+            record = {
+                "object_name": obj.name,
+                "modifier": _modifier_context(modifier),
+                "before": before,
+                "planned": planned,
+                "applied": {},
+                "status": "planned",
+            }
+            records.append(record)
+            entries.append((obj, cache, record))
+
+        if dry_run:
+            return skill_success(
+                "Simulation cache operation prepared",
+                dry_run=True,
+                targets=records,
+                count=len(records),
+                mutation_state="none",
             )
-        if not dry_run:
-            _activate_object(bpy, targets[0][0])
-            bpy.ops.ptcache.free_bake_all()
+
+        override = getattr(bpy.context, "temp_override", None)
+        operator = getattr(bpy.ops.ptcache, "bake" if operation == "bake" else "free_bake", None)
+        if not callable(override) or not callable(operator) or not callable(getattr(operator, "poll", None)):
+            return skill_error(
+                "Scoped cache context unavailable",
+                "This runtime must support context.temp_override and the per-cache operator; no global fallback.",
+                targets=records,
+                mutation_state="none",
+            )
+
+        # Poll every target before changing any frame range or invoking a bake.
+        for obj, cache, _record in entries:
+            with override(scene=bpy.context.scene, object=obj, active_object=obj, point_cache=cache):
+                if not operator.poll():
+                    return skill_error(
+                        "Scoped cache operator unavailable",
+                        "The per-cache operator cannot run in this target's context.",
+                        object_name=obj.name,
+                        targets=records,
+                        mutation_state="none",
+                    )
+
+        for obj, cache, record in entries:
+            mutation_started = True
+            record["status"] = "attempted"
+            try:
+                planned = record["planned"]
+                # Blender may clamp range assignments; set the upper bound first
+                # when moving the entire range above its previous end.
+                keys = ["frame_start", "frame_end"]
+                if planned.get("frame_start", cache.frame_start) > cache.frame_end:
+                    keys.reverse()
+                for key in keys:
+                    if key in planned:
+                        setattr(cache, key, planned[key])
+                        record["applied"][key] = getattr(cache, key)
+                if record["applied"] != planned:
+                    raise ValueError("The target cache did not retain the requested frame range.")
+                with override(scene=bpy.context.scene, object=obj, active_object=obj, point_cache=cache):
+                    result = operator(bake=True) if operation == "bake" else operator()
+                record["operator_result"] = sorted(result)
+                if result != {"FINISHED"}:
+                    raise ValueError("The scoped cache operator did not finish.")
+                if bool(cache.is_baked) != (operation == "bake"):
+                    raise ValueError("The target cache did not satisfy the baked-state postcondition.")
+                record["status"] = "completed"
+            finally:
+                record["after"] = _cache_context(cache)
         return skill_success(
-            "Simulation cache clear prepared" if dry_run else "Cleared simulation caches",
-            dry_run=bool(dry_run),
-            targets=cleared,
-            count=len(cleared),
+            "Baked simulation caches" if operation == "bake" else "Cleared simulation caches",
+            dry_run=False,
+            targets=records,
+            count=len(records),
+            mutation_state="completed",
         )
     except ImportError:
         return skill_error("Blender not available", "bpy could not be imported")
     except Exception as exc:
-        return skill_exception(exc, message="Failed to clear simulation cache")
+        return skill_exception(
+            exc,
+            message="Simulation cache operation failed",
+            targets=records,
+            completed_count=sum(record["status"] == "completed" for record in records),
+            mutation_state="partial_or_unknown" if mutation_started else "none",
+            prompt="Inspect get_simulation_status for these targets before deciding whether to retry; no global fallback was used.",
+        )
+
+
+def bake_simulation(
+    object_name: Optional[str] = None,
+    modifier_name: Optional[str] = None,
+    frame_start: Optional[int] = None,
+    frame_end: Optional[int] = None,
+    dry_run: bool = False,
+) -> dict:
+    """Bake only matching point caches without changing scene range or selection."""
+    return _simulation_cache_operation("bake", object_name, modifier_name, dry_run, frame_start, frame_end)
+
+
+def clear_simulation_cache(
+    object_name: Optional[str] = None,
+    modifier_name: Optional[str] = None,
+    dry_run: bool = False,
+) -> dict:
+    """Clear only matching point caches; never invoke a scene-wide cache operator."""
+    return _simulation_cache_operation("clear", object_name, modifier_name, dry_run)
 
 
 # ---------------------------------------------------------------------------

--- a/src/dcc_mcp_blender/skills/blender-physics/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-physics/SKILL.md
@@ -33,7 +33,8 @@ metadata:
 
 # blender-physics
 
-Full-coverage physics and dynamics skill for AI-assisted scene assembly.
+Typed physics and dynamics tools for AI-assisted scene assembly. Host-specific
+cache limitations are explicit; this is not a claim of complete API coverage.
 
 ## Capabilities
 
@@ -61,3 +62,21 @@ Full-coverage physics and dynamics skill for AI-assisted scene assembly.
 
 Baking and cache-clearing tools mutate scene state; pass `dry_run=true` when
 you only need target discovery and frame-range validation.
+
+`bake_simulation` and `clear_simulation_cache` operate on matching cloth,
+soft-body, and particle point caches in the current scene only. Use both exact
+object and modifier names to narrow the target. With no names, all supported
+matching caches are selected; any unsupported target aborts preflight before
+mutation. Collision-only, fluid, and dynamic-paint caches require their own
+host-specific workflows and never trigger a global cache fallback.
+
+Dry runs do not change cache ranges, scene frames, selection, or baked state.
+Actual operations require Blender's `context.temp_override` and per-cache
+operator support, retain the scene range and selection, and return before/after
+cache state. Clear an already baked target explicitly before rebaking it.
+Native baking is monolithic: no mid-call cancellation is promised. On failure,
+inspect `targets`, `completed_count`, and `mutation_state` through the response
+and `get_simulation_status` before considering a retry.
+
+The distinction between per-cache and scene-wide operators follows Blender's
+[official point-cache API](https://docs.blender.org/api/5.2/bpy.ops.ptcache.html).

--- a/src/dcc_mcp_blender/skills/blender-physics/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-physics/tools.yaml
@@ -468,7 +468,7 @@ tools:
       open_world_hint: false
 
   - name: bake_simulation
-    description: "Bake simulation caches for matching modifiers."
+    description: "Bake only matching cloth, soft-body or particle point caches in the current scene. Dry run validates without mutation; unsupported cache types fail closed."
     source_file: scripts/bake_simulation.py
     execution: sync
     affinity: main
@@ -480,13 +480,20 @@ tools:
         object_name:
           type: string
           minLength: 1
+          maxLength: 256
+          description: "Exact current-scene object name; omit to inspect all matching objects."
         modifier_name:
           type: string
           minLength: 1
+          maxLength: 256
         frame_start:
           type: integer
+          minimum: 1
+          maximum: 1048574
         frame_end:
           type: integer
+          minimum: 1
+          maximum: 1048574
         dry_run:
           type: boolean
           default: false
@@ -511,7 +518,7 @@ tools:
       open_world_hint: false
 
   - name: clear_simulation_cache
-    description: "Clear simulation caches for matching modifiers."
+    description: "Free only matching cloth, soft-body or particle point caches in the current scene. Never clears unrelated caches; dry run does not mutate."
     source_file: scripts/clear_simulation_cache.py
     execution: sync
     affinity: main
@@ -523,9 +530,12 @@ tools:
         object_name:
           type: string
           minLength: 1
+          maxLength: 256
+          description: "Exact current-scene object name; omit to inspect all matching objects."
         modifier_name:
           type: string
           minLength: 1
+          maxLength: 256
         dry_run:
           type: boolean
           default: false

--- a/tests/e2e/test_simulation_cache_scope_e2e.py
+++ b/tests/e2e/test_simulation_cache_scope_e2e.py
@@ -1,0 +1,97 @@
+"""Tiny, isolated real-host cache scope regressions (two quads, two frames)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dcc_mcp_blender._physics_ops import bake_simulation, clear_simulation_cache
+
+bpy = pytest.importorskip("bpy")
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.fixture
+def cloth_pair():
+    objects = []
+    meshes = []
+    for index in range(2):
+        mesh = bpy.data.meshes.new("ScopeTestMesh")
+        mesh.from_pydata([(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)], [], [(0, 1, 2, 3)])
+        obj = bpy.data.objects.new("ScopeTestCloth", mesh)
+        bpy.context.scene.collection.objects.link(obj)
+        obj.location.x = index * 3
+        modifier = obj.modifiers.new("ScopeTestCloth", "CLOTH")
+        modifier.settings.quality = 1
+        modifier.point_cache.frame_start = 1
+        modifier.point_cache.frame_end = 2
+        objects.append(obj)
+        meshes.append(mesh)
+    bpy.context.view_layer.objects.active = objects[1]
+    try:
+        yield objects
+    finally:
+        for obj in objects:
+            bpy.data.objects.remove(obj, do_unlink=True)
+        for mesh in meshes:
+            bpy.data.meshes.remove(mesh)
+
+
+def _state(objects):
+    return {
+        "scene_range": (bpy.context.scene.frame_start, bpy.context.scene.frame_end),
+        "frame": bpy.context.scene.frame_current,
+        "active": bpy.context.view_layer.objects.active.name,
+        "selected": sorted(obj.name for obj in bpy.context.selected_objects),
+        "caches": [
+            (
+                obj.modifiers[0].point_cache.frame_start,
+                obj.modifiers[0].point_cache.frame_end,
+                obj.modifiers[0].point_cache.is_baked,
+            )
+            for obj in objects
+        ],
+    }
+
+
+def test_dry_run_does_not_change_host_state(cloth_pair):
+    before = _state(cloth_pair)
+    first = cloth_pair[0]
+    result = bake_simulation(first.name, first.modifiers[0].name, frame_start=5, frame_end=6, dry_run=True)
+    assert result["success"] is True, result
+    assert _state(cloth_pair) == before
+    result = clear_simulation_cache(first.name, first.modifiers[0].name, dry_run=True)
+    assert result["success"] is True, result
+    assert _state(cloth_pair) == before
+
+
+def test_bake_and_free_preserve_unrelated_cache(cloth_pair):
+    first, second = cloth_pair
+    before = _state(cloth_pair)
+    result = bake_simulation(first.name, first.modifiers[0].name, frame_start=1, frame_end=2)
+    assert result["success"] is True, result
+    assert first.modifiers[0].point_cache.is_baked
+    assert not second.modifiers[0].point_cache.is_baked
+    after = _state(cloth_pair)
+    assert {key: value for key, value in after.items() if key != "caches"} == {
+        key: value for key, value in before.items() if key != "caches"
+    }
+    result = bake_simulation(second.name, second.modifiers[0].name, frame_start=1, frame_end=2)
+    assert result["success"] is True, result
+    assert second.modifiers[0].point_cache.is_baked
+    result = clear_simulation_cache(first.name, first.modifiers[0].name)
+    assert result["success"] is True, result
+    assert not first.modifiers[0].point_cache.is_baked
+    assert second.modifiers[0].point_cache.is_baked
+    assert result["context"]["targets"][0]["after"]["is_baked"] is False
+
+
+def test_unsupported_cache_fails_without_mutating_supported_target(cloth_pair):
+    first, second = cloth_pair
+    second.modifiers.new("ScopeTestCollision", "COLLISION")
+    before = _state(cloth_pair)
+    result = bake_simulation(second.name, frame_start=5, frame_end=6)
+    assert result["success"] is False
+    assert result["context"]["mutation_state"] == "none"
+    assert _state(cloth_pair) == before
+    assert not first.modifiers[0].point_cache.is_baked

--- a/tests/test_simulation_cache_scope.py
+++ b/tests/test_simulation_cache_scope.py
@@ -1,0 +1,263 @@
+"""Scoped physics-cache operations must not touch unrelated objects or dry runs."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from tests.conftest import load_and_call
+
+
+class Objects(list):
+    def get(self, name):
+        return next((item for item in self if item.name == name), None)
+
+
+def host():
+    objects = Objects()
+    for name in ("Target", "Unrelated"):
+        cache = SimpleNamespace(frame_start=1, frame_end=250, is_baked=False, use_disk_cache=False)
+        modifier = SimpleNamespace(name="Cloth", type="CLOTH", point_cache=cache)
+        obj = SimpleNamespace(name=name, modifiers=Objects([modifier]), select_set=Mock())
+        objects.append(obj)
+    scene = SimpleNamespace(frame_start=1, frame_end=250, frame_current=7, objects=objects)
+    current = {}
+
+    @contextmanager
+    def override(**kwargs):
+        assert "point_cache" in kwargs
+        assert kwargs["object"] is kwargs["active_object"]
+        current.update(kwargs)
+        try:
+            yield
+        finally:
+            current.clear()
+
+    def bake(**kwargs):
+        assert kwargs == {"bake": True}
+        current["point_cache"].is_baked = True
+        return {"FINISHED"}
+
+    def clear():
+        current["point_cache"].is_baked = False
+        return {"FINISHED"}
+
+    bake_op = Mock(side_effect=bake)
+    bake_op.poll.return_value = True
+    clear_op = Mock(side_effect=clear)
+    clear_op.poll.return_value = True
+
+    def global_bake(**kwargs):
+        for obj in objects:
+            obj.modifiers[0].point_cache.is_baked = True
+        return {"FINISHED"}
+
+    def global_clear():
+        for obj in objects:
+            obj.modifiers[0].point_cache.is_baked = False
+        return {"FINISHED"}
+
+    return SimpleNamespace(
+        data=SimpleNamespace(objects=objects),
+        context=SimpleNamespace(
+            scene=scene,
+            temp_override=Mock(side_effect=override),
+            view_layer=SimpleNamespace(objects=SimpleNamespace(active=objects[1])),
+        ),
+        ops=SimpleNamespace(
+            object=SimpleNamespace(select_all=Mock()),
+            ptcache=SimpleNamespace(
+                bake=bake_op,
+                free_bake=clear_op,
+                bake_all=Mock(side_effect=global_bake),
+                free_bake_all=Mock(side_effect=global_clear),
+            ),
+        ),
+    )
+
+
+def call(tool, bpy, **kwargs):
+    return load_and_call("blender-physics/scripts/{}.py".format(tool), bpy, **kwargs)
+
+
+def cache(bpy, name="Target"):
+    return bpy.data.objects.get(name).modifiers[0].point_cache
+
+
+def test_bake_dry_run_leaves_cache_and_scene_frames_untouched():
+    bpy = host()
+    before = vars(cache(bpy)).copy(), vars(cache(bpy, "Unrelated")).copy(), vars(bpy.context.scene).copy()
+    result = call(
+        "bake_simulation", bpy, object_name="Target", modifier_name="Cloth", frame_start=5, frame_end=10, dry_run=True
+    )
+    assert result["success"] is True
+    assert (vars(cache(bpy)), vars(cache(bpy, "Unrelated")), vars(bpy.context.scene)) == before
+    assert result["context"]["targets"][0]["planned"] == {"frame_start": 5, "frame_end": 10}
+    bpy.ops.ptcache.bake.assert_not_called()
+    bpy.ops.ptcache.bake_all.assert_not_called()
+    bpy.context.temp_override.assert_not_called()
+
+
+def test_bake_only_updates_requested_cache_and_preserves_scene_range():
+    bpy = host()
+    result = call("bake_simulation", bpy, object_name="Target", modifier_name="Cloth", frame_start=1, frame_end=2)
+    assert result["success"] is True, result
+    assert cache(bpy).is_baked is True
+    assert cache(bpy).frame_end == 2
+    assert vars(cache(bpy, "Unrelated")) == dict(frame_start=1, frame_end=250, is_baked=False, use_disk_cache=False)
+    assert (bpy.context.scene.frame_start, bpy.context.scene.frame_end, bpy.context.scene.frame_current) == (1, 250, 7)
+    bpy.ops.ptcache.bake.assert_called_once_with(bake=True)
+    bpy.ops.ptcache.bake_all.assert_not_called()
+    assert result["context"]["targets"][0]["after"]["is_baked"] is True
+
+
+def test_clear_only_frees_requested_cache():
+    bpy = host()
+    cache(bpy).is_baked = cache(bpy, "Unrelated").is_baked = True
+    result = call("clear_simulation_cache", bpy, object_name="Target", modifier_name="Cloth")
+    assert result["success"] is True, result
+    assert cache(bpy).is_baked is False
+    assert cache(bpy, "Unrelated").is_baked is True
+    bpy.ops.ptcache.free_bake.assert_called_once_with()
+    bpy.ops.ptcache.free_bake_all.assert_not_called()
+
+
+def test_clear_dry_run_does_not_change_bake_state():
+    bpy = host()
+    cache(bpy).is_baked = True
+    result = call("clear_simulation_cache", bpy, object_name="Target", dry_run=True)
+    assert result["success"] is True
+    assert cache(bpy).is_baked is True
+    bpy.ops.ptcache.free_bake.assert_not_called()
+    bpy.ops.ptcache.free_bake_all.assert_not_called()
+    bpy.context.temp_override.assert_not_called()
+
+
+@pytest.mark.parametrize("tool", ["bake_simulation", "clear_simulation_cache"])
+def test_unsupported_cache_preflight_stops_all_targets_before_mutation(tool):
+    bpy = host()
+    bpy.data.objects.get("Unrelated").modifiers[0].type = "FLUID"
+    result = call(tool, bpy)
+    assert result["success"] is False
+    assert cache(bpy).is_baked is False
+    bpy.ops.ptcache.bake.assert_not_called()
+    bpy.ops.ptcache.free_bake.assert_not_called()
+    bpy.ops.ptcache.bake_all.assert_not_called()
+    bpy.ops.ptcache.free_bake_all.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"frame_start": 10, "frame_end": 2},
+        {"frame_start": True},
+        {"frame_end": 0},
+        {"frame_end": 1048575},
+        {"dry_run": "false"},
+        {"object_name": ""},
+        {"modifier_name": ""},
+    ],
+)
+def test_invalid_requests_fail_before_mutation(kwargs):
+    bpy = host()
+    result = call("bake_simulation", bpy, **kwargs)
+    assert result["success"] is False
+    assert cache(bpy).frame_end == 250
+    bpy.ops.ptcache.bake.assert_not_called()
+    bpy.ops.ptcache.bake_all.assert_not_called()
+
+
+def test_missing_scoped_context_support_fails_closed():
+    bpy = host()
+    bpy.context.temp_override = None
+    result = call("bake_simulation", bpy, object_name="Target", frame_end=2)
+    assert result["success"] is False
+    assert cache(bpy).frame_end == 250
+    bpy.ops.ptcache.bake_all.assert_not_called()
+
+
+def test_operator_cancelled_or_unverified_does_not_report_success():
+    for returned in ({"CANCELLED"}, {"FINISHED"}):
+        bpy = host()
+        bpy.ops.ptcache.bake.side_effect = None
+        bpy.ops.ptcache.bake.return_value = returned
+        result = call("bake_simulation", bpy, object_name="Target", frame_end=2)
+        assert result["success"] is False
+        assert result["context"]["targets"][0]["after"]["is_baked"] is False
+        bpy.ops.ptcache.bake_all.assert_not_called()
+
+
+def test_second_target_poll_failure_does_not_modify_first():
+    bpy = host()
+    bpy.ops.ptcache.bake.poll.side_effect = [True, False]
+    result = call("bake_simulation", bpy, frame_end=2)
+    assert result["success"] is False
+    assert cache(bpy).frame_end == 250
+    bpy.ops.ptcache.bake.assert_not_called()
+
+
+def test_scene_wide_selection_excludes_objects_in_other_scenes():
+    bpy = host()
+    bpy.context.scene.objects = Objects([bpy.data.objects.get("Target")])
+    result = call("bake_simulation", bpy, frame_end=2)
+    assert result["success"] is True, result
+    assert result["context"]["count"] == 1
+    assert cache(bpy, "Unrelated").is_baked is False
+    assert call("bake_simulation", bpy, object_name="Unrelated")["success"] is False
+
+
+def test_modifier_name_also_limits_scope_within_one_object():
+    bpy = host()
+    extra = SimpleNamespace(
+        name="OtherCloth",
+        type="CLOTH",
+        point_cache=SimpleNamespace(frame_start=1, frame_end=250, is_baked=False, use_disk_cache=False),
+    )
+    bpy.data.objects.get("Target").modifiers.append(extra)
+    result = call("bake_simulation", bpy, object_name="Target", modifier_name="Cloth", frame_end=2)
+    assert result["success"] is True
+    assert extra.point_cache.is_baked is False
+    assert extra.point_cache.frame_end == 250
+
+
+def test_partial_failure_reports_completed_target_without_retrying():
+    bpy = host()
+    real_bake = bpy.ops.ptcache.bake.side_effect
+    calls = []
+
+    def fails_second(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 2:
+            raise RuntimeError("Native bake failed")
+        return real_bake(**kwargs)
+
+    bpy.ops.ptcache.bake.side_effect = fails_second
+    result = call("bake_simulation", bpy, frame_end=2)
+    assert result["success"] is False
+    assert result["context"]["completed_count"] == 1
+    assert result["context"]["mutation_state"] == "partial_or_unknown"
+    assert result["context"]["targets"][0]["status"] == "completed"
+    assert result["context"]["targets"][1]["after"]["is_baked"] is False
+    assert len(calls) == 2
+
+
+def test_baked_cache_requires_explicit_clear_before_frame_changes():
+    bpy = host()
+    cache(bpy).is_baked = True
+    result = call("bake_simulation", bpy, object_name="Target", frame_end=2)
+    assert result["success"] is False
+    assert cache(bpy).frame_end == 250
+    bpy.ops.ptcache.bake.assert_not_called()
+
+
+def test_clear_finished_without_clearing_baked_flag_is_failure():
+    bpy = host()
+    cache(bpy).is_baked = True
+    bpy.ops.ptcache.free_bake.side_effect = None
+    bpy.ops.ptcache.free_bake.return_value = {"FINISHED"}
+    result = call("clear_simulation_cache", bpy, object_name="Target")
+    assert result["success"] is False
+    assert result["context"]["targets"][0]["after"]["is_baked"] is True

--- a/tests/test_skills_physics.py
+++ b/tests/test_skills_physics.py
@@ -77,6 +77,7 @@ class _ModifierCollection(list):
 def _bpy_with_objects(*objects):
     bpy = make_mock_bpy()
     bpy.data.objects = _ObjectCollection(objects)
+    bpy.context.scene.objects = bpy.data.objects
     return bpy
 
 


### PR DESCRIPTION
Scope point-cache bake/free to matching current-scene modifiers. Validate all targets before mutation, preserve dry-run state, and report cache readback and partial failures without global fallback.

Validation: 57 targeted unit tests; 3 isolated Blender 5.2 two-object tests; skill validation and Ruff passed.

Independent protocol regression remains tracked in dcc-mcp/dcc-mcp-core#2432.