### PR TITLE
feat: add solid pointed arch modeling tool

### DIFF
--- a/src/dcc_mcp_blender/_architectural_mesh.py
+++ b/src/dcc_mcp_blender/_architectural_mesh.py
@@ -1,0 +1,121 @@
+"""Bounded, context-independent solid pointed-arch construction."""
+
+from __future__ import annotations
+
+import math
+
+from dcc_mcp_core.skill import skill_error, skill_success
+
+
+def pointed_arch_geometry(width, spring_height, rise, frame_width, depth, segments):
+    """Return an open-bottom U frame, closed at both feet, in local X/Z.
+
+    Each half is a scaled circular arc with a pointed crown. Frame width
+    specifies the horizontal jamb thickness and vertical crown thickness;
+    it is not a constant normal offset along the curved head.
+    """
+    for value in (width, spring_height, rise, frame_width, depth):
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value <= 0:
+            raise ValueError("All dimensions must be finite positive numbers")
+    if isinstance(segments, bool) or not isinstance(segments, int) or not 2 <= segments <= 128:
+        raise ValueError("segments must be an integer from 2 to 128 per half arch")
+
+    def profile(w, r):
+        points = [(-w / 2, 0), (-w / 2, spring_height)]
+        for i in range(1, segments + 1):
+            theta = math.pi * i / (3 * segments)
+            points.append((w / 2 - w * math.cos(theta), spring_height + r * math.sin(theta) / math.sin(math.pi / 3)))
+        points[-1] = (0, spring_height + r)
+        points.extend([(-x, z) for x, z in reversed(points[:-1])])
+        return points
+
+    inner = profile(width, rise)
+    outer = profile(width + 2 * frame_width, rise + frame_width)
+    vertices = []
+    for (ix, iz), (ox, oz) in zip(inner, outer):
+        vertices.extend(((ix, 0, iz), (ox, 0, oz), (ox, depth, oz), (ix, depth, iz)))
+    faces = []
+    for i in range(len(inner) - 1):
+        for j in range(4):
+            faces.append((4 * i + j, 4 * i + (j + 1) % 4, 4 * (i + 1) + (j + 1) % 4, 4 * (i + 1) + j))
+    faces.extend(((3, 2, 1, 0), tuple(4 * (len(inner) - 1) + j for j in range(4))))
+    return vertices, [tuple(reversed(face)) for face in faces]
+
+
+def create_pointed_arch(name, width, spring_height, rise, frame_width, depth, segments=16, location=(0, 0, 0)):
+    """Create a closed mesh without operators or selection changes."""
+    try:
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("name must be a nonempty string")
+        if not isinstance(location, (list, tuple)) or len(location) != 3:
+            raise ValueError("location must contain three finite numbers")
+        if any(isinstance(v, bool) or not isinstance(v, (int, float)) or not math.isfinite(v) for v in location):
+            raise ValueError("location must contain three finite numbers")
+        vertices, faces = pointed_arch_geometry(width, spring_height, rise, frame_width, depth, segments)
+    except (ValueError, TypeError) as exc:
+        return skill_error(str(exc), "Use positive dimensions and a bounded segment count.", mutation_applied=False)
+
+    import bpy
+
+    if bpy.data.objects.get(name) is not None:
+        return skill_error("Object name already exists", "Choose an unused object name.", mutation_applied=False)
+    mesh = None
+    obj = None
+    try:
+        mesh = bpy.data.meshes.new(name + "Mesh")
+        mesh.from_pydata(vertices, [], faces)
+        mesh.update()
+        if len(mesh.vertices) != len(vertices) or len(mesh.polygons) != len(faces):
+            raise RuntimeError("Created mesh counts do not match the requested solid")
+        bounds = [[min(v.co[axis] for v in mesh.vertices), max(v.co[axis] for v in mesh.vertices)] for axis in range(3)]
+        if any(not math.isfinite(value) for pair in bounds for value in pair):
+            raise RuntimeError("Dimensions exceed Blender's finite coordinate range")
+        edge_uses = {}
+        for polygon in mesh.polygons:
+            indices = list(polygon.vertices)
+            for a, b in zip(indices, indices[1:] + indices[:1]):
+                key = tuple(sorted((a, b)))
+                edge_uses[key] = edge_uses.get(key, 0) + 1
+        if any(count != 2 for count in edge_uses.values()) or any(
+            not math.isfinite(p.area) or p.area <= 0 for p in mesh.polygons
+        ):
+            raise RuntimeError("Created mesh is degenerate or not a closed two-manifold")
+        obj = bpy.data.objects.new(name, mesh)
+        obj.location = location
+        bpy.context.scene.collection.objects.link(obj)
+        if any(not math.isfinite(value) for value in obj.location):
+            raise RuntimeError("Location exceeds Blender's finite coordinate range")
+        return skill_success(
+            "Created solid pointed arch",
+            object_name=obj.name,
+            location=list(obj.location),
+            vertex_count=len(mesh.vertices),
+            face_count=len(mesh.polygons),
+            local_dimensions=[hi - lo for lo, hi in bounds],
+            local_bounds=bounds,
+            world_bounds=[[lo + obj.location[i], hi + obj.location[i]] for i, (lo, hi) in enumerate(bounds)],
+            closed_two_manifold=True,
+            opening_dimensions=[width, spring_height + rise],
+            depth_axis="+Y",
+            mutation_applied=True,
+        )
+    except Exception as exc:
+        cleanup_errors = []
+        if obj is not None:
+            try:
+                bpy.data.objects.remove(obj, do_unlink=True)
+            except Exception as cleanup_exc:
+                cleanup_errors.append(str(cleanup_exc))
+        if mesh is not None:
+            try:
+                bpy.data.meshes.remove(mesh)
+            except Exception as cleanup_exc:
+                cleanup_errors.append(str(cleanup_exc))
+        return skill_error(
+            "Arch creation failed: " + str(exc),
+            "Inspect the scene before retrying if rollback failed.",
+            mutation_applied=mesh is not None,
+            rollback_attempted=mesh is not None,
+            rollback_verified=not cleanup_errors,
+            cleanup_errors=cleanup_errors,
+        )

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/SKILL.md
@@ -55,3 +55,18 @@ reporting success.
 Prefer `blender-objects` for object transforms and selection, `blender-mesh` for
 modifier management, `blender-uv-ops` for UVs, and `blender-scripting` only
 after checking this typed surface.
