### PR TITLE
feat: add isolated multiview and wire render jobs

### DIFF
--- a/.github/scripts/run_blender_e2e.py
+++ b/.github/scripts/run_blender_e2e.py
@@ -31,13 +31,12 @@ def main() -> int:
             "--override-ini=addopts=",
         ]
     )
+    sys.stdout.flush()
+    sys.stderr.flush()
     return 0 if exit_code == 5 else exit_code
 
 
 if __name__ == "__main__":
     # Bypass Blender C++ cleanup in Linux background mode; sys.exit() can
     # otherwise try to destroy uninitialized X11/OpenGL resources.
-    result = main()
-    sys.stdout.flush()
-    sys.stderr.flush()
-    os._exit(result)
+    os._exit(main())

--- a/.github/scripts/run_blender_e2e.py
+++ b/.github/scripts/run_blender_e2e.py
@@ -37,4 +37,7 @@ def main() -> int:
 if __name__ == "__main__":
     # Bypass Blender C++ cleanup in Linux background mode; sys.exit() can
     # otherwise try to destroy uninitialized X11/OpenGL resources.
-    os._exit(main())
+    result = main()
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(result)

--- a/src/dcc_mcp_blender/_multiview_ops.py
+++ b/src/dcc_mcp_blender/_multiview_ops.py
@@ -13,7 +13,13 @@ from dcc_mcp_blender._multiview_receipt import multiview_context, write_receipt
 
 
 def start_multiview_render_job(
-    output_directory, camera_names, passes=("beauty", "wire"), resolution_x=1200, resolution_y=1200, wire_radius=0.008
+    output_directory,
+    camera_names,
+    passes=("beauty", "wire"),
+    resolution_x=1200,
+    resolution_y=1200,
+    wire_radius=0.008,
+    max_source_edges=100000,
 ):
     try:
         import bpy
