### PR TITLE
fix: validate material node trees and image resources

### DIFF
--- a/src/dcc_mcp_blender/_asset_pipeline_ops.py
+++ b/src/dcc_mcp_blender/_asset_pipeline_ops.py
@@ -10,6 +10,8 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
 
+from ._material_validation import material_image_issues
+
 ASSET_METADATA_KEY = "dcc_mcp_asset_metadata"
 PROJECT_CONTEXT_KEY = "dcc_mcp_project_context"
 SUPPORTED_EXPORT_FORMATS = {"fbx", "obj", "gltf", "glb", "usd", "usda", "usdc", "abc", "blend"}
@@ -132,11 +134,11 @@ def _material_slots(obj: Any) -> List[Any]:
 
 
 def _object_materials(obj: Any) -> List[Any]:
+    slots = _material_slots(obj)
+    if slots:
+        return [getattr(slot, "material", None) for slot in slots]
     data = getattr(obj, "data", None)
-    materials = list(_iter_or_empty(getattr(data, "materials", [])))
-    if materials:
-        return materials
-    return [getattr(slot, "material", None) for slot in _material_slots(obj)]
+    return list(_iter_or_empty(getattr(data, "materials", [])))
 
 
 def _custom_get(target: Any, key: str, default: Any = None) -> Any:
@@ -291,7 +293,17 @@ def validate_mesh(object_name: str, rules: Optional[Dict[str, Any]] = None) -> d
 
 
 def validate_materials(object_names: Optional[List[str]] = None, rules: Optional[Dict[str, Any]] = None) -> dict:
-    """Validate material assignments for scene objects."""
+    """Validate slots, required node trees, and connected image file presence.
+
+    ``require_nodes`` rejects disabled or empty node trees. Image checks cover
+    linked, unmuted nodes within material graphs, not final-output reachability,
+    image decoding, or render fidelity. They never load, reload, or write images.
+    Generated/viewer and packed FILE images need no external path. UDIM checks
+    use declared tiles only; packed tile coverage, sequence/movie sources, and
+    graph/file budget limits produce explicit unverified warnings. ``passed``
+    means no errors, while ``context.resource_checks_complete`` distinguishes
+    incomplete resource inspection from a fully checked report.
+    """
     try:
         import bpy
 