+
+### Solid pointed arches
+
+`create_pointed_arch` creates a closed, all-quad U-shaped solid for deep door
+and window surrounds. Load the `modeling` group first. `width` is the clear
+opening, `spring_height` is the jamb height, `rise` is the pointed head rise,
+`frame_width` is horizontal jamb / vertical crown thickness, and `depth` is
+physical reveal depth. Curved head thickness is not a constant normal offset.
+The opening bottom center is the origin; X spans width, Z height, and the
+solid occupies Y=0 through Y=depth. Use object transforms to orient it on a
+side wall. The tool leaves selection and active object unchanged, rejects
+existing names, and does not cut the wall behind the opening, create glass,
+assign material, bevel, or unwrap UVs. Follow with the corresponding typed
+tools. Recess the glazing and cut the wall separately so the depth remains
+visible; a coplanar opaque wall can hide the entire reveal.

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/groups.yaml
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/groups.yaml
@@ -17,6 +17,7 @@ groups:
     default_active: false
     tools:
       - create_primitive
+      - create_pointed_arch
       - loft_sections
       - lathe_profile
       - extrude_faces

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/create_pointed_arch.py
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/create_pointed_arch.py
@@ -1,0 +1,10 @@
+"""Create a dimensioned, closed solid pointed arch."""
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._architectural_mesh import create_pointed_arch
+
+
+@skill_entry
+def main(**kwargs):
+    return create_pointed_arch(**kwargs)

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/tools.yaml
@@ -709,3 +709,43 @@ tools:
       destructive_hint: false
       idempotent_hint: true
       open_world_hint: false
