### PR TITLE
feat: add bounded UV quality audit and layout export

### DIFF
--- a/src/dcc_mcp_blender/_uv_quality.py
+++ b/src/dcc_mcp_blender/_uv_quality.py
@@ -1,0 +1,342 @@
+"""Bounded, read-only source-mesh UV inspection and SVG delivery.
+
+No selection, mode, active-map, or coordinate writes. Mesh tessellation only
+refreshes Blender's derived triangle cache. Edit-mode data is rejected rather
+than implicitly flushing it or auditing a stale object-mode copy.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from pathlib import Path
+from xml.etree import ElementTree
+from xml.sax.saxutils import escape
+
+from dcc_mcp_core.skill import skill_exception, skill_success
+
+
+def _integer(value, label, low, high):
+    if type(value) is not int or not low <= value <= high:
+        raise ValueError("{} must be an integer in [{}, {}]".format(label, low, high))
+
+
+def _objects(object_names, uv_map, max_triangles):
+    import bpy
+
+    if not isinstance(object_names, list) or not 1 <= len(object_names) <= 4096:
+        raise ValueError("object_names must contain 1 to 4096 unique mesh names")
+    if any(not isinstance(n, str) or not n.strip() for n in object_names):
+        raise ValueError("object_names must contain non-empty strings")
+    if len(set(object_names)) != len(object_names):
+        raise ValueError("object_names must be unique")
+    if uv_map is not None and (not isinstance(uv_map, str) or not uv_map.strip()):
+        raise ValueError("uv_map must be null (active per object) or a non-empty name")
+    _integer(max_triangles, "max_triangles", 1, 200000)
+    objects = []
+    for name in object_names:
+        obj = bpy.data.objects.get(name)
+        if obj is None or obj.type != "MESH":
+            raise ValueError("Mesh object not found: {}".format(name))
+        if obj.mode != "OBJECT":
+            raise ValueError("Object must be in OBJECT mode: {}".format(name))
+        objects.append(obj)
+    return objects
+
+
+def _cross(a, b, c):
+    return (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])
+
+
+def _area(points):
+    if len(points) < 3:
+        return 0.0
+    origin = points[0]
+    return abs(sum(_cross(origin, points[i], points[i + 1]) for i in range(1, len(points) - 1))) * 0.5
+
+
+def _intersection_area(first, second):
+    """Convex clipping; positive area excludes edge/point-only contact."""
+    clip = second if _cross(*second) > 0 else tuple(reversed(second))
+    polygon = list(first)
+    for a, b in zip(clip, clip[1:] + clip[:1]):
+        if not polygon:
+            return 0.0
+        output = []
+        previous = polygon[-1]
+        previous_side = _cross(a, b, previous)
+        for point in polygon:
+            side = _cross(a, b, point)
+            if (side >= 0) != (previous_side >= 0):
+                ratio = previous_side / (previous_side - side)
+                output.append(tuple(previous[i] + ratio * (point[i] - previous[i]) for i in range(2)))
+            if side >= 0:
+                output.append(point)
+            previous, previous_side = point, side
+        polygon = output
+    return _area(polygon)
+
+
+def _extract(obj, uv_map, remaining):
+    mesh = obj.data
+    layer = mesh.uv_layers.get(uv_map) if uv_map else mesh.uv_layers.active
+    row = {
+        "object_name": obj.name,
+        "uv_map": layer.name if layer else None,
+        "polygon_count": len(mesh.polygons),
+        "complete": True,
+        "issues": {},
+    }
+    if layer is None:
+        row["issues"]["missing_uv_map"] = 1
+        return row, [], 0
+    # Conservative O(1) bound: sum(n - 2) for valid mesh polygons.
+    estimate = max(0, len(mesh.loops) - 2 * len(mesh.polygons))
+    if estimate > remaining:
+        row.update(complete=False, incomplete_reason="triangle_budget", estimated_triangles=estimate)
+        return row, [], 0
+    mesh.calc_loop_triangles()
+    if len(mesh.loop_triangles) > remaining:
+        row.update(complete=False, incomplete_reason="triangle_budget")
+        return row, [], 0
+    triangles = []
+    missing_faces = set()
+    for tri in mesh.loop_triangles:
+        if any(i >= len(layer.data) for i in tri.loops):
+            missing_faces.add(tri.polygon_index)
+            continue
+        points = tuple(tuple(float(c) for c in layer.data[i].uv) for i in tri.loops)
+        triangles.append((tri.polygon_index, points))
+    if missing_faces:
+        row["issues"]["uncovered_faces"] = len(missing_faces)
+    if not mesh.polygons:
+        row["issues"]["empty_mesh"] = 1
+    return row, triangles, len(mesh.loop_triangles)
+
+
+def audit_uv_layout(
+    object_names,
+    uv_map=None,
+    tile_policy="unit",
+    check_overlap=True,
+    overlap_scope="per_object",
+    allow_stacked=False,
+    max_triangles=50000,
+    max_pair_tests=200000,
+    max_report_items=100,
+    area_epsilon=1e-10,
+):
+    """Audit requested source meshes; budgets never produce a false pass.
+
+    Overlap counts are triangle pairs (including folded triangles of one face).
+    allow_stacked permits exact coincident triangles, including reversed winding,
+    not arbitrary partial overlap. UDIM means U in [0,10], V >= 0; it does not
+    assert that a face stays inside a single tile. Epsilon is in UV area units.
+    """
+    try:
+        _integer(max_pair_tests, "max_pair_tests", 1, 2000000)
+        _integer(max_report_items, "max_report_items", 0, 1000)
+        if any(type(v) is not bool for v in (check_overlap, allow_stacked)):
+            raise ValueError("check_overlap and allow_stacked must be booleans")
+        if tile_policy not in ("unit", "udim", "unrestricted") or overlap_scope not in ("per_object", "selection"):
+            raise ValueError("Invalid tile_policy or overlap_scope")
+        if isinstance(area_epsilon, bool) or not isinstance(area_epsilon, (int, float)):
+            raise ValueError("area_epsilon must be a finite positive number")
+        if not math.isfinite(area_epsilon) or not 0 < area_epsilon <= 0.0001:
+            raise ValueError("area_epsilon must be in (0, 0.0001]")
+        objects = _objects(object_names, uv_map, max_triangles)
+        rows, details, valid = [], [], []
+        consumed, pair_tests, stacked = 0, 0, 0
+
+        def issue(index, kind, face=None, other=None):
+            counts = rows[index]["issues"]
+            counts[kind] = counts.get(kind, 0) + 1
+            if len(details) < max_report_items:
+                details.append(
+                    {"object_name": rows[index]["object_name"], "kind": kind, "face_index": face, "other": other}
+                )
+
+        for obj in objects:
+            row, triangles, used = _extract(obj, uv_map, max_triangles - consumed)
+            index = len(rows)
+            rows.append(row)
+            consumed += used
+            row["triangles_checked"] = used
+            for face, points in triangles:
+                # Limit coordinates to keep all cross products finite in double precision.
+                if any(not math.isfinite(c) or abs(c) > 1e12 for p in points for c in p):
+                    issue(index, "invalid_coordinates", face)
+                    continue
+                if _area(points) <= area_epsilon:
+                    issue(index, "degenerate_triangles", face)
+                    continue
+                if tile_policy == "unit" and any(not 0 <= c <= 1 for p in points for c in p):
+                    issue(index, "out_of_tile_triangles", face)
+                elif tile_policy == "udim" and any(not 0 <= p[0] <= 10 or p[1] < 0 for p in points):
+                    issue(index, "out_of_tile_triangles", face)
+                if check_overlap:
+                    xs, ys = zip(*points)
+                    valid.append((index, face, points, (min(xs), max(xs), min(ys), max(ys))))
+        overlap_complete = True
+        groups = {}
+        for tri in valid:
+            groups.setdefault(tri[0] if overlap_scope == "per_object" else 0, []).append(tri)
+        for group in groups.values():
+            group.sort(key=lambda t: t[3][0])
+            for i, first in enumerate(group):
+                for j in range(i + 1, len(group)):
+                    second = group[j]
+                    if second[3][0] >= first[3][1]:
+                        break
+                    if pair_tests >= max_pair_tests:
+                        overlap_complete = False
+                        break
+                    pair_tests += 1
+                    if second[3][2] >= first[3][3] or second[3][3] <= first[3][2]:
+                        continue
+                    if _intersection_area(first[2], second[2]) > area_epsilon:
+                        if allow_stacked and sorted(first[2]) == sorted(second[2]):
+                            stacked += 1
+                        else:
+                            issue(
+                                first[0],
+                                "overlap_pairs",
+                                first[1],
+                                {"object_name": rows[second[0]]["object_name"], "face_index": second[1]},
+                            )
+                if not overlap_complete:
+                    break
+            if not overlap_complete:
+                break
+        counts = Counter()
+        if not overlap_complete:
+            # Conservatively mark every overlap participant incomplete; do not
+            # suggest an object passed based only on its coordinate extraction.
+            for index in {tri[0] for tri in valid}:
+                rows[index]["complete"] = False
+                rows[index]["incomplete_reason"] = "overlap_budget"
+        for row in rows:
+            counts.update(row["issues"])
+        complete = overlap_complete and all(row["complete"] for row in rows)
+        return skill_success(
+            "UV audit {}".format("incomplete" if not complete else "finished"),
+            complete=complete,
+            passed=complete and not counts,
+            mutation_applied=False,
+            topology="source_mesh",
+            objects=rows,
+            issue_counts=dict(counts),
+            details=details,
+            details_truncated=sum(counts.values()) > len(details),
+            triangles_checked=consumed,
+            pair_tests=pair_tests,
+            overlap_complete=overlap_complete,
+            allowed_stacked_pairs=stacked,
+            checks={
+                "coordinates": True,
+                "degeneracy": True,
+                "tile_policy": tile_policy,
+                "overlap": check_overlap,
+                "overlap_scope": overlap_scope,
+                "allow_stacked": allow_stacked,
+            },
+            area_epsilon=area_epsilon,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="UV audit failed")
+
+
+def export_uv_layout(object_names, output_path, uv_map=None, resolution=2048, max_triangles=50000):
+    """Export actual polygon UV edges to a new SVG, one labelled panel per object."""
+    try:
+        _integer(resolution, "resolution", 256, 8192)
+        objects = _objects(object_names, uv_map, max_triangles)
+        if len(objects) > 64:
+            raise ValueError("SVG export supports at most 64 objects per sheet")
+        if not isinstance(output_path, str) or not output_path:
+            raise ValueError("output_path must be a non-empty absolute SVG path")
+        path = Path(output_path)
+        if not path.is_absolute() or path.suffix.lower() != ".svg":
+            raise ValueError("output_path must be an absolute .svg path")
+        if path.exists():
+            raise ValueError("Output already exists; choose a new path")
+        panels, consumed = [], 0
+        for obj in objects:
+            row, triangles, used = _extract(obj, uv_map, max_triangles - consumed)
+            if not row["complete"] or row["issues"]:
+                raise ValueError("Cannot export {}: {}".format(obj.name, row))
+            consumed += used
+            coords = [p for _, triangle in triangles for p in triangle]
+            if any(not math.isfinite(c) or abs(c) > 1e12 for p in coords for c in p):
+                raise ValueError("Invalid UV coordinates on {}".format(obj.name))
+            layer = obj.data.uv_layers.get(uv_map) if uv_map else obj.data.uv_layers.active
+            # Polygon edges, not tessellation diagonals or an artistic wire texture.
+            edges = set()
+            for poly in obj.data.polygons:
+                points = [tuple(float(c) for c in layer.data[i].uv) for i in poly.loop_indices]
+                for a, b in zip(points, points[1:] + points[:1]):
+                    edges.add(tuple(sorted((a, b))))
+            panels.append((obj.name, layer.name, coords, sorted(edges)))
+        columns = math.ceil(math.sqrt(len(panels)))
+        rows = math.ceil(len(panels) / columns)
+        size = resolution / columns
+        height = math.ceil(rows * size)
+        parts = [
+            '<svg xmlns="http://www.w3.org/2000/svg" width="{}" height="{}" viewBox="0 0 {} {}">'.format(
+                resolution, height, resolution, height
+            ),
+            '<rect width="100%" height="100%" fill="#151d24"/>',
+        ]
+        for index, (name, layer, coords, edges) in enumerate(panels):
+            x = (index % columns) * size
+            y = (index // columns) * size
+            pad = size * 0.07
+            xs, ys = zip(*coords)
+            lo_u, hi_u = min(0.0, min(xs)), max(1.0, max(xs))
+            lo_v, hi_v = min(0.0, min(ys)), max(1.0, max(ys))
+            scale = (size - 3 * pad) / max(hi_u - lo_u, hi_v - lo_v)
+
+            def xy(p):
+                return x + pad + (p[0] - lo_u) * scale, y + size - pad - (p[1] - lo_v) * scale
+
+            tx, ty = xy((0, 1))
+            parts.append(
+                '<rect x="{:.5f}" y="{:.5f}" width="{:.5f}" height="{:.5f}" fill="none" stroke="#52606a"/>'.format(
+                    tx, ty, scale, scale
+                )
+            )
+            parts.append(
+                '<text x="{}" y="{}" fill="#e1e8ec" font-family="sans-serif" font-size="{}">{}</text>'.format(
+                    x + pad, y + pad, size * 0.025, escape("{} | {}".format(name, layer))
+                )
+            )
+            commands = []
+            for a, b in edges:
+                ax, ay = xy(a)
+                bx, by = xy(b)
+                commands.append("M{:.5f},{:.5f}L{:.5f},{:.5f}".format(ax, ay, bx, by))
+            parts.append(
+                '<path d="{}" fill="none" stroke="#71d6e4" stroke-width="{}"/>'.format(
+                    " ".join(commands), max(0.25, size / 1400)
+                )
+            )
+        parts.append("</svg>")
+        content = "\n".join(parts)
+        ElementTree.fromstring(content)  # Reject invalid XML characters before creating the file.
+        # Exclusive creation never replaces a previous delivery, including a race.
+        with path.open("x", encoding="utf-8") as stream:
+            stream.write(content)
+        return skill_success(
+            "UV SVG exported",
+            output_path=str(path),
+            format="SVG",
+            width=resolution,
+            height=height,
+            object_count=len(panels),
+            edge_count=sum(len(p[3]) for p in panels),
+            triangles_read=consumed,
+            mutation_applied=False,
+            topology="source_polygon_uv_edges",
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="UV SVG export failed")

--- a/src/dcc_mcp_blender/_uv_quality.py
+++ b/src/dcc_mcp_blender/_uv_quality.py
@@ -21,7 +21,7 @@ def _integer(value, label, low, high):
         raise ValueError("{} must be an integer in [{}, {}]".format(label, low, high))
 
 
-def _objects(object_names, uv_map, max_triangles):
+def _objects(object_names, uv_map, max_triangles, triangle_limit=200000):
     import bpy
 
     if not isinstance(object_names, list) or not 1 <= len(object_names) <= 4096:
@@ -32,7 +32,7 @@ def _objects(object_names, uv_map, max_triangles):
         raise ValueError("object_names must be unique")
     if uv_map is not None and (not isinstance(uv_map, str) or not uv_map.strip()):
         raise ValueError("uv_map must be null (active per object) or a non-empty name")
-    _integer(max_triangles, "max_triangles", 1, 200000)
+    _integer(max_triangles, "max_triangles", 1, triangle_limit)
     objects = []
     for name in object_names:
         obj = bpy.data.objects.get(name)
@@ -246,13 +246,17 @@ def audit_uv_layout(
         return skill_exception(exc, message="UV audit failed")
 
 
-def export_uv_layout(object_names, output_path, uv_map=None, resolution=2048, max_triangles=50000):
-    """Export actual polygon UV edges to a new SVG, one labelled panel per object."""
+def export_uv_layout(
+    object_names, output_path, uv_map=None, resolution=2048, max_triangles=50000, layout_mode="panels"
+):
+    """Export polygon UV edges to a new SVG as object panels or a shared atlas."""
     try:
         _integer(resolution, "resolution", 256, 8192)
-        objects = _objects(object_names, uv_map, max_triangles)
-        if len(objects) > 64:
-            raise ValueError("SVG export supports at most 64 objects per sheet")
+        objects = _objects(object_names, uv_map, max_triangles, triangle_limit=500000)
+        if layout_mode not in ("panels", "overlay"):
+            raise ValueError("layout_mode must be panels or overlay")
+        if layout_mode == "panels" and len(objects) > 64:
+            raise ValueError("Panel export supports at most 64 objects; use overlay for a shared atlas")
         if not isinstance(output_path, str) or not output_path:
             raise ValueError("output_path must be a non-empty absolute SVG path")
         path = Path(output_path)
@@ -277,6 +281,10 @@ def export_uv_layout(object_names, output_path, uv_map=None, resolution=2048, ma
                 for a, b in zip(points, points[1:] + points[:1]):
                     edges.add(tuple(sorted((a, b))))
             panels.append((obj.name, layer.name, coords, sorted(edges)))
+        if layout_mode == "overlay":
+            coords = [point for panel in panels for point in panel[2]]
+            edges = sorted({edge for panel in panels for edge in panel[3]})
+            panels = [("Shared UV space ({} objects)".format(len(objects)), uv_map or "active maps", coords, edges)]
         columns = math.ceil(math.sqrt(len(panels)))
         rows = math.ceil(len(panels) / columns)
         size = resolution / columns
@@ -332,7 +340,9 @@ def export_uv_layout(object_names, output_path, uv_map=None, resolution=2048, ma
             format="SVG",
             width=resolution,
             height=height,
-            object_count=len(panels),
+            object_count=len(objects),
+            panel_count=len(panels),
+            layout_mode=layout_mode,
             edge_count=sum(len(p[3]) for p in panels),
             triangles_read=consumed,
             mutation_applied=False,

--- a/src/dcc_mcp_blender/_uv_quality.py
+++ b/src/dcc_mcp_blender/_uv_quality.py
@@ -38,8 +38,9 @@ def _objects(object_names, uv_map, max_triangles, triangle_limit=200000):
         obj = bpy.data.objects.get(name)
         if obj is None or obj.type != "MESH":
             raise ValueError("Mesh object not found: {}".format(name))
-        if obj.mode != "OBJECT":
-            raise ValueError("Object must be in OBJECT mode: {}".format(name))
+        # An object-mode alias may share a mesh being edited by another object.
+        if obj.mode != "OBJECT" or obj.data.is_editmode:
+            raise ValueError("Object must be in OBJECT mode and its shared mesh must not be edited: {}".format(name))
         objects.append(obj)
     return objects
 

--- a/src/dcc_mcp_blender/skills/blender-materials/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-materials/SKILL.md
@@ -35,3 +35,11 @@ metadata:
 # blender-materials
 
 Blender material management skill.
+
+
+For existing material metallic/roughness edits, load `blender-shader-nodes`
+and use `set_principled_inputs` with `material_name` and
+`inputs: {"Metallic": 0.94, "Roughness": 0.28}`. Use `list_node_sockets` to inspect
+the target node and its linked sockets first; a linked socket's default value
+does not replace its upstream shader. Material creation already accepts PBR
+values; do not recreate an existing material just to change its roughness.

--- a/src/dcc_mcp_blender/skills/blender-shader-nodes/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-shader-nodes/SKILL.md
@@ -8,8 +8,8 @@ metadata:
     dcc: blender
     version: "1.0.0"
     tags: [blender, shader-nodes, geometry-nodes, node-graph, sockets, links, materials, procedural]
-    search-hint: "shader nodes, material nodes, node graph, sockets, links, principled bsdf, texture node, geometry node tree"
-    search-aliases: [node editor, shader graph, material graph, create node, connect nodes, set socket, principled shader, BSDF, texture input, geometry nodes modifier]
+    search-hint: "shader nodes, material nodes, node graph, sockets, links, principled bsdf, texture node, geometry node tree, metallic, metalness, roughness, existing PBR material"
+    search-aliases: [node editor, shader graph, material graph, create node, connect nodes, set socket, principled shader, BSDF, texture input, geometry nodes modifier, metallic, roughness, metalness, PBR material adjustment]
     intent: "Inspect and edit Blender shader/compositing/geometry node graphs — create nodes, connect sockets, set values, and manage node trees."
     recall-context:
       app_type: blender

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/SKILL.md
@@ -69,3 +69,6 @@ Use `export_uv_layout` to write actual polygon UV edges to a new SVG path.
 Each object gets its own labelled panel, fitted to its coordinates with the
 unit-tile border shown; panels do not imply shared texel scale. Export is a
 layout visualization, not a quality pass. It neither packs nor repairs UVs.
+The default `panels` mode accepts at most 64 objects. Choose `layout_mode=overlay`
+to display up to 4096 objects in their shared UV coordinate space. Set an
+explicit `max_triangles` budget (up to 500000) for larger atlas exports.

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/SKILL.md
@@ -2,7 +2,7 @@
 name: blender-uv-ops
 description: >-
   Blender authoring skill for UV maps, texture coordinate projection, unwraps,
-  island inspection, packing, and normalization. Use this before falling back to
+  island inspection, quality audits, SVG layout export, packing, and normalization. Use this before falling back to
   blender-scripting whenever a task touches UVs or texture coordinates.
 license: "MIT"
 allowed-tools: ["Bash", "Read"]
@@ -15,7 +15,7 @@ metadata:
     tags: [blender, uv, texture, mesh, authoring]
     search-hint: >-
       uv map, texture coordinates, unwrap uv, smart project, planar projection,
-      cube projection, uv islands, pack islands, normalize uv, copy uv map
+      cube projection, uv islands, pack islands, normalize uv, copy uv map, audit UV overlap, degenerate UV, export UV layout SVG
     search-aliases: [UV editor, texture mapping, UV layout, seam unwrap, lightmap UV, UV channel, transfer UV, projection mapping]
     intent: "Create, inspect, and edit UV maps — unwrap, project, pack, normalize, and copy UV data for texture authoring."
     recall-context:
@@ -46,3 +46,26 @@ packing, or normalization.
 Prefer `blender-mesh` for topology and modifier work, `blender-materials` for
 material slots, and `blender-shader-nodes` for shader graph edits. Use
 `blender-scripting` only after checking this typed surface.
+
+
+## Quality and delivery
+
+Use `audit_uv_layout` with explicit mesh names (up to 4096) for source mesh
+quality checks. It does not evaluate modifiers or silently switch out of Edit
+Mode. `success` means the query ran; require both `context.complete` and
+`context.passed` for a clean result for the enabled checks (reported in
+`context.checks`); disabling overlap is not a complete quality acceptance.
+Budget limits are shared by the entire
+request; `complete=false` requires a narrower request or a larger budget.
+Counts for degeneracy, tile bounds and overlap are triangle counts/pairs,
+not unique polygons. Face indices in the bounded detail list locate problems.
+`per_object` overlap is the default; choose `selection` only when those objects
+must share a non-overlapping atlas. Exact coincident triangle stacks (including
+mirrors) are allowed only with `allow_stacked=true`. UV distortion and texel
+density are not measured. `udim` permits tile crossings and validates only the
+nonnegative ten-column coordinate domain, not texture-file availability.
+
+Use `export_uv_layout` to write actual polygon UV edges to a new SVG path.
+Each object gets its own labelled panel, fitted to its coordinates with the
+unit-tile border shown; panels do not imply shared texel scale. Export is a
+layout visualization, not a quality pass. It neither packs nor repairs UVs.

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/audit_uv_layout.py
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/audit_uv_layout.py
@@ -1,0 +1,18 @@
+"""Read source UV data without changing Blender context."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._uv_quality import audit_uv_layout
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return audit_uv_layout(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/export_uv_layout.py
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/scripts/export_uv_layout.py
@@ -1,0 +1,18 @@
+"""Read source UV data without changing Blender context."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._uv_quality import export_uv_layout
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return export_uv_layout(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/tools.yaml
@@ -387,7 +387,7 @@ tools:
 
   - name: export_uv_layout
     timeout_hint_secs: 30
-    description: "Export actual source polygon UV edges to a labelled SVG sheet without changing UVs, selection or mode. Refuses overwrite, missing maps, invalid coordinates and budget exhaustion."
+    description: "Export actual source polygon UV edges to SVG: up to 64 labelled object panels, or a shared atlas overlay of up to 4096 meshes. Does not change UVs, selection or mode. Refuses overwrite, missing maps, invalid coordinates and budget exhaustion."
     source_file: scripts/export_uv_layout.py
     execution: sync
     affinity: main
@@ -400,7 +400,7 @@ tools:
         object_names:
           type: array
           minItems: 1
-          maxItems: 64
+          maxItems: 4096
           uniqueItems: true
           items: {type: string, minLength: 1}
         output_path:
@@ -409,7 +409,12 @@ tools:
           description: "Absolute new .svg path; parent directory must exist. Existing output is never overwritten."
         uv_map: {type: string, minLength: 1}
         resolution: {type: integer, minimum: 256, maximum: 8192, default: 2048}
-        max_triangles: {type: integer, minimum: 1, maximum: 200000, default: 50000}
+        max_triangles: {type: integer, minimum: 1, maximum: 500000, default: 50000}
+        layout_mode:
+          type: string
+          enum: [panels, overlay]
+          default: panels
+          description: "panels separates objects (max 64); overlay preserves shared coordinates for a scene atlas (max 4096)."
     output_schema: *uv_result_schema
     read_only: false
     destructive: false

--- a/src/dcc_mcp_blender/skills/blender-uv-ops/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-uv-ops/tools.yaml
@@ -327,3 +327,95 @@ tools:
       destructive_hint: false
       idempotent_hint: true
       open_world_hint: false
+
+  - name: audit_uv_layout
+    timeout_hint_secs: 30
+    description: "Read-only bounded UV quality audit of named source meshes: missing maps, invalid coordinates, degenerate triangles, tile bounds and positive-area overlaps. Budget exhaustion returns complete=false and passed=false."
+    source_file: scripts/audit_uv_layout.py
+    execution: sync
+    affinity: main
+    enforce_thread_affinity: true
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_names]
+      properties:
+        object_names:
+          type: array
+          minItems: 1
+          maxItems: 4096
+          uniqueItems: true
+          items: {type: string, minLength: 1}
+          description: "Explicit source meshes in OBJECT mode; pass scene mesh names for a scene audit."
+        uv_map:
+          type: string
+          minLength: 1
+          description: "Named UV map; omit to inspect each object's active map without changing it."
+        tile_policy:
+          type: string
+          enum: [unit, udim, unrestricted]
+          default: unit
+          description: "unit=[0,1]^2; udim=U in [0,10] and V>=0, allows tile crossings; unrestricted skips tile bounds."
+        check_overlap: {type: boolean, default: true}
+        overlap_scope:
+          type: string
+          enum: [per_object, selection]
+          default: per_object
+          description: "selection also checks overlap between objects sharing one UV space."
+        allow_stacked:
+          type: boolean
+          default: false
+          description: "Allow exactly coincident UV triangles, including opposite winding; partial overlaps still fail."
+        max_triangles: {type: integer, minimum: 1, maximum: 200000, default: 50000}
+        max_pair_tests: {type: integer, minimum: 1, maximum: 2000000, default: 200000}
+        max_report_items: {type: integer, minimum: 0, maximum: 1000, default: 100}
+        area_epsilon:
+          type: number
+          exclusiveMinimum: 0
+          maximum: 0.0001
+          default: 0.0000000001
+          description: "Area tolerance in UV square units. Coordinates beyond magnitude 1e12 are invalid."
+    output_schema: *uv_result_schema
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
+  - name: export_uv_layout
+    timeout_hint_secs: 30
+    description: "Export actual source polygon UV edges to a labelled SVG sheet without changing UVs, selection or mode. Refuses overwrite, missing maps, invalid coordinates and budget exhaustion."
+    source_file: scripts/export_uv_layout.py
+    execution: sync
+    affinity: main
+    enforce_thread_affinity: true
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_names, output_path]
+      properties:
+        object_names:
+          type: array
+          minItems: 1
+          maxItems: 64
+          uniqueItems: true
+          items: {type: string, minLength: 1}
+        output_path:
+          type: string
+          minLength: 1
+          description: "Absolute new .svg path; parent directory must exist. Existing output is never overwritten."
+        uv_map: {type: string, minLength: 1}
+        resolution: {type: integer, minimum: 256, maximum: 8192, default: 2048}
+        max_triangles: {type: integer, minimum: 1, maximum: 200000, default: 50000}
+    output_schema: *uv_result_schema
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: true

--- a/tests/e2e/test_uv_quality_e2e.py
+++ b/tests/e2e/test_uv_quality_e2e.py
@@ -65,3 +65,44 @@ def test_real_triangle_stacks(tmp_path):
     result = audit([obj.name])
     assert result["context"]["issue_counts"] == {"overlap_pairs": 1}
     assert audit([obj.name], allow_stacked=True)["context"]["passed"]
+
+
+@pytest.mark.parametrize("tool", ["audit_uv_layout", "export_uv_layout"])
+def test_shared_edit_mesh_rejected_without_flushing_uvs_or_exporting(tool, tmp_path):
+    import bmesh
+
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    bpy.ops.mesh.primitive_plane_add()
+    editor = bpy.context.object
+    alias = bpy.data.objects.new("SharedMeshAlias", editor.data)
+    bpy.context.scene.collection.objects.link(alias)
+    alias.select_set(False)
+    bpy.ops.object.mode_set(mode="EDIT")
+    path = tmp_path / "shared.svg"
+    try:
+        assert editor.mode == "EDIT" and alias.mode == "OBJECT"
+        assert alias.data.is_editmode is True
+        edit_mesh = bmesh.from_edit_mesh(editor.data)
+        uv_layer = edit_mesh.loops.layers.uv.active
+        assert uv_layer is not None
+        loops = [loop for face in edit_mesh.faces for loop in face.loops]
+        loops[0][uv_layer].uv = (0.25, 0.75)
+        coordinates = [tuple(loop[uv_layer].uv) for loop in loops]
+        active = bpy.context.view_layer.objects.active
+        selected = list(bpy.context.selected_objects)
+        arguments = {"object_names": [alias.name]}
+        if tool == "export_uv_layout":
+            arguments["output_path"] = str(path)
+
+        result = load_skill("blender-uv-ops", tool).main(**arguments)
+
+        assert result["success"] is False, result
+        assert "OBJECT mode" in result["_meta"]["dcc.error"]["message"]
+        assert editor.mode == "EDIT" and alias.mode == "OBJECT"
+        assert alias.data.is_editmode is True
+        assert bpy.context.view_layer.objects.active == active
+        assert list(bpy.context.selected_objects) == selected
+        assert [tuple(loop[uv_layer].uv) for loop in loops] == coordinates
+        assert not path.exists()
+    finally:
+        bpy.ops.object.mode_set(mode="OBJECT")

--- a/tests/e2e/test_uv_quality_e2e.py
+++ b/tests/e2e/test_uv_quality_e2e.py
@@ -1,0 +1,64 @@
+"""Real Blender UV audit and polygon-edge SVG export acceptance."""
+
+from __future__ import annotations
+
+from xml.etree import ElementTree
+
+import pytest
+
+bpy = pytest.importorskip("bpy")
+pytestmark = pytest.mark.e2e
+
+from tests.e2e.conftest import load_skill  # noqa: E402
+
+
+def test_uv_quality_named_map_and_source_state(tmp_path):
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    bpy.ops.mesh.primitive_plane_add()
+    obj = bpy.context.object
+    layer = obj.data.uv_layers.new(name="Named")
+    for dst, src in zip(layer.data, obj.data.uv_layers[0].data):
+        dst.uv = src.uv
+    obj.data.uv_layers.active_index = 0
+    active = bpy.context.view_layer.objects.active
+    selected = list(bpy.context.selected_objects)
+    coordinates = [tuple(v.uv) for v in layer.data]
+    audit = load_skill("blender-uv-ops", "audit_uv_layout").audit_uv_layout
+    export = load_skill("blender-uv-ops", "export_uv_layout").export_uv_layout
+    report = audit([obj.name], uv_map="Named")
+    assert report["success"], report
+    assert report["context"]["passed"], report
+    path = tmp_path / "named.svg"
+    result = export([obj.name], str(path), uv_map="Named")
+    assert result["success"], result
+    assert result["context"]["edge_count"] == 4  # no tessellation diagonal
+    ElementTree.parse(path)
+    assert bpy.context.view_layer.objects.active == active
+    assert list(bpy.context.selected_objects) == selected
+    assert obj.data.uv_layers.active_index == 0
+    assert [tuple(v.uv) for v in layer.data] == coordinates
+    for item in layer.data:
+        item.uv = (0, 0)
+    result = audit([obj.name], uv_map="Named")
+    assert result["context"]["issue_counts"]["degenerate_triangles"] == 2
+    bpy.ops.object.mode_set(mode="EDIT")
+    try:
+        assert not audit([obj.name])["success"]
+        assert obj.mode == "EDIT"
+    finally:
+        bpy.ops.object.mode_set(mode="OBJECT")
+
+
+def test_real_triangle_stacks(tmp_path):
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    mesh = bpy.data.meshes.new("Stacked")
+    mesh.from_pydata([(0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1), (1, 0, 1), (0, 1, 1)], [], [(0, 1, 2), (3, 4, 5)])
+    obj = bpy.data.objects.new("Stacked", mesh)
+    bpy.context.scene.collection.objects.link(obj)
+    layer = mesh.uv_layers.new()
+    for i, point in enumerate([(0, 0), (1, 0), (0, 1)] * 2):
+        layer.data[i].uv = point
+    audit = load_skill("blender-uv-ops", "audit_uv_layout").audit_uv_layout
+    result = audit([obj.name])
+    assert result["context"]["issue_counts"] == {"overlap_pairs": 1}
+    assert audit([obj.name], allow_stacked=True)["context"]["passed"]

--- a/tests/e2e/test_uv_quality_e2e.py
+++ b/tests/e2e/test_uv_quality_e2e.py
@@ -33,6 +33,9 @@ def test_uv_quality_named_map_and_source_state(tmp_path):
     assert result["success"], result
     assert result["context"]["edge_count"] == 4  # no tessellation diagonal
     ElementTree.parse(path)
+    atlas = export([obj.name], str(tmp_path / "atlas.svg"), uv_map="Named", layout_mode="overlay")
+    assert atlas["success"] and atlas["context"]["panel_count"] == 1
+    assert atlas["context"]["edge_count"] == 4
     assert bpy.context.view_layer.objects.active == active
     assert list(bpy.context.selected_objects) == selected
     assert obj.data.uv_layers.active_index == 0

--- a/tests/test_skills_uv_ops.py
+++ b/tests/test_skills_uv_ops.py
@@ -175,6 +175,8 @@ def test_tools_yaml_declares_modern_contract():
         "unwrap_uvs",
         "pack_uvs",
         "normalize_uvs",
+        "audit_uv_layout",
+        "export_uv_layout",
     }
     tools = {tool["name"]: tool for tool in doc["tools"]}
     assert set(tools) == expected

--- a/tests/test_uv_quality.py
+++ b/tests/test_uv_quality.py
@@ -9,6 +9,7 @@ from xml.etree import ElementTree
 import pytest
 
 from dcc_mcp_blender._uv_quality import _intersection_area, audit_uv_layout, export_uv_layout
+from tests.conftest import load_and_call
 
 TRI = ((0.0, 0.0), (1.0, 0.0), (0.0, 1.0))
 
@@ -19,6 +20,7 @@ def mesh(name="Mesh", triangles=(TRI,), with_uv=True):
     uv_layers = NS(active=layer if with_uv else None, get=lambda name: layer if name == "UVMap" and with_uv else None)
     polygons = [NS(index=i, loop_indices=tuple(range(3 * i, 3 * i + 3))) for i in range(len(triangles))]
     data = NS(
+        is_editmode=False,
         uv_layers=uv_layers,
         loops=list(range(len(coords))),
         polygons=polygons,
@@ -137,6 +139,29 @@ def test_object_validation_and_edit_mode_fail_closed(install):
     obj.mode = "EDIT"
     assert not audit_uv_layout(["Mesh"])["success"]
     assert obj.mode == "EDIT"
+
+
+@pytest.mark.parametrize("tool", ["audit_uv_layout", "export_uv_layout"])
+def test_shared_edit_mesh_is_rejected_through_skill_entry_without_changes(tool, tmp_path):
+    editor = mesh("Editing")
+    editor.mode = "EDIT"
+    editor.data.is_editmode = True
+    alias = NS(name="Alias", type="MESH", mode="OBJECT", data=editor.data)
+    host = NS(data=NS(objects={editor.name: editor, alias.name: alias}))
+    before = [item.uv for item in editor.data.uv_layers.active.data]
+    path = tmp_path / "shared.svg"
+    arguments = {"object_names": [alias.name]}
+    if tool == "export_uv_layout":
+        arguments["output_path"] = str(path)
+
+    result = load_and_call("blender-uv-ops/scripts/{}.py".format(tool), host, **arguments)
+
+    assert result["success"] is False, result
+    assert "OBJECT mode" in result["_meta"]["dcc.error"]["message"]
+    assert not path.exists()
+    assert editor.mode == "EDIT" and alias.mode == "OBJECT"
+    assert editor.data.is_editmode is True
+    assert [item.uv for item in editor.data.uv_layers.active.data] == before
 
 
 def test_export_true_edges_xml_escaping_and_no_overwrite(install, tmp_path):

--- a/tests/test_uv_quality.py
+++ b/tests/test_uv_quality.py
@@ -1,0 +1,182 @@
+"""UV audit geometry and non-mutating delivery contracts."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace as NS
+from xml.etree import ElementTree
+
+import pytest
+
+from dcc_mcp_blender._uv_quality import _intersection_area, audit_uv_layout, export_uv_layout
+
+TRI = ((0.0, 0.0), (1.0, 0.0), (0.0, 1.0))
+
+
+def mesh(name="Mesh", triangles=(TRI,), with_uv=True):
+    coords = [p for tri in triangles for p in tri]
+    layer = NS(name="UVMap", data=[NS(uv=p) for p in coords])
+    uv_layers = NS(active=layer if with_uv else None, get=lambda name: layer if name == "UVMap" and with_uv else None)
+    polygons = [NS(index=i, loop_indices=tuple(range(3 * i, 3 * i + 3))) for i in range(len(triangles))]
+    data = NS(
+        uv_layers=uv_layers,
+        loops=list(range(len(coords))),
+        polygons=polygons,
+        loop_triangles=[NS(loops=p.loop_indices, polygon_index=p.index) for p in polygons],
+        calc_loop_triangles=lambda: None,
+    )
+    return NS(name=name, type="MESH", mode="OBJECT", data=data)
+
+
+@pytest.fixture
+def install(monkeypatch):
+    def apply(*objects):
+        monkeypatch.setitem(sys.modules, "bpy", NS(data=NS(objects={o.name: o for o in objects})))
+
+    return apply
+
+
+def context(result):
+    assert result["success"], result
+    return result["context"]
+
+
+def test_overlap_is_area_not_bbox_or_edge_contact():
+    assert _intersection_area(TRI, tuple(reversed(TRI))) == pytest.approx(0.5)
+    touching = ((1.0, 0.0), (1.0, 1.0), (0.0, 1.0))
+    assert _intersection_area(TRI, touching) == 0
+    contained = ((0.1, 0.1), (0.2, 0.1), (0.1, 0.2))
+    assert _intersection_area(TRI, contained) == pytest.approx(0.005)
+    disjoint_bbox = ((0.8, 0.8), (1.0, 0.8), (0.8, 1.0))
+    assert _intersection_area(TRI, disjoint_bbox) == 0
+
+
+def test_audit_nonmutating_named_map_and_missing_map(install):
+    obj = mesh()
+    obj.data.uv_layers.active = None
+    install(obj)
+    assert context(audit_uv_layout([obj.name], uv_map="UVMap"))["passed"]
+    assert obj.data.uv_layers.active is None
+    missing = context(audit_uv_layout([obj.name]))
+    assert missing["complete"] and not missing["passed"]
+    assert missing["issue_counts"] == {"missing_uv_map": 1}
+
+
+def test_stacks_and_scope_are_explicit(install):
+    install(mesh("A"), mesh("B", (tuple(reversed(TRI)),)))
+    assert context(audit_uv_layout(["A", "B"]))["passed"]
+    assert context(audit_uv_layout(["A", "B"], overlap_scope="selection"))["issue_counts"] == {"overlap_pairs": 1}
+    allowed = context(audit_uv_layout(["A", "B"], overlap_scope="selection", allow_stacked=True))
+    assert allowed["passed"] and allowed["allowed_stacked_pairs"] == 1
+
+
+def test_partial_overlap_still_fails_when_stacks_allowed(install):
+    shifted = tuple((x + 0.1, y) for x, y in TRI)
+    install(mesh(triangles=(TRI, shifted)))
+    report = context(audit_uv_layout(["Mesh"], allow_stacked=True, tile_policy="unrestricted"))
+    assert report["issue_counts"] == {"overlap_pairs": 1}
+
+
+def test_invalid_degenerate_and_tile_policies(install):
+    invalid = ((float("nan"), 0), (1, 0), (0, 1))
+    flat = ((0, 0), (0.5, 0), (1, 0))
+    udim = tuple((x + 2, y + 3) for x, y in TRI)
+    install(mesh(triangles=(invalid, flat, udim)))
+    report = context(audit_uv_layout(["Mesh"]))
+    assert report["issue_counts"] == {"invalid_coordinates": 1, "degenerate_triangles": 1, "out_of_tile_triangles": 1}
+    report = context(audit_uv_layout(["Mesh"], tile_policy="udim"))
+    assert "out_of_tile_triangles" not in report["issue_counts"]
+
+
+def test_no_false_pass_when_budget_exhausted(install):
+    install(mesh(triangles=(TRI,) * 5))
+    report = context(audit_uv_layout(["Mesh"], max_triangles=1))
+    assert not report["complete"] and not report["passed"]
+    assert report["objects"][0]["incomplete_reason"] == "triangle_budget"
+    report = context(audit_uv_layout(["Mesh"], allow_stacked=True, max_pair_tests=1))
+    assert not report["complete"] and not report["passed"]
+    assert report["pair_tests"] == 1 and not report["overlap_complete"]
+    assert not report["objects"][0]["complete"]
+
+
+def test_triangle_budget_shared_between_objects_and_details_bounded(install):
+    install(mesh("A"), mesh("B"))
+    report = context(audit_uv_layout(["A", "B"], max_triangles=1))
+    assert report["triangles_checked"] == 1 and not report["complete"]
+    install(mesh(triangles=(TRI,) * 5))
+    report = context(audit_uv_layout(["Mesh"], max_report_items=1))
+    assert len(report["details"]) == 1 and report["details_truncated"]
+    assert report["issue_counts"]["overlap_pairs"] == 10
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"max_triangles": True},
+        {"max_pair_tests": 0},
+        {"area_epsilon": float("inf")},
+        {"area_epsilon": 0},
+        {"area_epsilon": True},
+        {"check_overlap": 1},
+        {"tile_policy": "wrong"},
+        {"overlap_scope": "wrong"},
+        {"max_report_items": -1},
+        {"uv_map": ""},
+    ],
+)
+def test_invalid_arguments_rejected(install, kwargs):
+    install(mesh())
+    assert not audit_uv_layout(["Mesh"], **kwargs)["success"]
+
+
+def test_object_validation_and_edit_mode_fail_closed(install):
+    obj = mesh()
+    install(obj)
+    for names in ([], ["Mesh", "Mesh"], ["Missing"], "Mesh", [True]):
+        assert not audit_uv_layout(names)["success"]
+    obj.mode = "EDIT"
+    assert not audit_uv_layout(["Mesh"])["success"]
+    assert obj.mode == "EDIT"
+
+
+def test_export_true_edges_xml_escaping_and_no_overwrite(install, tmp_path):
+    obj = mesh('A<&"')
+    install(obj)
+    path = tmp_path / "layout.svg"
+    result = context(export_uv_layout([obj.name], str(path)))
+    assert result["edge_count"] == 3 and not result["mutation_applied"]
+    root = ElementTree.parse(path).getroot()
+    assert root.attrib["width"] == "2048"
+    text = root.find("{http://www.w3.org/2000/svg}text")
+    assert text.text == obj.name + " | UVMap"
+    original = path.read_bytes()
+    assert not export_uv_layout([obj.name], str(path))["success"]
+    assert path.read_bytes() == original
+
+
+def test_export_does_not_create_partial_file_on_preflight_failure(install, tmp_path):
+    install(mesh("A"), mesh("B", with_uv=False))
+    path = tmp_path / "layout.svg"
+    assert not export_uv_layout(["A", "B"], str(path))["success"]
+    assert not path.exists()
+    install(mesh(triangles=(TRI, TRI)))
+    assert not export_uv_layout(["Mesh"], str(path), max_triangles=1)["success"]
+    assert not path.exists()
+    assert not export_uv_layout(["Mesh"], "relative.svg")["success"]
+
+
+def test_missing_loop_coordinates_and_empty_mesh(install):
+    obj = mesh()
+    obj.data.uv_layers.active.data.pop()
+    install(obj)
+    assert context(audit_uv_layout(["Mesh"]))["issue_counts"] == {"uncovered_faces": 1}
+    install(mesh(triangles=()))
+    assert context(audit_uv_layout(["Mesh"]))["issue_counts"] == {"empty_mesh": 1}
+
+
+def test_invalid_xml_name_never_creates_broken_artifact(install, tmp_path):
+    obj = mesh("invalid\x01name")
+    install(obj)
+    path = tmp_path / "layout.svg"
+    assert not export_uv_layout([obj.name], str(path))["success"]
+    assert not path.exists()