@@ -317,14 +329,36 @@ def validate_materials(object_names: Optional[List[str]] = None, rules: Optional
                     issues.append(
                         _issue(
                             "MATERIAL_NODES_DISABLED",
-                            "warning",
+                            "error",
                             f"Material {getattr(material, 'name', '<unnamed>')} does not use nodes.",
                             name,
                         )
                     )
+                elif rules.get("require_nodes") and not _len_or_zero(
+                    getattr(getattr(material, "node_tree", None), "nodes", None)
+                ):
+                    issues.append(
+                        _issue(
+                            "MATERIAL_NODE_TREE_EMPTY",
+                            "error",
+                            f"Material {getattr(material, 'name', '<unnamed>')} has no shader nodes.",
+                            name,
+                            {"material": getattr(material, "name", ""), "slot": index},
+                        )
+                    )
+                for finding in material_image_issues(bpy, material):
+                    issues.append(dict(finding, object_name=name))
         if not issues:
             issues.append(_issue("MATERIALS_VALID", "info", "Material validation passed."))
-        report = _make_report("materials", issues, [_object_name(obj) for obj in objects], {"rules": rules})
+        report = _make_report(
+            "materials",
+            issues,
+            [_object_name(obj) for obj in objects],
+            {
+                "rules": rules,
+                "resource_checks_complete": not any(issue["code"].endswith("UNVERIFIED") for issue in issues),
+            },
+        )
         return skill_success("Material validation completed", report=report)
     except ImportError:
         return skill_error("Blender not available", "bpy could not be imported")

--- a/src/dcc_mcp_blender/_asset_pipeline_ops.py
+++ b/src/dcc_mcp_blender/_asset_pipeline_ops.py
@@ -296,7 +296,8 @@ def validate_materials(object_names: Optional[List[str]] = None, rules: Optional
     """Validate slots, required node trees, and connected image file presence.
 
     ``require_nodes`` rejects disabled or empty node trees. Image checks cover
-    linked, unmuted nodes within material graphs, not final-output reachability,
+    linked, unmuted image and environment textures in enabled material graphs,
+    not dormant node trees or final-output reachability,
     image decoding, or render fidelity. They never load, reload, or write images.
     Generated/viewer and packed FILE images need no external path. UDIM checks
     use declared tiles only; packed tile coverage, sequence/movie sources, and
@@ -325,7 +326,7 @@ def validate_materials(object_names: Optional[List[str]] = None, rules: Optional
                         )
                     )
                     continue
-                if rules.get("require_nodes") and not bool(getattr(material, "use_nodes", False)):
+                if rules.get("require_nodes") and not bool(getattr(material, "use_nodes", True)):
                     issues.append(
                         _issue(
                             "MATERIAL_NODES_DISABLED",

--- a/src/dcc_mcp_blender/_material_validation.py
+++ b/src/dcc_mcp_blender/_material_validation.py
@@ -33,7 +33,7 @@ def _connected_images(material):
                 return images, True
             if getattr(node, "mute", False) or not any(output.is_linked for output in node.outputs):
                 continue
-            if node.type == "TEX_IMAGE":
+            if node.type in {"TEX_IMAGE", "TEX_ENVIRONMENT"}:
                 images.append(node)
             elif node.type == "GROUP":
                 stack.append((node.node_tree, depth + 1))
@@ -55,9 +55,10 @@ def _image_issue(material, node, image, code, message, tile=None):
 
 
 def material_image_issues(bpy, material):
-    """Return resource findings for image nodes connected within a material."""
+    """Return resource findings for image nodes in an enabled material graph."""
     tree = getattr(material, "node_tree", None)
-    if tree is None:
+    # Hosts without the legacy toggle always use material node trees.
+    if tree is None or not bool(getattr(material, "use_nodes", True)):
         return []
     issues = []
     nodes, incomplete = _connected_images(material)

--- a/src/dcc_mcp_blender/_material_validation.py
+++ b/src/dcc_mcp_blender/_material_validation.py
@@ -1,0 +1,136 @@
+"""Read-only validation of material resources without loading artist images."""
+
+from pathlib import Path
+
+_MAX_GRAPH_NODES = 4096
+_MAX_GROUP_DEPTH = 16
+_MAX_IMAGE_FILES = 1024
+
+
+def _connected_images(material):
+    """Inspect shared node groups once, with a fixed graph work budget."""
+    stack = [(material.node_tree, 0)]
+    seen = set()
+    images = []
+    count = 0
+    incomplete = False
+    while stack:
+        tree, depth = stack.pop()
+        if tree is None:
+            incomplete = True
+            continue
+        pointer = getattr(tree, "as_pointer", None)
+        identity = pointer() if callable(pointer) else id(tree)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        if depth > _MAX_GROUP_DEPTH:
+            incomplete = True
+            continue
+        for node in tree.nodes:
+            count += 1
+            if count > _MAX_GRAPH_NODES:
+                return images, True
+            if getattr(node, "mute", False) or not any(output.is_linked for output in node.outputs):
+                continue
+            if node.type == "TEX_IMAGE":
+                images.append(node)
+            elif node.type == "GROUP":
+                stack.append((node.node_tree, depth + 1))
+    return images, incomplete
+
+
+def _image_issue(material, node, image, code, message, tile=None):
+    return {
+        "code": code,
+        "severity": "warning" if code.endswith("UNVERIFIED") else "error",
+        "message": message,
+        "details": {
+            "material": material.name,
+            "node": node.name,
+            "image": image.name if image else None,
+            "tile": tile,
+        },
+    }
+
+
+def material_image_issues(bpy, material):
+    """Return resource findings for image nodes connected within a material."""
+    tree = getattr(material, "node_tree", None)
+    if tree is None:
+        return []
+    issues = []
+    nodes, incomplete = _connected_images(material)
+    if incomplete:
+        issues.append(
+            {
+                "code": "MATERIAL_GRAPH_UNVERIFIED",
+                "severity": "warning",
+                "message": "Connected node groups could not be fully inspected within the graph budget.",
+                "details": {"material": material.name},
+            }
+        )
+    files_checked = 0
+    for node in nodes:
+        image = node.image
+        packed = image is not None and (
+            getattr(image, "packed_file", None) is not None or bool(getattr(image, "packed_files", ()))
+        )
+        if image is not None and image.source == "TILED" and packed:
+            issues.append(
+                _image_issue(
+                    material,
+                    node,
+                    image,
+                    "MATERIAL_IMAGE_UNVERIFIED",
+                    "Packed UDIM coverage is not verified per declared tile.",
+                )
+            )
+            continue
+        if image is not None and (image.source in {"GENERATED", "VIEWER"} or image.source == "FILE" and packed):
+            continue
+        if image is not None and (
+            image.source not in {"FILE", "TILED"}
+            or image.source == "TILED"
+            and ("<UDIM>" not in image.filepath or not image.tiles)
+        ):
+            issues.append(
+                _image_issue(
+                    material,
+                    node,
+                    image,
+                    "MATERIAL_IMAGE_UNVERIFIED",
+                    "Image source requires sequence/media validation or a declared UDIM tile template.",
+                )
+            )
+            continue
+        required_files = len(image.tiles) if image is not None and image.source == "TILED" else 1
+        if files_checked + required_files > _MAX_IMAGE_FILES:
+            issues.append(
+                _image_issue(
+                    material,
+                    node,
+                    image,
+                    "MATERIAL_IMAGE_UNVERIFIED",
+                    "Material image file-check budget exceeded.",
+                )
+            )
+            return issues
+        path = bpy.path.abspath(image.filepath, library=getattr(image, "library", None)) if image else ""
+        paths = [(path, None)]
+        if image is not None and image.source == "TILED":
+            paths = [(path.replace("<UDIM>", str(tile.number)), tile.number) for tile in image.tiles]
+        for candidate, tile in paths:
+            files_checked += 1
+            if not candidate or not Path(candidate).is_file():
+                issues.append(
+                    _image_issue(
+                        material,
+                        node,
+                        image,
+                        "MATERIAL_IMAGE_MISSING",
+                        f"Connected image is missing for material {material.name}.",
+                        tile,
+                    )
+                )
+    return issues

--- a/src/dcc_mcp_blender/skills/blender-validation/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-validation/tools.yaml
@@ -75,7 +75,7 @@ tools:
       open_world_hint: false
 
   - name: validate_materials
-    description: "Validate material assignments and optional material rules."
+    description: "Validate material slots, required node trees, and linked image file presence without loading images. Check report.context.resource_checks_complete for incomplete sequence, packed UDIM, or bounded graph inspection; this is not image decoding or render validation."
     source_file: scripts/validate_materials.py
     execution: sync
     affinity: main
@@ -91,6 +91,15 @@ tools:
         rules:
           type: object
           additionalProperties: true
+          properties:
+            require_materials:
+              type: boolean
+              default: true
+              description: "Report mesh objects without material assignments."
+            require_nodes:
+              type: boolean
+              default: false
+              description: "Reject disabled or empty material node trees. Linked image resources are checked independently; unlinked and muted nodes are ignored."
     output_schema:
       type: object
       additionalProperties: true

--- a/tests/e2e/test_asset_pipeline_e2e.py
+++ b/tests/e2e/test_asset_pipeline_e2e.py
@@ -104,6 +104,55 @@ class TestMaterialValidationE2E:
             assert "MATERIAL_IMAGE_MISSING" in {issue["code"] for issue in report["issues"]}
             assert (image.filepath, image.has_data, image.is_dirty) == before
 
+    @pytest.mark.parametrize("missing_datablock", [True, False])
+    def test_missing_environment_image_fails_without_loading_it(self, tmp_path, missing_datablock):
+        image = None
+        if not missing_datablock:
+            image = bpy.data.images.new("MissingEnvironment", width=1, height=1)
+            image.source = "FILE"
+            image.filepath = str(tmp_path / "missing.exr")
+        texture = self.material.node_tree.nodes.new("ShaderNodeTexEnvironment")
+        texture.image = image
+        shader = self.material.node_tree.nodes.get("Principled BSDF")
+        self.material.node_tree.links.new(texture.outputs["Color"], shader.inputs["Base Color"])
+        assert texture.type == "TEX_ENVIRONMENT"
+        before = (image.filepath, image.has_data, image.is_dirty) if image else None
+
+        report = self._report()
+
+        assert report["passed"] is False
+        assert "MATERIAL_IMAGE_MISSING" in {issue["code"] for issue in report["issues"]}
+        assert texture.image == image
+        if image:
+            assert (image.filepath, image.has_data, image.is_dirty) == before
+
+    @pytest.mark.parametrize("require_nodes", [False, True])
+    def test_image_checks_follow_native_material_node_state(self, require_nodes):
+        texture = self._texture(None)
+        tree = self.material.node_tree
+        # New Blender versions may retain a no-op use_nodes setter or remove it.
+        if hasattr(self.material, "use_nodes"):
+            self.material.use_nodes = False
+        nodes_enabled = bool(getattr(self.material, "use_nodes", True))
+        assert self.material.node_tree == tree
+        assert texture.outputs["Color"].is_linked
+
+        result = self.validate(object_names=[self.obj.name], rules={"require_nodes": require_nodes})
+
+        assert result["success"] is True
+        report = result["context"]["report"]
+        codes = {issue["code"] for issue in report["issues"]}
+        if nodes_enabled:
+            # Do not claim disabled-tree coverage if the native API cannot disable it.
+            assert report["passed"] is False
+            assert codes == {"MATERIAL_IMAGE_MISSING"}
+        else:
+            assert report["passed"] is (not require_nodes)
+            assert codes == ({"MATERIAL_NODES_DISABLED"} if require_nodes else {"MATERIALS_VALID"})
+        assert bool(getattr(self.material, "use_nodes", True)) is nodes_enabled
+        assert self.material.node_tree == tree
+        assert texture.image is None
+
     @pytest.mark.parametrize("packed", [False, True])
     def test_generated_and_packed_images_need_no_external_file(self, packed):
         image = bpy.data.images.new("InternalFixture", width=1, height=1)

--- a/tests/e2e/test_asset_pipeline_e2e.py
+++ b/tests/e2e/test_asset_pipeline_e2e.py
@@ -47,3 +47,133 @@ class TestAssetPipelineE2E:
             assert manifest_result["success"] is True
             payload = json.loads(manifest_path.read_text(encoding="utf-8"))
             assert payload["assets"][0]["metadata"]["asset_type"] == "prop"
+
+
+class TestMaterialValidationE2E:
+    def setup_method(self):
+        _new_scene()
+        bpy.ops.mesh.primitive_cube_add()
+        self.obj = bpy.context.active_object
+        self.material = bpy.data.materials.new("ValidationFixture")
+        self.material.use_nodes = True
+        self.obj.data.materials.append(self.material)
+        self.validate = load_skill("blender-validation", "validate_materials").validate_materials
+
+    def _report(self):
+        result = self.validate(object_names=[self.obj.name], rules={"require_nodes": True})
+        assert result["success"] is True
+        return result["context"]["report"]
+
+    def _texture(self, image, linked=True):
+        texture = self.material.node_tree.nodes.new("ShaderNodeTexImage")
+        texture.image = image
+        if linked:
+            shader = self.material.node_tree.nodes.get("Principled BSDF")
+            self.material.node_tree.links.new(texture.outputs["Color"], shader.inputs["Base Color"])
+        return texture
+
+    def test_empty_imported_material_node_tree_fails(self):
+        self.material.node_tree.nodes.clear()
+
+        report = self._report()
+
+        assert report["passed"] is False
+        assert "MATERIAL_NODE_TREE_EMPTY" in {issue["code"] for issue in report["issues"]}
+
+    def test_effective_object_material_override_is_validated(self):
+        unused = bpy.data.materials.new("UnusedMeshMaterial")
+        unused.use_nodes = True
+        unused.node_tree.nodes.clear()
+        self.obj.data.materials[0] = unused
+        self.obj.material_slots[0].link = "OBJECT"
+        self.obj.material_slots[0].material = self.material
+
+        assert self._report()["passed"] is True
+
+    def test_missing_connected_image_fails_without_loading_it(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            image = bpy.data.images.new("MissingFixture", width=1, height=1)
+            image.source = "FILE"
+            image.filepath = str(Path(tmp) / "missing.png")
+            self._texture(image)
+            before = (image.filepath, image.has_data, image.is_dirty)
+
+            report = self._report()
+
+            assert report["passed"] is False
+            assert "MATERIAL_IMAGE_MISSING" in {issue["code"] for issue in report["issues"]}
+            assert (image.filepath, image.has_data, image.is_dirty) == before
+
+    @pytest.mark.parametrize("packed", [False, True])
+    def test_generated_and_packed_images_need_no_external_file(self, packed):
+        image = bpy.data.images.new("InternalFixture", width=1, height=1)
+        if packed:
+            image.pixels[:] = [1.0, 0.0, 0.0, 1.0]
+            image.pack()
+            assert image.packed_file is not None
+        self._texture(image)
+
+        report = self._report()
+
+        assert report["passed"] is True
+        assert report["context"]["resource_checks_complete"] is True
+
+    def test_unconnected_missing_image_does_not_fail_material(self):
+        image = bpy.data.images.new("UnusedFixture", width=1, height=1)
+        image.source = "FILE"
+        image.filepath = "//unused-missing.png"
+        self._texture(image, linked=False)
+
+        assert self._report()["passed"] is True
+
+    def test_sequence_is_explicitly_unverified_not_missing(self):
+        image = bpy.data.images.new("SequenceFixture", width=1, height=1)
+        image.source = "SEQUENCE"
+        image.filepath = "//frames/frame0001.png"
+        self._texture(image)
+
+        report = self._report()
+
+        assert report["counts"]["error"] == 0
+        assert report["context"]["resource_checks_complete"] is False
+        assert "MATERIAL_IMAGE_UNVERIFIED" in {issue["code"] for issue in report["issues"]}
+
+    def test_udim_checks_only_declared_tiles(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # Existence validation must not decode/reload these artist resources.
+            (Path(tmp) / "leaf.1001.png").write_bytes(b"exists")
+            image = bpy.data.images.new("TilesFixture", width=1, height=1, tiled=True)
+            image.filepath = str(Path(tmp) / "leaf.<UDIM>.png")
+            image.tiles.new(1002)
+            assert [tile.number for tile in image.tiles] == [1001, 1002]
+            self._texture(image)
+
+            report = self._report()
+
+            missing = [issue for issue in report["issues"] if issue["code"] == "MATERIAL_IMAGE_MISSING"]
+            assert report["passed"] is False, report
+            assert [issue["details"]["tile"] for issue in missing] == [1002]
+
+    def test_nested_node_group_image_is_inspected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            group_tree = bpy.data.node_groups.new("ValidationGroup", "ShaderNodeTree")
+            if hasattr(group_tree, "interface"):
+                group_tree.interface.new_socket(name="Color", in_out="OUTPUT", socket_type="NodeSocketColor")
+            else:
+                group_tree.outputs.new("NodeSocketColor", "Color")
+            group_output = group_tree.nodes.new("NodeGroupOutput")
+            texture = group_tree.nodes.new("ShaderNodeTexImage")
+            image = bpy.data.images.new("NestedMissing", width=1, height=1)
+            image.source = "FILE"
+            image.filepath = str(Path(tmp) / "missing.png")
+            texture.image = image
+            group_tree.links.new(texture.outputs["Color"], group_output.inputs["Color"])
+            group = self.material.node_tree.nodes.new("ShaderNodeGroup")
+            group.node_tree = group_tree
+            shader = self.material.node_tree.nodes.get("Principled BSDF")
+            self.material.node_tree.links.new(group.outputs["Color"], shader.inputs["Base Color"])
+
+            report = self._report()
+
+            assert report["passed"] is False
+            assert "MATERIAL_IMAGE_MISSING" in {issue["code"] for issue in report["issues"]}

--- a/tests/test_skills_asset_pipeline.py
+++ b/tests/test_skills_asset_pipeline.py
@@ -7,6 +7,8 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from tests.conftest import load_and_call, make_mock_bpy
 
 
@@ -73,6 +75,16 @@ def _codes(result):
     return {issue["code"] for issue in result["context"]["report"]["issues"]}
 
 
+def _bpy_with_image(image, connected=True):
+    texture = SimpleNamespace(
+        name="Texture", type="TEX_IMAGE", image=image, outputs=[SimpleNamespace(is_linked=connected)]
+    )
+    material = SimpleNamespace(name="Leaves", use_nodes=True, node_tree=SimpleNamespace(nodes=[texture]))
+    bpy = _make_bpy(_FakeObject(materials=[material]))
+    bpy.path.abspath.side_effect = lambda path, **kwargs: path
+    return bpy
+
+
 class TestValidationSkills:
     def test_validate_mesh_passes_with_info_report(self):
         cube = _FakeObject()
@@ -108,6 +120,220 @@ class TestValidationSkills:
 
         assert result["success"] is True
         assert {"OBJECT_MISSING", "MATERIALS_MISSING"}.issubset(_codes(result))
+
+    def test_validate_materials_rejects_empty_enabled_node_tree(self):
+        material = SimpleNamespace(name="ImportedPlaceholder", use_nodes=True, node_tree=SimpleNamespace(nodes=[]))
+        bpy = _make_bpy(_FakeObject(materials=[material]))
+
+        result = load_and_call(
+            "blender-validation/scripts/validate_materials.py",
+            bpy,
+            object_names=["Cube"],
+            rules={"require_nodes": True},
+        )
+
+        assert result["success"] is True
+        assert result["context"]["report"]["passed"] is False
+        assert "MATERIAL_NODE_TREE_EMPTY" in _codes(result)
+
+    def test_validate_materials_reports_missing_connected_image(self, tmp_path):
+        image = SimpleNamespace(
+            name="Normal", source="FILE", filepath=str(tmp_path / "missing.png"), packed_file=None, packed_files=[]
+        )
+        texture = SimpleNamespace(
+            name="Texture", type="TEX_IMAGE", image=image, outputs=[SimpleNamespace(is_linked=True)]
+        )
+        material = SimpleNamespace(name="Leaves", use_nodes=True, node_tree=SimpleNamespace(nodes=[texture]))
+        bpy = _make_bpy(_FakeObject(materials=[material]))
+        bpy.path.abspath.side_effect = lambda path, **kwargs: path
+
+        result = load_and_call(
+            "blender-validation/scripts/validate_materials.py",
+            bpy,
+            object_names=["Cube"],
+            rules={"require_nodes": True},
+        )
+
+        assert result["success"] is True
+        assert result["context"]["report"]["passed"] is False
+        assert "MATERIAL_IMAGE_MISSING" in _codes(result)
+
+    @pytest.mark.parametrize("source,packed", [("GENERATED", False), ("VIEWER", False), ("FILE", True)])
+    def test_validate_materials_does_not_require_external_files_for_internal_images(self, source, packed):
+        image = SimpleNamespace(
+            name="Internal", source=source, filepath="", packed_file=object() if packed else None, packed_files=[]
+        )
+        texture = SimpleNamespace(
+            name="Texture", type="TEX_IMAGE", image=image, outputs=[SimpleNamespace(is_linked=True)]
+        )
+        material = SimpleNamespace(name="Internal", use_nodes=True, node_tree=SimpleNamespace(nodes=[texture]))
+        bpy = _make_bpy(_FakeObject(materials=[material]))
+        bpy.path.abspath.side_effect = lambda path, **kwargs: path
+
+        result = load_and_call("blender-validation/scripts/validate_materials.py", bpy, object_names=["Cube"])
+
+        assert result["context"]["report"]["passed"] is True
+        assert "MATERIAL_IMAGE_MISSING" not in _codes(result)
+        bpy.path.abspath.assert_not_called()
+
+    @pytest.mark.parametrize("missing_tile", [False, True])
+    def test_validate_materials_checks_declared_udim_tiles_not_literal_template(self, tmp_path, missing_tile):
+        (tmp_path / "leaf.1001.png").write_bytes(b"fixture")
+        if not missing_tile:
+            (tmp_path / "leaf.1002.png").write_bytes(b"fixture")
+        image = SimpleNamespace(
+            name="Tiles",
+            source="TILED",
+            filepath=str(tmp_path / "leaf.<UDIM>.png"),
+            packed_file=None,
+            packed_files=[],
+            tiles=[SimpleNamespace(number=1001), SimpleNamespace(number=1002)],
+        )
+        bpy = _bpy_with_image(image)
+
+        result = load_and_call("blender-validation/scripts/validate_materials.py", bpy, object_names=["Cube"])
+
+        assert result["context"]["report"]["passed"] is (not missing_tile)
+        if missing_tile:
+            findings = result["context"]["report"]["issues"]
+            assert any(
+                item["code"] == "MATERIAL_IMAGE_MISSING" and item["details"]["tile"] == 1002 for item in findings
+            )
+
+    @pytest.mark.parametrize(
+        "source,template,tiles",
+        [
+            ("SEQUENCE", "frame0001.png", []),
+            ("MOVIE", "clip.mov", []),
+            ("TILED", "leaf.png", [1001]),
+            ("TILED", "leaf.<UDIM>.png", []),
+            ("UNKNOWN", "image.png", []),
+        ],
+    )
+    def test_validate_materials_reports_unverified_sources_without_false_missing(self, source, template, tiles):
+        image = SimpleNamespace(
+            name="Special",
+            source=source,
+            filepath=template,
+            packed_file=None,
+            packed_files=[],
+            tiles=[SimpleNamespace(number=number) for number in tiles],
+        )
+        bpy = _bpy_with_image(image)
+
+        result = load_and_call("blender-validation/scripts/validate_materials.py", bpy, object_names=["Cube"])
+
+        report = result["context"]["report"]
+        assert report["counts"]["error"] == 0
+        assert "MATERIAL_IMAGE_UNVERIFIED" in _codes(result)
+        assert "MATERIALS_VALID" not in _codes(result)
+        assert report["context"]["resource_checks_complete"] is False
+
+    def test_validate_materials_checks_connected_nested_node_groups(self, tmp_path):
+        image = SimpleNamespace(name="Nested", source="FILE", filepath=str(tmp_path / "missing.png"), packed_file=None)
+        bpy = _bpy_with_image(image)
+        material = bpy.data.objects[0].data.materials[0]
+        nested_tree = material.node_tree
+        group = SimpleNamespace(
+            name="Group", type="GROUP", node_tree=nested_tree, outputs=[SimpleNamespace(is_linked=True)]
+        )
+        material.node_tree = SimpleNamespace(nodes=[group])
+
+        result = load_and_call("blender-validation/scripts/validate_materials.py", bpy, object_names=["Cube"])
+
+        assert result["context"]["report"]["passed"] is False
+        assert "MATERIAL_IMAGE_MISSING" in _codes(result)
+
+    def test_validate_materials_bounds_udim_file_checks(self):
+        image = SimpleNamespace(
+            name="ManyTiles",
+            source="TILED",
+            filepath="many.<UDIM>.png",
+            packed_file=None,
+            tiles=[SimpleNamespace(number=number) for number in range(1001, 2026)],
+        )
+        bpy = _bpy_with_image(image)
+
+        result = load_and_call("blender-validation/scripts/validate_materials.py", bpy, object_names=["Cube"])
+
+        assert "MATERIAL_IMAGE_UNVERIFIED" in _codes(result)
+        assert result["context"]["report"]["context"]["resource_checks_complete"] is False
+        assert result["context"]["report"]["counts"]["error"] == 0
+
+    def test_validate_materials_does_not_assume_partial_packed_udim_is_complete(self):
+        image = SimpleNamespace(
+            name="PartialPacked",
+            source="TILED",
+            filepath="leaf.<UDIM>.png",
+            packed_file=object(),
+            packed_files=[object()],
+            tiles=[SimpleNamespace(number=1001), SimpleNamespace(number=1002)],
+        )
+        bpy = _bpy_with_image(image)
+
+        result = load_and_call("blender-validation/scripts/validate_materials.py", bpy, object_names=["Cube"])
+
+        assert "MATERIAL_IMAGE_UNVERIFIED" in _codes(result)
+        assert result["context"]["report"]["context"]["resource_checks_complete"] is False
+        assert result["context"]["report"]["counts"]["error"] == 0
+        bpy.path.abspath.assert_not_called()
+
+    @pytest.mark.parametrize("case", ["depth", "nodes", "unavailable_group"])
+    def test_validate_materials_marks_bounded_or_unavailable_groups_incomplete(self, case):
+        bpy = _bpy_with_image(None)
+        material = bpy.data.objects[0].data.materials[0]
+        if case == "nodes":
+            material.node_tree.nodes = [SimpleNamespace(outputs=[], mute=False)] * 4097
+        else:
+            tree = None if case == "unavailable_group" else material.node_tree
+            for _ in range(1 if case == "unavailable_group" else 18):
+                tree = SimpleNamespace(
+                    nodes=[
+                        SimpleNamespace(
+                            name="Group", type="GROUP", node_tree=tree, outputs=[SimpleNamespace(is_linked=True)]
+                        )
+                    ]
+                )
+            material.node_tree = tree
+
+        result = load_and_call("blender-validation/scripts/validate_materials.py", bpy, object_names=["Cube"])
+
+        assert "MATERIAL_GRAPH_UNVERIFIED" in _codes(result)
+        assert result["context"]["report"]["context"]["resource_checks_complete"] is False
+
+    @pytest.mark.parametrize("muted,linked", [(True, True), (False, False)])
+    def test_validate_materials_does_not_check_inactive_images(self, muted, linked):
+        bpy = _bpy_with_image(None, connected=linked)
+        bpy.data.objects[0].data.materials[0].node_tree.nodes[0].mute = muted
+
+        result = load_and_call("blender-validation/scripts/validate_materials.py", bpy, object_names=["Cube"])
+
+        assert result["context"]["report"]["passed"] is True
+        bpy.path.abspath.assert_not_called()
+
+    def test_validate_materials_fails_closed_on_unreadable_image_metadata(self):
+        image = SimpleNamespace(name="Unreadable", source="FILE", filepath="//locked.png", packed_file=None)
+        bpy = _bpy_with_image(image)
+        bpy.path.abspath.side_effect = OSError("Image library cannot be resolved")
+
+        result = load_and_call("blender-validation/scripts/validate_materials.py", bpy, object_names=["Cube"])
+
+        assert result["success"] is False
+
+    def test_validate_materials_uses_effective_object_material_override(self):
+        unused = SimpleNamespace(name="UnusedMeshMaterial", use_nodes=True, node_tree=SimpleNamespace(nodes=[]))
+        image = SimpleNamespace(name="Generated", source="GENERATED", filepath="")
+        bpy = _bpy_with_image(image)
+        bpy.data.objects[0].data.materials = [unused]
+
+        result = load_and_call(
+            "blender-validation/scripts/validate_materials.py",
+            bpy,
+            object_names=["Cube"],
+            rules={"require_nodes": True},
+        )
+
+        assert result["context"]["report"]["passed"] is True
 
     def test_validate_export_readiness_reports_unsupported_format(self):
         cube = _FakeObject()

--- a/tests/test_skills_asset_pipeline.py
+++ b/tests/test_skills_asset_pipeline.py
@@ -158,6 +158,65 @@ class TestValidationSkills:
         assert result["context"]["report"]["passed"] is False
         assert "MATERIAL_IMAGE_MISSING" in _codes(result)
 
+    @pytest.mark.parametrize("missing_datablock", [True, False])
+    def test_validate_materials_reports_missing_environment_image(self, tmp_path, missing_datablock):
+        image = (
+            None
+            if missing_datablock
+            else SimpleNamespace(
+                name="Environment", source="FILE", filepath=str(tmp_path / "missing.exr"), packed_file=None
+            )
+        )
+        bpy = _bpy_with_image(image)
+        bpy.data.objects[0].material_slots[0].material.node_tree.nodes[0].type = "TEX_ENVIRONMENT"
+
+        result = load_and_call(
+            "blender-validation/scripts/validate_materials.py",
+            bpy,
+            object_names=["Cube"],
+            rules={"require_nodes": True},
+        )
+
+        assert result["success"] is True
+        assert result["context"]["report"]["passed"] is False
+        assert "MATERIAL_IMAGE_MISSING" in _codes(result)
+
+    @pytest.mark.parametrize("require_nodes", [False, True])
+    def test_validate_materials_does_not_inspect_disabled_node_tree(self, require_nodes):
+        bpy = _bpy_with_image(None)
+        material = bpy.data.objects[0].material_slots[0].material
+        material.use_nodes = False
+
+        result = load_and_call(
+            "blender-validation/scripts/validate_materials.py",
+            bpy,
+            object_names=["Cube"],
+            rules={"require_nodes": require_nodes},
+        )
+
+        assert result["success"] is True
+        assert result["context"]["report"]["passed"] is (not require_nodes)
+        assert _codes(result) == ({"MATERIAL_NODES_DISABLED"} if require_nodes else {"MATERIALS_VALID"})
+        assert material.use_nodes is False
+        assert material.node_tree.nodes[0].image is None
+
+    @pytest.mark.parametrize("missing_image", [False, True])
+    def test_validate_materials_inspects_nodes_when_legacy_toggle_is_absent(self, missing_image):
+        image = None if missing_image else SimpleNamespace(name="Internal", source="GENERATED")
+        bpy = _bpy_with_image(image)
+        del bpy.data.objects[0].material_slots[0].material.use_nodes
+
+        result = load_and_call(
+            "blender-validation/scripts/validate_materials.py",
+            bpy,
+            object_names=["Cube"],
+            rules={"require_nodes": True},
+        )
+
+        assert result["success"] is True
+        assert result["context"]["report"]["passed"] is (not missing_image)
+        assert _codes(result) == ({"MATERIAL_IMAGE_MISSING"} if missing_image else {"MATERIALS_VALID"})
+
     @pytest.mark.parametrize("source,packed", [("GENERATED", False), ("VIEWER", False), ("FILE", True)])
     def test_validate_materials_does_not_require_external_files_for_internal_images(self, source, packed):
         image = SimpleNamespace(


### PR DESCRIPTION
## Summary
- Validate effective material slots and required node trees.
- Check linked image/environment resources in active graphs with bounded traversal and explicit incomplete results.
- Cover disabled graphs, missing resources, nested groups and declared UDIM tiles without loading artist images.

## Validation
- 736 unit tests passed.
- 14 material/asset E2E tests passed on each Blender 5.2.1 and 4.5.13.
- Ruff, skill metadata and independent review passed; final-head CI passed.