@@ -51,12 +57,18 @@ def start_multiview_render_job(
             camera = bpy.context.scene.objects.get(name)
             if camera is None or camera.type != "CAMERA":
                 raise ValueError("Not a camera in the active scene: " + name)
+        if (
+            isinstance(max_source_edges, bool)
+            or not isinstance(max_source_edges, int)
+            or not 1 <= max_source_edges <= 500000
+        ):
+            raise ValueError("max_source_edges must be an integer from 1 to 500000")
         if "wire" in passes:
             edge_count = sum(
                 len(obj.data.edges) for obj in bpy.context.scene.objects if obj.type == "MESH" and not obj.hide_render
             )
-            if edge_count > 100000:
-                raise ValueError("Wire pass exceeds 100000 source edges")
+            if edge_count > max_source_edges:
+                raise ValueError("Wire pass exceeds max_source_edges ({})".format(max_source_edges))
         job_id = uuid.uuid4().hex
         directory = root / ("dcc-mcp-multiview-" + job_id)
         directory.mkdir(parents=True, exist_ok=False)
@@ -67,6 +79,7 @@ def start_multiview_render_job(
             resolution_x=resolution_x,
             resolution_y=resolution_y,
             wire_radius=wire_radius,
+            max_source_edges=max_source_edges,
         )
         (directory / "request.json").write_text(json.dumps(request), encoding="utf-8")
         result = dict(

--- a/src/dcc_mcp_blender/_multiview_ops.py
+++ b/src/dcc_mcp_blender/_multiview_ops.py
@@ -1,0 +1,120 @@
+"""Submit bounded multiview jobs through the existing render process registry."""
+
+from __future__ import annotations
+
+import json
+import math
+import uuid
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
+
+from dcc_mcp_blender._multiview_receipt import multiview_context, write_receipt
+
+
+def start_multiview_render_job(
+    output_directory, camera_names, passes=("beauty", "wire"), resolution_x=1200, resolution_y=1200, wire_radius=0.008
+):
+    try:
+        import bpy
+
+        from dcc_mcp_blender import _render_job_ops as jobs
+
+        root = Path(output_directory)
+        if not root.is_absolute():
+            raise ValueError("output_directory must be absolute")
+        if not isinstance(camera_names, (list, tuple)) or not 1 <= len(camera_names) <= 8:
+            raise ValueError("camera_names must contain 1 to 8 unique camera names")
+        if any(not isinstance(name, str) or not name for name in camera_names) or len(set(camera_names)) != len(
+            camera_names
+        ):
+            raise ValueError("camera_names must contain unique nonempty strings")
+        if (
+            not isinstance(passes, (list, tuple))
+            or not passes
+            or len(passes) > 2
+            or any(p not in ("beauty", "wire") for p in passes)
+            or len(set(passes)) != len(passes)
+        ):
+            raise ValueError("passes must be a unique selection of beauty and wire")
+        for value in (resolution_x, resolution_y):
+            if isinstance(value, bool) or not isinstance(value, int) or not 16 <= value <= 4096:
+                raise ValueError("Image dimensions must be integers from 16 to 4096")
+        if (
+            isinstance(wire_radius, bool)
+            or not isinstance(wire_radius, (int, float))
+            or not math.isfinite(wire_radius)
+            or not 0 < wire_radius <= 1
+        ):
+            raise ValueError("wire_radius must be finite and between 0 (exclusive) and 1 scene unit")
+        for name in camera_names:
+            camera = bpy.context.scene.objects.get(name)
+            if camera is None or camera.type != "CAMERA":
+                raise ValueError("Not a camera in the active scene: " + name)
+        if "wire" in passes:
+            edge_count = sum(
+                len(obj.data.edges) for obj in bpy.context.scene.objects if obj.type == "MESH" and not obj.hide_render
+            )
+            if edge_count > 100000:
+                raise ValueError("Wire pass exceeds 100000 source edges")
+        job_id = uuid.uuid4().hex
+        directory = root / ("dcc-mcp-multiview-" + job_id)
+        directory.mkdir(parents=True, exist_ok=False)
+        request = dict(
+            job_id=job_id,
+            camera_names=list(camera_names),
+            passes=list(passes),
+            resolution_x=resolution_x,
+            resolution_y=resolution_y,
+            wire_radius=wire_radius,
+        )
+        (directory / "request.json").write_text(json.dumps(request), encoding="utf-8")
+        result = dict(
+            job_id=job_id,
+            kind="multiview",
+            status="running",
+            items=[
+                dict(camera=name, **{"pass": render_pass}, status="pending")
+                for name in camera_names
+                for render_pass in passes
+            ],
+        )
+        write_receipt(directory, result)
+        try:
+            # copy=True preserves the live filename and unsaved source changes.
+            saved = bpy.ops.wm.save_as_mainfile(
+                filepath=str(directory / "scene.blend"), copy=True, check_existing=False
+            )
+            if "FINISHED" not in saved:
+                raise RuntimeError("Saving the isolated scene copy did not finish")
+            worker = Path(__file__).with_name("_multiview_worker.py")
+            command = [
+                str(bpy.app.binary_path),
+                "--background",
+                "--factory-startup",
+                "--disable-autoexec",
+                "--python-exit-code",
+                "1",
+                "--python",
+                str(worker),
+                "--",
+                str(directory),
+            ]
+            process = jobs._launch_worker(command, directory, directory / "stdout.log", directory / "stderr.log")
+        except Exception as exc:
+            result["status"] = "failed"
+            result["error"] = str(exc)
+            write_receipt(directory, result)
+            return skill_error("Multiview submission failed", str(exc), job_id=job_id, job_directory=str(directory))
+        job = dict(job_id=job_id, kind="multiview", job_directory=str(directory), process=process, status="running")
+        with jobs._LOCK:
+            jobs._JOBS[job_id] = job
+        return skill_success(
+            "Multiview render submitted",
+            **multiview_context(job),
+            prompt="Poll get_render_job; retain job_directory for receipt recovery after an adapter restart.",
+        )
+    except (TypeError, ValueError) as exc:
+        return skill_error("Invalid multiview request", str(exc))
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to submit multiview render")

--- a/src/dcc_mcp_blender/_multiview_receipt.py
+++ b/src/dcc_mcp_blender/_multiview_receipt.py
@@ -1,0 +1,109 @@
+"""Durable receipts shared by the isolated multiview worker and job queries."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import struct
+from pathlib import Path
+
+TERMINAL = {"completed", "failed", "cancelled"}
+
+
+def write_receipt(directory, receipt):
+    path = Path(directory) / "result.json"
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(json.dumps(receipt), encoding="utf-8")
+    temporary.replace(path)
+
+
+def read_receipt(directory, job_id):
+    if not Path(directory).is_absolute():
+        raise ValueError("job_directory must be absolute")
+    path = Path(directory) / "result.json"
+    if path.stat().st_size > 1_000_000:
+        raise ValueError("Render receipt exceeds the size limit")
+    result = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(result, dict) or result.get("job_id") != job_id or result.get("kind") != "multiview":
+        raise ValueError("Render receipt does not match this multiview job")
+    items = result.get("items")
+    if (
+        not isinstance(result.get("status"), str)
+        or result["status"] not in TERMINAL | {"running"}
+        or not isinstance(items, list)
+        or not 1 <= len(items) <= 16
+    ):
+        raise ValueError("Invalid multiview receipt state")
+    for item in items:
+        if (
+            not isinstance(item, dict)
+            or item.get("pass") not in ("beauty", "wire")
+            or not isinstance(item.get("status"), str)
+            or item.get("status") not in TERMINAL | {"pending", "running"}
+        ):
+            raise ValueError("Invalid multiview item")
+    if result["status"] == "completed" and any(item["status"] != "completed" for item in items):
+        raise ValueError("Completed receipt contains unfinished images")
+    return result
+
+
+def png_evidence(path):
+    """Hash the complete PNG; the worker separately verifies host decoding."""
+    path = Path(path)
+    if path.stat().st_size > 100_000_000:
+        raise ValueError("PNG output exceeds the bounded image size")
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        header = stream.read(24)
+        if len(header) != 24 or header[:8] != b"\x89PNG\r\n\x1a\n" or header[12:16] != b"IHDR":
+            raise ValueError("Output is not a PNG image")
+        width, height = struct.unpack(">II", header[16:24])
+        digest.update(header)
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return {"sha256": digest.hexdigest(), "width": width, "height": height, "size_bytes": path.stat().st_size}
+
+
+def multiview_context(job):
+    directory = Path(job["job_directory"])
+    result = read_receipt(directory, job["job_id"])
+    process = job.get("process")
+    return_code = process.poll() if process is not None else None
+    if result["status"] not in TERMINAL:
+        if process is None:
+            result["last_recorded_status"] = result["status"]
+            result["status"] = "unknown"
+        elif return_code is not None:
+            result["status"] = "failed"
+            result["error"] = "Worker exited before a terminal receipt (code {})".format(return_code)
+            for item in result["items"]:
+                if item["status"] not in TERMINAL:
+                    item["status"] = "failed"
+                    item["error"] = "Worker exited before completing this image"
+            write_receipt(directory, result)
+    if result["status"] == "completed" and process is not None and return_code not in (None, 0):
+        result["status"] = "failed"
+        result["error"] = "Worker exited unsuccessfully after writing its receipt"
+        write_receipt(directory, result)
+    for index, item in enumerate(result["items"]):
+        if item["status"] != "completed":
+            continue
+        try:
+            # Never trust paths embedded in a recovered receipt.
+            filename = "{:02d}_{}.png".format(index, item["pass"])
+            if item["pass"] not in ("beauty", "wire") or png_evidence(directory / filename) != item["image"]:
+                raise ValueError("Image differs from the decoded worker output")
+        except (OSError, ValueError, KeyError) as exc:
+            item["status"] = "failed"
+            item["error"] = str(exc)
+            if result["status"] in TERMINAL:
+                result["status"] = "failed"
+    result["job_directory"] = str(directory)
+    result["stdout_path"] = str(directory / "stdout.log")
+    result["stderr_path"] = str(directory / "stderr.log")
+    result["cancellation_requested"] = (directory / "cancel").exists()
+    result["process_observed"] = process is not None
+    result["pid"] = process.pid if process is not None else None
+    result["progress"] = sum(item["status"] in TERMINAL for item in result["items"]) / len(result["items"])
+    job["status"] = result["status"]
+    return result

--- a/src/dcc_mcp_blender/_multiview_worker.py
+++ b/src/dcc_mcp_blender/_multiview_worker.py
@@ -1,0 +1,133 @@
+"""Blender-only isolated worker. Imports no adapter or native Core extension."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _multiview_receipt import png_evidence, read_receipt, write_receipt  # noqa: E402
+
+
+def prepare_wire(scene, radius):
+    import bpy
+
+    surface = bpy.data.materials.new("DCC Wire Surface")
+    surface.diffuse_color = (0.65, 0.68, 0.72, 1)
+    line = bpy.data.materials.new("DCC Source Mesh Edges")
+    line.diffuse_color = (0.015, 0.02, 0.03, 1)
+    objects = list(scene.objects)
+    edge_count = sum(len(obj.data.edges) for obj in objects if obj.type == "MESH" and not obj.hide_render)
+    if edge_count > 100000:
+        raise ValueError("Wire pass exceeds 100000 source edges")
+    for obj in objects:
+        if obj.type != "MESH":
+            if obj.type not in {"CAMERA", "LIGHT"}:
+                obj.hide_render = True
+            continue
+        if obj.hide_render:
+            continue
+        for modifier in obj.modifiers:
+            modifier.show_render = False
+            modifier.show_viewport = False
+        obj.data = obj.data.copy()
+        if obj.data.shape_keys is not None:
+            obj.shape_key_clear()
+        obj.instance_type = "NONE"
+        obj.data.materials.clear()
+        obj.data.materials.append(surface)
+        for polygon in obj.data.polygons:
+            polygon.material_index = 0
+        curve = bpy.data.curves.new("DCC Source Edges", "CURVE")
+        curve.dimensions = "3D"
+        curve.bevel_depth = radius
+        curve.bevel_resolution = 0
+        curve.resolution_u = 1
+        curve.materials.append(line)
+        for edge in obj.data.edges:
+            spline = curve.splines.new("POLY")
+            spline.points.add(1)
+            for point, vertex_index in zip(spline.points, edge.vertices):
+                point.co = (*obj.data.vertices[vertex_index].co, 1)
+        overlay = bpy.data.objects.new("DCC Source Edges", curve)
+        for collection in obj.users_collection:
+            collection.objects.link(overlay)
+        overlay.matrix_world = obj.matrix_world.copy()
+    scene.render.engine = "BLENDER_WORKBENCH"
+    shading = scene.display.shading
+    shading.light = "STUDIO"
+    shading.color_type = "MATERIAL"
+    shading.show_shadows = True
+    shading.show_cavity = False
+    shading.show_specular_highlight = False
+    shading.background_type = "WORLD"
+    if scene.world is None:
+        scene.world = bpy.data.worlds.new("DCC Wire World")
+    scene.world.color = (0.15, 0.15, 0.15)
+    return edge_count
+
+
+def run(directory):
+    import bpy
+
+    directory = Path(directory)
+    request = json.loads((directory / "request.json").read_text(encoding="utf-8"))
+    result = read_receipt(directory, request["job_id"])
+    for index, item in enumerate(result["items"]):
+        if (directory / "cancel").exists():
+            result["status"] = "cancelled"
+            for pending in result["items"]:
+                if pending["status"] == "pending":
+                    pending["status"] = "cancelled"
+            write_receipt(directory, result)
+            return
+        item["status"] = "running"
+        write_receipt(directory, result)
+        try:
+            bpy.ops.wm.open_mainfile(filepath=str(directory / "scene.blend"), load_ui=False, use_scripts=False)
+            scene = bpy.context.scene
+            camera = scene.objects.get(item["camera"])
+            if camera is None or camera.type != "CAMERA":
+                raise ValueError("Camera missing in the saved scene")
+            scene.camera = camera
+            if item["pass"] == "wire":
+                item["source_edge_count"] = prepare_wire(scene, request["wire_radius"])
+            scene.render.resolution_x = request["resolution_x"]
+            scene.render.resolution_y = request["resolution_y"]
+            scene.render.resolution_percentage = 100
+            scene.render.image_settings.file_format = "PNG"
+            scene.render.image_settings.color_mode = "RGBA"
+            scene.render.image_settings.color_depth = "8"
+            # A compositor File Output node must not write outside the job directory.
+            scene.render.use_compositing = False
+            scene.render.use_sequencer = False
+            scene.render.use_border = False
+            scene.render.use_multiview = False
+            scene.render.film_transparent = False
+            path = directory / "{:02d}_{}.png".format(index, item["pass"])
+            scene.render.filepath = str(path)
+            bpy.ops.render.render(write_still=True)
+            image = bpy.data.images.load(str(path), check_existing=False)
+            try:
+                if tuple(image.size) != (request["resolution_x"], request["resolution_y"]) or not image.has_data:
+                    raise ValueError("Rendered PNG failed decode/dimension verification")
+                # Force pixel decoding, rather than accepting a filename or header.
+                if len(image.pixels) != image.size[0] * image.size[1] * 4:
+                    raise ValueError("Rendered image pixel data is incomplete")
+            finally:
+                bpy.data.images.remove(image)
+            item["image"] = png_evidence(path)
+            item["path"] = str(path)
+            item["status"] = "completed"
+        except Exception as exc:
+            item["status"] = "failed"
+            item["error"] = str(exc)
+        write_receipt(directory, result)
+    result["status"] = "completed" if all(item["status"] == "completed" for item in result["items"]) else "failed"
+    write_receipt(directory, result)
+
+
+if __name__ == "__main__":
+    run(sys.argv[sys.argv.index("--") + 1])

--- a/src/dcc_mcp_blender/_multiview_worker.py
+++ b/src/dcc_mcp_blender/_multiview_worker.py
@@ -11,17 +11,22 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _multiview_receipt import png_evidence, read_receipt, write_receipt  # noqa: E402
 
 
-def prepare_wire(scene, radius):
+def prepare_wire(scene, radius, max_source_edges=100000):
     import bpy
 
     surface = bpy.data.materials.new("DCC Wire Surface")
     surface.diffuse_color = (0.65, 0.68, 0.72, 1)
     line = bpy.data.materials.new("DCC Source Mesh Edges")
     line.diffuse_color = (0.015, 0.02, 0.03, 1)
+    for material in (surface, line):
+        material.use_nodes = True
+        shader = material.node_tree.nodes.get("Principled BSDF")
+        shader.inputs["Base Color"].default_value = material.diffuse_color
+        shader.inputs["Roughness"].default_value = 1
     objects = list(scene.objects)
     edge_count = sum(len(obj.data.edges) for obj in objects if obj.type == "MESH" and not obj.hide_render)
-    if edge_count > 100000:
-        raise ValueError("Wire pass exceeds 100000 source edges")
+    if type(max_source_edges) is not int or not 1 <= max_source_edges <= 500000 or edge_count > max_source_edges:
+        raise ValueError("Wire pass exceeds its bounded source edge budget")
     for obj in objects:
         if obj.type != "MESH":
             if obj.type not in {"CAMERA", "LIGHT"}:
@@ -55,17 +60,19 @@ def prepare_wire(scene, radius):
         for collection in obj.users_collection:
             collection.objects.link(overlay)
         overlay.matrix_world = obj.matrix_world.copy()
-    scene.render.engine = "BLENDER_WORKBENCH"
-    shading = scene.display.shading
-    shading.light = "STUDIO"
-    shading.color_type = "MATERIAL"
-    shading.show_shadows = True
-    shading.show_cavity = False
-    shading.show_specular_highlight = False
-    shading.background_type = "WORLD"
+    # CPU ray tracing avoids requiring an OpenGL context on headless workers.
+    scene.render.engine = "CYCLES"
+    scene.cycles.device = "CPU"
+    scene.cycles.samples = 16
+    scene.cycles.use_denoising = False
     if scene.world is None:
         scene.world = bpy.data.worlds.new("DCC Wire World")
     scene.world.color = (0.15, 0.15, 0.15)
+    scene.world.use_nodes = True
+    background = scene.world.node_tree.nodes.get("Background")
+    if background is not None:
+        background.inputs["Color"].default_value = (0.6, 0.6, 0.6, 1)
+        background.inputs["Strength"].default_value = 1
     return edge_count
 
 
@@ -93,7 +100,11 @@ def run(directory):
                 raise ValueError("Camera missing in the saved scene")
             scene.camera = camera
             if item["pass"] == "wire":
-                item["source_edge_count"] = prepare_wire(scene, request["wire_radius"])
+                item["source_edge_count"] = prepare_wire(
+                    scene, request["wire_radius"], request.get("max_source_edges", 100000)
+                )
+            if scene.render.engine == "CYCLES":
+                scene.cycles.device = "CPU"
             scene.render.resolution_x = request["resolution_x"]
             scene.render.resolution_y = request["resolution_y"]
             scene.render.resolution_percentage = 100

--- a/src/dcc_mcp_blender/_multiview_worker.py
+++ b/src/dcc_mcp_blender/_multiview_worker.py
@@ -15,9 +15,9 @@ def prepare_wire(scene, radius, max_source_edges=100000):
     import bpy
 
     surface = bpy.data.materials.new("DCC Wire Surface")
-    surface.diffuse_color = (0.65, 0.68, 0.72, 1)
+    surface.diffuse_color = (0.35, 0.38, 0.42, 1)
     line = bpy.data.materials.new("DCC Source Mesh Edges")
-    line.diffuse_color = (0.015, 0.02, 0.03, 1)
+    line.diffuse_color = (0.008, 0.008, 0.008, 1)
     for material in (surface, line):
         material.use_nodes = True
         shader = material.node_tree.nodes.get("Principled BSDF")
@@ -29,7 +29,7 @@ def prepare_wire(scene, radius, max_source_edges=100000):
         raise ValueError("Wire pass exceeds its bounded source edge budget")
     for obj in objects:
         if obj.type != "MESH":
-            if obj.type not in {"CAMERA", "LIGHT"}:
+            if obj.type != "CAMERA":
                 obj.hide_render = True
             continue
         if obj.hide_render:
@@ -63,10 +63,9 @@ def prepare_wire(scene, radius, max_source_edges=100000):
     # CPU ray tracing avoids requiring an OpenGL context on headless workers.
     scene.render.engine = "CYCLES"
     scene.cycles.device = "CPU"
-    scene.cycles.samples = 16
-    scene.cycles.use_denoising = False
-    if scene.world is None:
-        scene.world = bpy.data.worlds.new("DCC Wire World")
+    scene.cycles.samples = 64
+    scene.cycles.use_denoising = True
+    scene.world = bpy.data.worlds.new("DCC Wire World")
     scene.world.color = (0.15, 0.15, 0.15)
     scene.world.use_nodes = True
     background = scene.world.node_tree.nodes.get("Background")

--- a/src/dcc_mcp_blender/_render_job_ops.py
+++ b/src/dcc_mcp_blender/_render_job_ops.py
@@ -30,7 +30,7 @@ def _launch_worker(command, directory, stdout_path, stderr_path):
     # Blender may report its relative launch path on macOS. Resolve it before
     # Popen switches cwd to the output directory; bare PATH commands stay bare.
     executable = Path(command[0])
-    if executable.parent != Path("."):
+    if os.sep in command[0] or (os.altsep and os.altsep in command[0]):
         command[0] = str(executable.resolve())
     env = os.environ.copy()
     env["DCC_MCP_BACKGROUND_RENDER"] = "1"

--- a/src/dcc_mcp_blender/_render_job_ops.py
+++ b/src/dcc_mcp_blender/_render_job_ops.py
@@ -25,6 +25,18 @@ _JOBS: Dict[str, Dict[str, Any]] = {}
 _LOCK = threading.Lock()
 
 
+def _launch_worker(command, directory, stdout_path, stderr_path):
+    env = os.environ.copy()
+    env["DCC_MCP_BACKGROUND_RENDER"] = "1"
+    popen_kwargs = {"env": env, "cwd": str(directory)}
+    if os.name == "nt":
+        popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
+    else:
+        popen_kwargs["start_new_session"] = True
+    with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
+        return subprocess.Popen(command, stdout=stdout, stderr=stderr, **popen_kwargs)
+
+
 def _output_format_spec(output_format: str) -> Tuple[str, bytes]:
     name = str(output_format).strip().upper()
     try:
@@ -169,15 +181,7 @@ def start_render_job(
                 factory_startup=factory_startup,
                 output_format=output_format,
             )
-            env = os.environ.copy()
-            env["DCC_MCP_BACKGROUND_RENDER"] = "1"
-            popen_kwargs: Dict[str, Any] = {"env": env, "cwd": str(output_dir)}
-            if os.name == "nt":
-                popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
-            else:
-                popen_kwargs["start_new_session"] = True
-            with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
-                process = subprocess.Popen(command, stdout=stdout, stderr=stderr, **popen_kwargs)
+            process = _launch_worker(command, output_dir, stdout_path, stderr_path)
 
         job = {
             "job_id": job_id,
@@ -204,19 +208,37 @@ def start_render_job(
         return skill_exception(exc, message="Failed to start background render job")
 
 
-def get_render_job(job_id: str) -> dict:
+def get_render_job(job_id: str, job_directory: str = None) -> dict:
     with _LOCK:
         job = _JOBS.get(job_id)
     if job is None:
-        return skill_error("Render job not found", "Unknown job_id: {}".format(job_id))
-    return skill_success("Render job status", **_job_context(job))
+        if job_directory is None:
+            return skill_error("Render job not found", "Unknown job_id: {}".format(job_id))
+        job = dict(job_id=job_id, kind="multiview", job_directory=job_directory)
+    try:
+        return skill_success("Render job status", **_job_context(job))
+    except (OSError, ValueError, KeyError) as exc:
+        return skill_error("Render receipt unavailable", str(exc))
 
 
-def cancel_render_job(job_id: str) -> dict:
+def cancel_render_job(job_id: str, job_directory: str = None) -> dict:
     with _LOCK:
         job = _JOBS.get(job_id)
     if job is None:
-        return skill_error("Render job not found", "Unknown job_id: {}".format(job_id))
+        if job_directory is None:
+            return skill_error("Render job not found", "Unknown job_id: {}".format(job_id))
+        job = dict(job_id=job_id, kind="multiview", job_directory=job_directory)
+    if job.get("kind") == "multiview":
+        from dcc_mcp_blender._multiview_receipt import TERMINAL, multiview_context
+
+        try:
+            context = multiview_context(job)
+            if context["status"] not in TERMINAL:
+                (Path(job["job_directory"]) / "cancel").touch()
+                context["cancellation_requested"] = True
+            return skill_success("Multiview cancellation requested at the next image boundary", **context)
+        except (OSError, ValueError, KeyError) as exc:
+            return skill_error("Render receipt unavailable", str(exc))
     _job_context(job)
     if job["status"] not in {"completed", "failed", "cancelled"}:
         process = job.get("process")
@@ -227,6 +249,10 @@ def cancel_render_job(job_id: str) -> dict:
 
 
 def _job_context(job: Dict[str, Any]) -> Dict[str, Any]:
+    if job.get("kind") == "multiview":
+        from dcc_mcp_blender._multiview_receipt import multiview_context
+
+        return multiview_context(job)
     process = job.get("process")
     output_format = str(job.get("output_format", "OPEN_EXR_MULTILAYER")).strip().upper()
     _output_format_spec(output_format)

--- a/src/dcc_mcp_blender/_render_job_ops.py
+++ b/src/dcc_mcp_blender/_render_job_ops.py
@@ -26,6 +26,12 @@ _LOCK = threading.Lock()
 
 
 def _launch_worker(command, directory, stdout_path, stderr_path):
+    command = list(command)
+    # Blender may report its relative launch path on macOS. Resolve it before
+    # Popen switches cwd to the output directory; bare PATH commands stay bare.
+    executable = Path(command[0])
+    if executable.parent != Path("."):
+        command[0] = str(executable.resolve())
     env = os.environ.copy()
     env["DCC_MCP_BACKGROUND_RENDER"] = "1"
     popen_kwargs = {"env": env, "cwd": str(directory)}

--- a/src/dcc_mcp_blender/_uv_ops.py
+++ b/src/dcc_mcp_blender/_uv_ops.py
@@ -464,6 +464,11 @@ def project_uvs(object_name: str, method: str = "planar", axis: str = "z", margi
             after_uv = _mesh_uv_context(obj)
             if "FINISHED" not in operator_result:
                 return _uv_operator_failed(object_name, "UV projection", operator_result, before_uv, after_uv)
+            # Edit/Object mode transitions can replace CustomData storage.
+            # Never dereference the pre-operator MeshUVLoopLayer RNA proxy.
+            layer = _get_uv_layer(obj.data)
+            if layer is None:
+                raise RuntimeError("UV layer unavailable after projection")
             return skill_success(
                 f"Projected UVs on {object_name} using {method_key}",
                 uv_map=layer.name,
@@ -566,6 +571,9 @@ def unwrap_uvs(object_name: str, method: str = "angle_based", margin: float = 0.
         after_uv = _mesh_uv_context(obj)
         if "FINISHED" not in operator_result:
             return _uv_operator_failed(object_name, "UV unwrap", operator_result, before_uv, after_uv)
+        layer = _get_uv_layer(obj.data)
+        if layer is None:
+            raise RuntimeError("UV layer unavailable after unwrap")
         return skill_success(
             f"Unwrapped UVs on {object_name} using {method_key}",
             uv_map=layer.name,
@@ -611,6 +619,9 @@ def pack_uvs(
             margin=float(margin),
             rotate=bool(rotate),
         )
+        layer = _get_uv_layer(obj.data)
+        if layer is None:
+            raise RuntimeError("UV layer unavailable after packing")
         if normalize:
             normalize_result = _normalize_layer(layer, float(margin))
         else:

--- a/src/dcc_mcp_blender/skills/blender-render/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-render/SKILL.md
@@ -45,7 +45,7 @@ Use `start_multiview_render_job` for a bounded camera list (up to 8) and
 scene without changing the live filename, selection, materials, or settings.
 The worker uses factory startup with automatic scripts disabled. External
 assets must remain accessible; add-on-generated render dependencies are not
-loaded. Beauty uses the saved render engine but bypasses compositor and
+loaded. Beauty uses the saved render engine (Cycles uses CPU) but bypasses compositor and
 sequencer to contain file output. Resolution is explicit and border rendering
 is disabled. Cameras render the current saved frame; camera animation markers
 are not used to select views.
@@ -54,7 +54,7 @@ Wire shows original mesh edges as physical tubes over the same unmodified
 mesh surfaces. Modifiers and shape keys are disabled, non-mesh geometry is omitted, and
 hidden render objects remain hidden. This is source topology, not evaluated
 modifier topology or a screen-space overlay. Radius is in local object units
-and scales with the object. Requests exceeding 100,000 source edges are
+and scales with the object. The wire pass uses Cycles CPU. Requests exceeding the explicit max_source_edges budget (default 100,000; maximum 500,000) are
 rejected. Each PNG is decoded by Blender, dimension checked, and hashed;
 status reads verify the entire file hash. Failed images retain individual
 errors and do not make the batch successful.

--- a/src/dcc_mcp_blender/skills/blender-render/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-render/SKILL.md
@@ -39,3 +39,30 @@ Use `render_scene` for short stills. Use `start_render_job` for animation or
 multi-layer EXR or display-ready PNG output so the interactive Blender process
 remains responsive; poll with `get_render_job` and cancel only through the
 returned job id.
+
+Use `start_multiview_render_job` for a bounded camera list (up to 8) and
+`beauty`/`wire` PNG deliverables. It saves an isolated copy of the current
+scene without changing the live filename, selection, materials, or settings.
+The worker uses factory startup with automatic scripts disabled. External
+assets must remain accessible; add-on-generated render dependencies are not
+loaded. Beauty uses the saved render engine but bypasses compositor and
+sequencer to contain file output. Resolution is explicit and border rendering
+is disabled. Cameras render the current saved frame; camera animation markers
+are not used to select views.
+
+Wire shows original mesh edges as physical tubes over the same unmodified
+mesh surfaces. Modifiers and shape keys are disabled, non-mesh geometry is omitted, and
+hidden render objects remain hidden. This is source topology, not evaluated
+modifier topology or a screen-space overlay. Radius is in local object units
+and scales with the object. Requests exceeding 100,000 source edges are
+rejected. Each PNG is decoded by Blender, dimension checked, and hashed;
+status reads verify the entire file hash. Failed images retain individual
+errors and do not make the batch successful.
+
+Poll using the existing `get_render_job(job_id)` and retain `job_directory`.
+After an adapter restart, `get_render_job(job_id, job_directory)` recovers
+terminal receipts; a nonterminal receipt returns `unknown` with its last
+recorded state because no live process handle has been observed. No PID from
+a disk file is trusted. Multiview cancellation writes an owned marker and
+is cooperative between images; it cannot interrupt an in-progress render.
+`cancel_render_job` accepts `job_directory` for the same recovery case.

--- a/src/dcc_mcp_blender/skills/blender-render/scripts/start_multiview_render_job.py
+++ b/src/dcc_mcp_blender/skills/blender-render/scripts/start_multiview_render_job.py
@@ -1,0 +1,10 @@
+"""Submit a bounded multiview render in an isolated Blender worker."""
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._multiview_ops import start_multiview_render_job
+
+
+@skill_entry
+def main(**kwargs):
+    return start_multiview_render_job(**kwargs)

--- a/src/dcc_mcp_blender/skills/blender-render/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-render/tools.yaml
@@ -223,6 +223,7 @@ tools:
         resolution_x: {type: integer, minimum: 16, maximum: 4096, default: 1200}
         resolution_y: {type: integer, minimum: 16, maximum: 4096, default: 1200}
         wire_radius: {type: number, exclusiveMinimum: 0, maximum: 1, default: 0.008, description: Source mesh edge tube radius in local object units.}
+        max_source_edges: {type: integer, minimum: 1, maximum: 500000, default: 100000, description: Explicit source edge budget checked before submission and again in the worker.}
     output_schema:
       type: object
       required: [success]

--- a/src/dcc_mcp_blender/skills/blender-render/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-render/tools.yaml
@@ -167,8 +167,12 @@ tools:
         job_id:
           type: string
           minLength: 1
+        job_directory:
+          type: string
+          minLength: 1
+          description: Absolute multiview job directory for receipt recovery after restart; nonterminal liveness is unknown.
   - name: cancel_render_job
-    description: "Cancel the owned background Blender process tree for a render job; repeated cancellation is safe."
+    description: "Cancel an owned animation worker, or request multiview cancellation between images; repeated cancellation is safe."
     source_file: scripts/cancel_render_job.py
     execution: sync
     affinity: any
@@ -183,3 +187,52 @@ tools:
         job_id:
           type: string
           minLength: 1
+        job_directory:
+          type: string
+          minLength: 1
+          description: Absolute multiview job directory for cooperative cancellation after restart; no PID is trusted from disk.
+  - name: start_multiview_render_job
+    description: "Render up to 8 cameras with beauty and/or real source-mesh wire edges in an isolated scene copy. PNG outputs have decoded dimensions and hashes. Beauty bypasses compositor/sequencer; wire ignores modifiers and non-mesh geometry."
+    source_file: scripts/start_multiview_render_job.py
+    execution: sync
+    job_strategy: isolated
+    affinity: main
+    enforce_thread_affinity: true
+    timeout_hint_secs: 120
+    read_only: false
+    destructive: false
+    idempotent: false
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [output_directory, camera_names]
+      properties:
+        output_directory: {type: string, minLength: 1, description: Absolute parent directory; a unique owned job subdirectory is created.}
+        camera_names:
+          type: array
+          minItems: 1
+          maxItems: 8
+          items: {type: string, minLength: 1}
+          description: Unique cameras in the current scene; renders its current frame.
+        passes:
+          type: array
+          minItems: 1
+          maxItems: 2
+          items: {type: string, enum: [beauty, wire]}
+          default: [beauty, wire]
+        resolution_x: {type: integer, minimum: 16, maximum: 4096, default: 1200}
+        resolution_y: {type: integer, minimum: 16, maximum: 4096, default: 1200}
+        wire_radius: {type: number, exclusiveMinimum: 0, maximum: 1, default: 0.008, description: Source mesh edge tube radius in local object units.}
+    output_schema:
+      type: object
+      required: [success]
+      properties:
+        success: {type: boolean}
+        context: {type: object}
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: false
+    next-tools:
+      on-success: [blender_render__get_render_job, blender_render__cancel_render_job]

--- a/tests/e2e/test_multiview_jobs_e2e.py
+++ b/tests/e2e/test_multiview_jobs_e2e.py
@@ -1,0 +1,95 @@
+"""Real isolated Blender multi-camera deliverables without source mutation."""
+
+import time
+
+import pytest
+
+bpy = pytest.importorskip("bpy")
+pytestmark = pytest.mark.e2e
+
+from dcc_mcp_blender._multiview_ops import start_multiview_render_job  # noqa: E402
+from dcc_mcp_blender._render_job_ops import get_render_job  # noqa: E402
+
+
+def test_multiview_images_and_source_topology(tmp_path):
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    bpy.ops.mesh.primitive_cube_add()
+    cube = bpy.context.active_object
+    cube.modifiers.new("Subdivision", "SUBSURF")
+    for name, position in [("Front", (4, -6, 3)), ("Side", (6, 2, 3))]:
+        data = bpy.data.cameras.new(name)
+        camera = bpy.data.objects.new(name, data)
+        bpy.context.scene.collection.objects.link(camera)
+        camera.location = position
+        camera.rotation_euler = (-camera.location).to_track_quat("-Z", "Y").to_euler()
+    scene = bpy.context.scene
+    scene.render.engine = "BLENDER_WORKBENCH"
+    scene.render.resolution_x = 333
+    before = (bpy.data.filepath, scene.render.resolution_x, cube.modifiers[0].show_render, len(bpy.data.objects))
+    result = start_multiview_render_job(str(tmp_path), ["Front", "Side"], resolution_x=64, resolution_y=64)
+    assert result["success"], result
+    job_id = result["context"]["job_id"]
+    directory = result["context"]["job_directory"]
+    deadline = time.monotonic() + 120
+    while time.monotonic() < deadline:
+        context = get_render_job(job_id)["context"]
+        if context["status"] in {"completed", "failed", "cancelled"}:
+            break
+        time.sleep(0.1)
+    assert context["status"] == "completed", context
+    assert len(context["items"]) == 4
+    assert all(item["image"]["width"] == 64 and item["image"]["height"] == 64 for item in context["items"])
+    assert all(item["source_edge_count"] == 12 for item in context["items"] if item["pass"] == "wire")
+    assert before == (
+        bpy.data.filepath,
+        scene.render.resolution_x,
+        cube.modifiers[0].show_render,
+        len(bpy.data.objects),
+    )
+    assert bpy.context.active_object == cube
+    from dcc_mcp_blender import _render_job_ops
+
+    del _render_job_ops._JOBS[job_id]
+    assert get_render_job(job_id, directory)["context"]["status"] == "completed"
+
+
+def test_worker_preserves_partial_failure(tmp_path):
+    import importlib.util
+    import json
+    from pathlib import Path
+
+    from dcc_mcp_blender import _render_job_ops
+    from dcc_mcp_blender._multiview_receipt import write_receipt
+
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    bpy.ops.mesh.primitive_cube_add()
+    bpy.ops.object.camera_add(location=(4, -6, 3))
+    camera = bpy.context.active_object
+    camera.rotation_euler = (-camera.location).to_track_quat("-Z", "Y").to_euler()
+    bpy.context.scene.render.engine = "BLENDER_WORKBENCH"
+    bpy.ops.wm.save_as_mainfile(filepath=str(tmp_path / "scene.blend"))
+    (tmp_path / "request.json").write_text(
+        json.dumps(dict(job_id="partial", resolution_x=32, resolution_y=32, wire_radius=0.01))
+    )
+    write_receipt(
+        tmp_path,
+        dict(
+            job_id="partial",
+            kind="multiview",
+            status="running",
+            items=[
+                {"camera": "Missing", "pass": "beauty", "status": "pending"},
+                {"camera": camera.name, "pass": "wire", "status": "pending"},
+            ],
+        ),
+    )
+    spec = importlib.util.spec_from_file_location(
+        "partial_worker", Path(_render_job_ops.__file__).with_name("_multiview_worker.py")
+    )
+    worker = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(worker)
+    worker.run(tmp_path)
+    result = get_render_job("partial", str(tmp_path))["context"]
+    assert result["status"] == "failed"
+    assert result["items"][0]["status"] == "failed"
+    assert result["items"][1]["status"] == "completed"

--- a/tests/e2e/test_multiview_jobs_e2e.py
+++ b/tests/e2e/test_multiview_jobs_e2e.py
@@ -23,7 +23,8 @@ def test_multiview_images_and_source_topology(tmp_path):
         camera.location = position
         camera.rotation_euler = (-camera.location).to_track_quat("-Z", "Y").to_euler()
     scene = bpy.context.scene
-    scene.render.engine = "BLENDER_WORKBENCH"
+    scene.render.engine = "CYCLES"
+    bpy.context.scene.cycles.samples = 1
     scene.render.resolution_x = 333
     before = (bpy.data.filepath, scene.render.resolution_x, cube.modifiers[0].show_render, len(bpy.data.objects))
     result = start_multiview_render_job(str(tmp_path), ["Front", "Side"], resolution_x=64, resolution_y=64)
@@ -54,7 +55,6 @@ def test_multiview_images_and_source_topology(tmp_path):
 
 
 def test_worker_preserves_partial_failure(tmp_path):
-    import importlib.util
     import json
     from pathlib import Path
 
@@ -66,7 +66,8 @@ def test_worker_preserves_partial_failure(tmp_path):
     bpy.ops.object.camera_add(location=(4, -6, 3))
     camera = bpy.context.active_object
     camera.rotation_euler = (-camera.location).to_track_quat("-Z", "Y").to_euler()
-    bpy.context.scene.render.engine = "BLENDER_WORKBENCH"
+    bpy.context.scene.render.engine = "CYCLES"
+    bpy.context.scene.cycles.samples = 1
     bpy.ops.wm.save_as_mainfile(filepath=str(tmp_path / "scene.blend"))
     (tmp_path / "request.json").write_text(
         json.dumps(dict(job_id="partial", resolution_x=32, resolution_y=32, wire_radius=0.01))
@@ -83,12 +84,24 @@ def test_worker_preserves_partial_failure(tmp_path):
             ],
         ),
     )
-    spec = importlib.util.spec_from_file_location(
-        "partial_worker", Path(_render_job_ops.__file__).with_name("_multiview_worker.py")
+    worker_path = Path(_render_job_ops.__file__).with_name("_multiview_worker.py")
+    process = _render_job_ops._launch_worker(
+        [
+            bpy.app.binary_path,
+            "--background",
+            "--factory-startup",
+            "--python-exit-code",
+            "1",
+            "--python",
+            str(worker_path),
+            "--",
+            str(tmp_path),
+        ],
+        tmp_path,
+        tmp_path / "stdout.log",
+        tmp_path / "stderr.log",
     )
-    worker = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(worker)
-    worker.run(tmp_path)
+    assert process.wait(timeout=120) == 0, (tmp_path / "stderr.log").read_text()
     result = get_render_job("partial", str(tmp_path))["context"]
     assert result["status"] == "failed"
     assert result["items"][0]["status"] == "failed"

--- a/tests/test_multiview_jobs.py
+++ b/tests/test_multiview_jobs.py
@@ -150,12 +150,13 @@ def test_source_edge_budget_is_validated(tmp_path, monkeypatch, budget):
     bpy.ops.wm.save_as_mainfile.assert_not_called()
 
 
-def test_worker_resolves_relative_executable_before_changing_cwd(tmp_path, monkeypatch):
+@pytest.mark.parametrize("executable", ["cache/Blender.app/Blender", "./Blender"])
+def test_worker_resolves_relative_executable_before_changing_cwd(tmp_path, monkeypatch, executable):
     monkeypatch.chdir(tmp_path)
     popen = MagicMock()
     monkeypatch.setattr(jobs.subprocess, "Popen", popen)
     output = tmp_path / "output"
     output.mkdir()
-    jobs._launch_worker(["cache/Blender.app/Blender", "--background"], output, output / "out", output / "err")
-    assert popen.call_args.args[0][0] == str((tmp_path / "cache/Blender.app/Blender").resolve())
+    jobs._launch_worker([executable, "--background"], output, output / "out", output / "err")
+    assert popen.call_args.args[0][0] == str((tmp_path / executable).resolve())
     assert popen.call_args.kwargs["cwd"] == str(output)

--- a/tests/test_multiview_jobs.py
+++ b/tests/test_multiview_jobs.py
@@ -148,3 +148,14 @@ def test_source_edge_budget_is_validated(tmp_path, monkeypatch, budget):
     result = start_multiview_render_job(str(tmp_path), ["Camera"], max_source_edges=budget)
     assert not result["success"]
     bpy.ops.wm.save_as_mainfile.assert_not_called()
+
+
+def test_worker_resolves_relative_executable_before_changing_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    popen = MagicMock()
+    monkeypatch.setattr(jobs.subprocess, "Popen", popen)
+    output = tmp_path / "output"
+    output.mkdir()
+    jobs._launch_worker(["cache/Blender.app/Blender", "--background"], output, output / "out", output / "err")
+    assert popen.call_args.args[0][0] == str((tmp_path / "cache/Blender.app/Blender").resolve())
+    assert popen.call_args.kwargs["cwd"] == str(output)

--- a/tests/test_multiview_jobs.py
+++ b/tests/test_multiview_jobs.py
@@ -134,3 +134,17 @@ def test_corrupt_earlier_image_does_not_claim_running_worker_stopped(tmp_path):
     context = multiview_context(dict(job_id="test", job_directory=str(tmp_path), process=process))
     assert context["status"] == "running"
     assert context["items"][0]["status"] == "failed"
+
+
+@pytest.mark.parametrize("budget", [0, 500001, True, 1.5])
+def test_source_edge_budget_is_validated(tmp_path, monkeypatch, budget):
+    import sys
+
+    from dcc_mcp_blender._multiview_ops import start_multiview_render_job
+
+    bpy = MagicMock()
+    bpy.context.scene.objects.get.return_value.type = "CAMERA"
+    monkeypatch.setitem(sys.modules, "bpy", bpy)
+    result = start_multiview_render_job(str(tmp_path), ["Camera"], max_source_edges=budget)
+    assert not result["success"]
+    bpy.ops.wm.save_as_mainfile.assert_not_called()

--- a/tests/test_multiview_jobs.py
+++ b/tests/test_multiview_jobs.py
@@ -1,0 +1,136 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from dcc_mcp_blender import _render_job_ops as jobs
+from dcc_mcp_blender._multiview_receipt import multiview_context, png_evidence, write_receipt
+
+
+def receipt(tmp_path, status="running"):
+    result = dict(
+        job_id="test",
+        kind="multiview",
+        status=status,
+        items=[{"camera": "Camera", "pass": "beauty", "status": "pending"}],
+    )
+    write_receipt(tmp_path, result)
+    return result
+
+
+def test_recovery_does_not_claim_live_worker(tmp_path):
+    receipt(tmp_path)
+    result = jobs.get_render_job("test", str(tmp_path))
+    assert result["success"]
+    assert result["context"]["status"] == "unknown"
+    assert result["context"]["last_recorded_status"] == "running"
+    assert result["context"]["process_observed"] is False
+
+
+def test_cancel_recovered_job_does_not_kill_pid(tmp_path, monkeypatch):
+    receipt(tmp_path)
+    kill = MagicMock()
+    monkeypatch.setattr(jobs, "_terminate_process_tree", kill)
+    result = jobs.cancel_render_job("test", str(tmp_path))
+    assert result["success"]
+    assert result["context"]["cancellation_requested"]
+    assert (tmp_path / "cancel").is_file()
+    kill.assert_not_called()
+
+
+def test_wrong_receipt_identity_is_rejected(tmp_path):
+    receipt(tmp_path)
+    assert not jobs.get_render_job("other", str(tmp_path))["success"]
+    assert not jobs.cancel_render_job("other", str(tmp_path))["success"]
+    assert not (tmp_path / "cancel").exists()
+
+
+def test_worker_crash_marks_unfinished_items_failed(tmp_path):
+    receipt(tmp_path)
+    process = MagicMock()
+    process.poll.return_value = 2
+    result = multiview_context(dict(job_id="test", job_directory=str(tmp_path), process=process))
+    assert result["status"] == "failed"
+    assert result["items"][0]["status"] == "failed"
+    assert jobs.get_render_job("test", str(tmp_path))["context"]["status"] == "failed"
+
+
+def test_completed_output_is_rechecked_not_just_file_exists(tmp_path):
+    result = receipt(tmp_path, "completed")
+    # Receipt verification hashes the worker-decoded PNG, not only its magic.
+    path = tmp_path / "00_beauty.png"
+    path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\0\0\0\rIHDR" + (16).to_bytes(4, "big") * 2 + b"original")
+    result["items"][0].update(status="completed", image=png_evidence(path))
+    write_receipt(tmp_path, result)
+    path.write_bytes(path.read_bytes()[:-1] + b"X")
+    result = jobs.get_render_job("test", str(tmp_path))["context"]
+    assert result["status"] == "failed"
+    assert result["items"][0]["status"] == "failed"
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("camera_names", []),
+        ("camera_names", ["A"] * 9),
+        ("passes", ["wire", "wire"]),
+        ("resolution_x", 4097),
+        ("wire_radius", float("nan")),
+    ],
+)
+def test_preflight_rejects_invalid_arguments_before_saving(tmp_path, monkeypatch, field, value):
+    from dcc_mcp_blender._multiview_ops import start_multiview_render_job
+
+    bpy = MagicMock()
+    monkeypatch.setitem(__import__("sys").modules, "bpy", bpy)
+    args = dict(output_directory=str(tmp_path), camera_names=["A"])
+    args[field] = value
+    assert not start_multiview_render_job(**args)["success"]
+    bpy.ops.wm.save_as_mainfile.assert_not_called()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_wire_contract_is_discoverable():
+    from pathlib import Path
+
+    import yaml
+
+    root = Path(__file__).resolve().parents[1] / "src/dcc_mcp_blender/skills/blender-render"
+    contracts = {tool["name"]: tool for tool in yaml.safe_load((root / "tools.yaml").read_text())["tools"]}
+    contract = contracts["start_multiview_render_job"]
+    assert contract["job_strategy"] == "isolated"
+    assert contract["affinity"] == "main"
+    assert contract["input_schema"]["properties"]["camera_names"]["maxItems"] == 8
+    assert "job_directory" in contracts["get_render_job"]["input_schema"]["properties"]
+    assert "job_directory" in contracts["cancel_render_job"]["input_schema"]["properties"]
+
+
+def test_worker_observes_cancel_before_first_image(tmp_path, monkeypatch):
+    import importlib.util
+    import sys
+    from pathlib import Path
+
+    path = Path(jobs.__file__).with_name("_multiview_worker.py")
+    spec = importlib.util.spec_from_file_location("test_multiview_worker", path)
+    worker = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(worker)
+    receipt(tmp_path)
+    (tmp_path / "request.json").write_text('{"job_id":"test"}')
+    (tmp_path / "cancel").touch()
+    bpy = MagicMock()
+    monkeypatch.setitem(sys.modules, "bpy", bpy)
+    worker.run(tmp_path)
+    result = jobs.get_render_job("test", str(tmp_path))["context"]
+    assert result["status"] == "cancelled"
+    assert result["items"][0]["status"] == "cancelled"
+    bpy.ops.wm.open_mainfile.assert_not_called()
+
+
+def test_corrupt_earlier_image_does_not_claim_running_worker_stopped(tmp_path):
+    result = receipt(tmp_path)
+    result["items"][0].update(status="completed", image={})
+    write_receipt(tmp_path, result)
+    process = MagicMock()
+    process.poll.return_value = None
+    context = multiview_context(dict(job_id="test", job_directory=str(tmp_path), process=process))
+    assert context["status"] == "running"
+    assert context["items"][0]["status"] == "failed"

--- a/tests/test_skills_uv_ops.py
+++ b/tests/test_skills_uv_ops.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
 import yaml
 
 from tests.conftest import load_and_call, make_mock_bpy
@@ -128,6 +129,37 @@ def _bpy_for(obj):
     bpy.ops.uv.smart_project.return_value = {"FINISHED"}
     bpy.ops.uv.pack_islands.return_value = {"FINISHED"}
     return bpy
+
+
+@pytest.mark.parametrize("tool", ["unwrap_uvs", "project_uvs", "pack_uvs"])
+def test_uv_operator_reacquires_layer_after_edit_mode_invalidates_rna(tool):
+    class ExpiringLayer(FakeUVLayer):
+        expired = False
+
+        def __getattribute__(self, name):
+            if name in {"name", "data"} and self.expired:
+                raise ReferenceError("UV RNA storage was replaced by mode transition")
+            return super().__getattribute__(name)
+
+    obj = _mesh_obj()
+    old_layer = ExpiringLayer("Original", len(obj.data.loops))
+    obj.data.uv_layers = FakeUVLayers(len(obj.data.loops), [old_layer])
+    bpy = _bpy_for(obj)
+
+    def mode_set(mode):
+        if mode == "OBJECT":
+            old_layer.expired = True
+            fresh = FakeUVLayer("Fresh", len(obj.data.loops), [(2, 2), (4, 2), (4, 4), (2, 4)])
+            obj.data.uv_layers = FakeUVLayers(len(obj.data.loops), [fresh])
+        return {"FINISHED"}
+
+    bpy.ops.object.mode_set.side_effect = mode_set
+    arguments = {} if tool == "pack_uvs" else {"method": "smart"}
+    result = load_and_call("blender-uv-ops/scripts/{}.py".format(tool), bpy, object_name=obj.name, **arguments)
+    assert result["success"], result
+    assert result["context"]["uv_map"] == "Fresh"
+    if tool == "pack_uvs":
+        assert result["context"]["normalized_coordinate_count"] == 4
 
 
 def test_tools_yaml_declares_modern_contract():


### PR DESCRIPTION
Adds bounded camera × beauty/wire jobs through the existing render job registry. Isolated workers preserve the source scene, report each image independently, verify decoded PNGs and hashes, support cooperative cancellation, and recover recorded results after restart. Wire output shows source mesh edges with explicit edge budgets and neutral CPU rendering.

Also fixes relative Blender worker paths and stale UV-layer handles after mode changes found by cross-platform E2E testing. Compositor/sequencer output is intentionally excluded from these presentation jobs.

Validation: 608 tests passed; 7 related Blender 5.1.1 E2E tests passed; Ruff and skill lint passed. A 219,995-edge architectural scene produced verified beauty and wire outputs without reducing topology.