+
+  - name: create_pointed_arch
+    description: "Create a closed solid pointed-arch door/window frame with real jamb, crown and reveal depth. Local X is width, Z is height, and depth extends from Y=0 toward +Y; origin is the opening bottom center. Does not cut a wall or create a door."
+    source_file: scripts/create_pointed_arch.py
+    group: modeling
+    execution: sync
+    affinity: main
+    enforce_thread_affinity: true
+    timeout_hint_secs: 10
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [name, width, spring_height, rise, frame_width, depth]
+      properties:
+        name: {type: string, minLength: 1, description: Unique object name. Existing names are rejected.}
+        width: {type: number, exclusiveMinimum: 0, description: Clear opening width in scene units.}
+        spring_height: {type: number, exclusiveMinimum: 0, description: Height of the straight jambs.}
+        rise: {type: number, exclusiveMinimum: 0, description: Opening crown height above the spring line.}
+        frame_width: {type: number, exclusiveMinimum: 0, description: Horizontal jamb and vertical crown thickness; curved thickness varies.}
+        depth: {type: number, exclusiveMinimum: 0, description: Solid reveal depth along local positive Y.}
+        segments: {type: integer, minimum: 2, maximum: 128, default: 16, description: Segments per half arch.}
+        location:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+          default: [0, 0, 0]
+          description: World position of opening bottom center.
+    output_schema: *mesh_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+    call_examples:
+      - arguments: {name: PortalFrame, width: 2.0, spring_height: 3.0, rise: 1.5, frame_width: 0.35, depth: 0.8}
+        note: Solid stone portal with an open threshold and closed jamb feet.

--- a/tests/e2e/test_architectural_mesh_e2e.py
+++ b/tests/e2e/test_architectural_mesh_e2e.py
@@ -1,0 +1,36 @@
+"""Real Blender geometry, positioning, and context preservation checks."""
+
+import pytest
+
+bpy = pytest.importorskip("bpy")
+pytestmark = pytest.mark.e2e
+
+from dcc_mcp_blender._architectural_mesh import create_pointed_arch  # noqa: E402
+
+
+def test_solid_arch_depth_bounds_and_context():
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    bpy.ops.mesh.primitive_cube_add()
+    active = bpy.context.active_object
+    selected = list(bpy.context.selected_objects)
+    result = create_pointed_arch("Portal", 2, 3, 1.5, 0.35, 0.8, location=(1, 2, 3))
+    assert result["success"], result
+    obj = bpy.data.objects["Portal"]
+    bpy.context.view_layer.update()
+    assert list(obj.dimensions) == pytest.approx([2.7, 0.8, 4.85])
+    assert list(obj.location) == [1, 2, 3]
+    assert result["context"]["world_bounds"][1] == pytest.approx([2, 2.8])
+    assert bpy.context.active_object == active
+    assert bpy.context.selected_objects == selected
+    import bmesh
+
+    mesh = bmesh.new()
+    try:
+        mesh.from_mesh(obj.data)
+        assert all(edge.is_manifold for edge in mesh.edges)
+        assert mesh.calc_volume(signed=True) > 0
+    finally:
+        mesh.free()
+    duplicate = create_pointed_arch("Portal", 2, 3, 1.5, 0.35, 0.8)
+    assert not duplicate["success"]
+    assert bpy.data.objects["Portal"] == obj