--- a/tests/test_uv_quality.py
+++ b/tests/test_uv_quality.py
@@ -180,3 +180,16 @@ def test_invalid_xml_name_never_creates_broken_artifact(install, tmp_path):
     path = tmp_path / "layout.svg"
     assert not export_uv_layout([obj.name], str(path))["success"]
     assert not path.exists()
+
+
+def test_shared_atlas_accepts_large_object_sets_without_moving_uvs(install, tmp_path):
+    objects = [mesh(str(i)) for i in range(65)]
+    install(*objects)
+    names = [o.name for o in objects]
+    path = tmp_path / "atlas.svg"
+    assert not export_uv_layout(names, str(path))["success"]
+    result = context(export_uv_layout(names, str(path), layout_mode="overlay"))
+    assert result["object_count"] == 65 and result["panel_count"] == 1
+    assert result["edge_count"] == 3  # coincident edges are drawn once
+    assert objects[0].data.uv_layers.active.data[0].uv == TRI[0]
+    assert not export_uv_layout(names, str(tmp_path / "bad.svg"), layout_mode="wrong")["success"]


### PR DESCRIPTION
Adds read-only UV quality auditing and polygon-edge SVG export (object panels or shared scene atlas). Audits report missing maps, invalid/degenerate coordinates, tile bounds and positive-area overlaps; explicit budgets return incomplete instead of a false pass. Named UV maps, scene selection and mode are preserved. SVG delivery refuses overwrite. Both tools reject shared meshes still being edited by another object.

Also routes existing-material metallic/roughness requests to the existing shader-node tools.

Validation: 774 unit tests and four UV E2E tests on each Blender 5.2.1/4.5.13 passed; Ruff, skill checks and review passed. Final-head CI passed. A 2,054-mesh scene was audited in bounded batches and produced actionable overlap/degeneracy findings. No automatic UV repair is included.