--- a/tests/test_architectural_mesh.py
+++ b/tests/test_architectural_mesh.py
@@ -1,0 +1,83 @@
+"""Geometric and host failure contracts for solid architectural arches."""
+
+from collections import Counter
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dcc_mcp_blender._architectural_mesh import create_pointed_arch, pointed_arch_geometry
+
+
+@pytest.mark.parametrize("segments", [2, 16, 128])
+def test_arch_is_closed_consistently_wound_and_has_real_depth(segments):
+    verts, faces = pointed_arch_geometry(2, 3, 1.5, 0.35, 0.8, segments)
+    edges = Counter()
+    directed = Counter()
+    volume = 0
+    for face in faces:
+        assert len(set(face)) == 4
+        for a, b in zip(face, face[1:] + face[:1]):
+            edges[tuple(sorted((a, b)))] += 1
+            directed[(a, b)] += 1
+        a = verts[face[0]]
+        for i in range(1, len(face) - 1):
+            b, c = verts[face[i]], verts[face[i + 1]]
+            volume += (
+                a[0] * (b[1] * c[2] - b[2] * c[1])
+                + a[1] * (b[2] * c[0] - b[0] * c[2])
+                + a[2] * (b[0] * c[1] - b[1] * c[0])
+            ) / 6
+    assert set(edges.values()) == {2}
+    assert all(directed[(b, a)] == count for (a, b), count in directed.items())
+    assert volume > 0  # Outward normals, not merely consistent winding.
+    assert len(verts) - len(edges) + len(faces) == 2
+    assert max(v[0] for v in verts) - min(v[0] for v in verts) == pytest.approx(2.7)
+    assert max(v[1] for v in verts) == pytest.approx(0.8)
+    assert min(v[1] for v in verts) == 0
+    assert max(v[2] for v in verts) == pytest.approx(4.85)
+    # No threshold face closes the actual door opening.
+    assert not any(
+        all(verts[i][2] == 0 for i in face) and min(verts[i][0] for i in face) < 0 < max(verts[i][0] for i in face)
+        for face in faces
+    )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("width", 0),
+        ("depth", -1),
+        ("rise", float("nan")),
+        ("frame_width", float("inf")),
+        ("segments", 129),
+        ("segments", True),
+        ("location", [1, 2]),
+        ("location", [0, float("nan"), 0]),
+    ],
+)
+def test_invalid_input_never_creates_blender_data(field, value):
+    args = dict(name="Arch", width=2, spring_height=3, rise=1.5, frame_width=0.35, depth=0.8)
+    args[field] = value
+    bpy = MagicMock()
+    with patch.dict("sys.modules", bpy=bpy):
+        result = create_pointed_arch(**args)
+    assert result["success"] is False
+    bpy.data.meshes.new.assert_not_called()
+
+
+def test_existing_name_does_not_overwrite():
+    bpy = MagicMock()
+    with patch.dict("sys.modules", bpy=bpy):
+        result = create_pointed_arch("Arch", 2, 3, 1.5, 0.35, 0.8)
+    assert result["success"] is False
+    bpy.data.meshes.new.assert_not_called()
+
+
+def test_creation_error_removes_owned_mesh():
+    bpy = MagicMock()
+    bpy.data.objects.get.return_value = None
+    bpy.data.meshes.new.return_value.from_pydata.side_effect = RuntimeError("injected failure")
+    with patch.dict("sys.modules", bpy=bpy):
+        result = create_pointed_arch("Arch", 2, 3, 1.5, 0.35, 0.8)
+    assert result["success"] is False
+    bpy.data.meshes.remove.assert_called_once_with(bpy.data.meshes.new.return_value)

--- a/tests/test_skills_mesh_scene_ops.py
+++ b/tests/test_skills_mesh_scene_ops.py
@@ -41,6 +41,7 @@ MESH_OPS_TOOLS = {
     "separate_mesh",
     "combine_meshes",
     "create_primitive",
+    "create_pointed_arch",
     "delete_history",
     "extrude_faces",
     "freeze_transforms",

--- a/tests/test_typed_modeling_verbs.py
+++ b/tests/test_typed_modeling_verbs.py
@@ -21,6 +21,7 @@ MODELING_TOOLS = {
     "bevel_edges",
     "boolean_op",
     "create_primitive",
+    "create_pointed_arch",
     "delete_history",
     "extrude_faces",
     "freeze_transforms",


### PR DESCRIPTION
Adds a typed solid pointed-arch frame with explicit opening dimensions, frame thickness and reveal depth, measured bounds and closed-mesh verification.

Preserves selection, rejects existing names and cleans up its own data on failure. Wall cutting, materials and UV authoring remain out of scope.

Validation: 749 unit tests passed; native arch regressions passed on Blender 5.2.1 and 4.5.13; Ruff, skill metadata and independent review passed. Final-head CI passed.