### PR TITLE
fix: discover registered Blender asset libraries

### DIFF
--- a/src/dcc_mcp_blender/_asset_source_ops.py
+++ b/src/dcc_mcp_blender/_asset_source_ops.py
@@ -137,30 +137,36 @@ def _scan_asset_library(
     query: Optional[str] = None,
     allowed_types: Optional[set[str]] = None,
     max_results: int = _DEFAULT_MAX_RESULTS,
-) -> tuple[List[AssetDescriptor], Optional[dict]]:
-    """Scan Blender's registered asset libraries via ``bpy.data.asset_libraries``."""
+) -> tuple[List[AssetDescriptor], Optional[dict], str]:
+    """Scan Blender's registered asset libraries from file path preferences."""
     results: List[AssetDescriptor] = []
 
-    # Force-refresh catalogues so the search sees the latest state.
-    try:
-        bpy.ops.asset.library_refresh()
-    except Exception:
-        pass
-
-    libraries = getattr(bpy.data, "asset_libraries", None)
+    preferences = getattr(getattr(bpy, "context", None), "preferences", None)
+    libraries = getattr(getattr(preferences, "filepaths", None), "asset_libraries", None)
 
     if libraries is None or not hasattr(libraries, "__iter__"):
-        return results, None
+        return (
+            results,
+            skill_error(
+                "Asset library API unavailable",
+                "Blender preferences.filepaths.asset_libraries is unavailable in this runtime.",
+                asset_library_status="unavailable",
+            ),
+            "unavailable",
+        )
 
+    failures = []
     try:
+        libraries = list(libraries)
+        if not libraries:
+            return results, None, "no_libraries"
         for lib in libraries:
             lib_path = getattr(lib, "path", None)
             if not lib_path:
+                failures.append(f"Registered library '{getattr(lib, 'name', '')}' has no directory path.")
                 continue
             lib_dir = Path(lib_path)
-            if not lib_dir.is_dir():
-                continue
-            sub_results, _ = _scan_filesystem(
+            sub_results, scan_error = _scan_filesystem(
                 lib_dir,
                 query=query,
                 allowed_types=allowed_types,
@@ -170,12 +176,22 @@ def _scan_asset_library(
                 desc["source"] = "asset_library"
                 desc["metadata"]["library_name"] = getattr(lib, "name", "")
             results.extend(sub_results)
+            if scan_error:
+                failures.append(f"Registered library '{getattr(lib, 'name', '')}': {scan_error['error']}")
             if len(results) >= max_results:
                 break
     except Exception as exc:
-        return results, skill_exception(exc, message="Failed to scan asset libraries")
+        failures.append(str(exc))
 
-    return results, None
+    if failures:
+        status = "partial" if results else "error"
+        return (
+            results,
+            skill_error("Failed to scan asset libraries", "; ".join(failures), asset_library_status=status),
+            status,
+        )
+
+    return results, None, "scanned"
 
 
 def search_assets(
@@ -223,6 +239,7 @@ def search_assets(
     all_results: List[AssetDescriptor] = []
     warnings: List[str] = []
     truncated = False
+    library_status = None
 
     try:
         import bpy
@@ -275,17 +292,17 @@ def search_assets(
             )
 
     # Asset library scan.
-    if source in ("asset_library", "all") and bpy is not None:
-        lib_results, lib_error = _scan_asset_library(
+    if source in ("asset_library", "all"):
+        lib_results, lib_error, library_status = _scan_asset_library(
             bpy,
             query=query,
             allowed_types=allowed,
             max_results=max_results - len(all_results),
         )
         if lib_error:
-            if not all_results:
+            if not all_results and not lib_results:
                 return lib_error
-            warnings.append(lib_error.get("message", "Asset library scan had errors"))
+            warnings.append(lib_error.get("error", "Asset library scan had errors"))
         all_results.extend(lib_results)
         if len(all_results) >= max_results:
             all_results = all_results[:max_results]
@@ -299,6 +316,8 @@ def search_assets(
     )
     if search_path:
         context["path"] = str(search_path)
+    if library_status:
+        context["asset_library_status"] = library_status
     if warnings:
         context["warnings"] = warnings
     if truncated:

--- a/src/dcc_mcp_blender/_asset_source_ops.py
+++ b/src/dcc_mcp_blender/_asset_source_ops.py
@@ -161,23 +161,28 @@ def _scan_asset_library(
         if not libraries:
             return results, None, "no_libraries"
         for lib in libraries:
-            lib_path = getattr(lib, "path", None)
-            if not lib_path:
-                failures.append(f"Registered library '{getattr(lib, 'name', '')}' has no directory path.")
-                continue
-            lib_dir = Path(lib_path)
-            sub_results, scan_error = _scan_filesystem(
-                lib_dir,
-                query=query,
-                allowed_types=allowed_types,
-                max_results=max_results - len(results),
-            )
-            for desc in sub_results:
-                desc["source"] = "asset_library"
-                desc["metadata"]["library_name"] = getattr(lib, "name", "")
-            results.extend(sub_results)
-            if scan_error:
-                failures.append(f"Registered library '{getattr(lib, 'name', '')}': {scan_error['error']}")
+            library_name = ""
+            try:
+                library_name = getattr(lib, "name", "")
+                lib_path = getattr(lib, "path", None)
+                if not lib_path:
+                    failures.append(f"Registered library '{library_name}' has no directory path.")
+                    continue
+                lib_dir = Path(lib_path)
+                sub_results, scan_error = _scan_filesystem(
+                    lib_dir,
+                    query=query,
+                    allowed_types=allowed_types,
+                    max_results=max_results - len(results),
+                )
+                for desc in sub_results:
+                    desc["source"] = "asset_library"
+                    desc["metadata"]["library_name"] = library_name
+                results.extend(sub_results)
+                if scan_error:
+                    failures.append(f"Registered library '{library_name}': {scan_error['error']}")
+            except Exception as exc:
+                failures.append(f"Registered library '{library_name}': {exc}")
             if len(results) >= max_results:
                 break
     except Exception as exc:

--- a/src/dcc_mcp_blender/skills/blender-asset-source/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-asset-source/SKILL.md
@@ -45,6 +45,18 @@ Supports:
 - **Type filtering** — restrict results to specific formats (blend, fbx, obj, usd, etc.).
 - **Name matching** — case-insensitive substring filter on asset names.
 
+Library registrations come from `bpy.context.preferences.filepaths.asset_libraries`.
+Search is read-only: it does not refresh Asset Browser UI or save preferences.
+`context.asset_library_status` distinguishes `scanned`, `no_libraries`,
+`unavailable`, `partial`, and `error`; missing APIs or unreadable libraries are not empty
+successful library searches. Broken registrations do not hide later valid
+libraries: partial results include explicit status and warnings. With `source=all`, filesystem results can be
+returned with a library warning. Reaching the result budget may truncate search.
+
+This searches supported files directly inside registered local directories,
+not asset-marked data-blocks inside `.blend` files. Remote libraries, catalogs,
+tags, and recursive dependency discovery require separate capabilities.
+
 ## Tools
 
 | Tool | Description |

--- a/src/dcc_mcp_blender/skills/blender-asset-source/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-asset-source/tools.yaml
@@ -65,6 +65,9 @@ tools:
               type: integer
             source:
               type: string
+            asset_library_status:
+              type: string
+              enum: [scanned, no_libraries, unavailable, partial, error]
     read_only: true
     destructive: false
     idempotent: true

--- a/tests/e2e/test_asset_source_e2e.py
+++ b/tests/e2e/test_asset_source_e2e.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 bpy = pytest.importorskip("bpy", reason="Requires native Blender")
@@ -15,7 +17,11 @@ def test_registered_local_library_is_discoverable(tmp_path):
     fixture = tmp_path / "registered_asset_probe.obj"
     fixture.write_text("v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n", encoding="utf-8")
     before = [(library.name, library.path) for library in libraries]
-    library = libraries.new(name="RegisteredDiscoveryProbe", directory=str(tmp_path))
+    # Blender 3.6 exposes a read-only RNA collection; the registration operator
+    # is the common API across legacy and current releases. Never save prefs.
+    assert bpy.ops.preferences.asset_library_add(directory=str(tmp_path)) == {"FINISHED"}
+    library = next(item for item in libraries if Path(item.path).resolve() == tmp_path.resolve())
+    library.name = "RegisteredDiscoveryProbe"
     try:
         result = load_skill("blender-asset-source", "search_assets").main(
             source="asset_library", query="registered_asset_probe", asset_types=["obj"]
@@ -30,5 +36,6 @@ def test_registered_local_library_is_discoverable(tmp_path):
         assert descriptor["name"] == fixture.stem
         assert descriptor["size_bytes"] == fixture.stat().st_size
     finally:
-        libraries.remove(library)
+        index = next(index for index, item in enumerate(libraries) if item.as_pointer() == library.as_pointer())
+        assert bpy.ops.preferences.asset_library_remove(index=index) == {"FINISHED"}
     assert [(library.name, library.path) for library in libraries] == before

--- a/tests/e2e/test_asset_source_e2e.py
+++ b/tests/e2e/test_asset_source_e2e.py
@@ -1,0 +1,34 @@
+"""Discover an actual registered library without persistent preference changes."""
+
+from __future__ import annotations
+
+import pytest
+
+bpy = pytest.importorskip("bpy", reason="Requires native Blender")
+pytestmark = pytest.mark.e2e
+
+from tests.e2e.conftest import load_skill  # noqa: E402
+
+
+def test_registered_local_library_is_discoverable(tmp_path):
+    libraries = bpy.context.preferences.filepaths.asset_libraries
+    fixture = tmp_path / "registered_asset_probe.obj"
+    fixture.write_text("v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n", encoding="utf-8")
+    before = [(library.name, library.path) for library in libraries]
+    library = libraries.new(name="RegisteredDiscoveryProbe", directory=str(tmp_path))
+    try:
+        result = load_skill("blender-asset-source", "search_assets").main(
+            source="asset_library", query="registered_asset_probe", asset_types=["obj"]
+        )
+        assert result["success"], result
+        context = result["context"]
+        assert context["asset_library_status"] in {"scanned", "partial"}
+        if context["asset_library_status"] == "partial":
+            assert context["warnings"]
+        descriptor = next(item for item in context["descriptors"] if item["metadata"]["library_name"] == library.name)
+        assert descriptor["source"] == "asset_library"
+        assert descriptor["name"] == fixture.stem
+        assert descriptor["size_bytes"] == fixture.stat().st_size
+    finally:
+        libraries.remove(library)
+    assert [(library.name, library.path) for library in libraries] == before

--- a/tests/test_skills_asset_source.py
+++ b/tests/test_skills_asset_source.py
@@ -12,14 +12,23 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from tests.conftest import load_and_call, make_mock_bpy
+from tests.conftest import load_and_call, load_skill_script, make_mock_bpy
 
 
 def _touch(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("dummy content", encoding="utf-8")
+
+
+def _library_bpy(libraries):
+    """Model the public PreferencesFilePaths owner without dynamic attributes."""
+    return SimpleNamespace(
+        data=SimpleNamespace(filepath=""),
+        context=SimpleNamespace(preferences=SimpleNamespace(filepaths=SimpleNamespace(asset_libraries=libraries))),
+    )
 
 
 class TestSearchAssetsFilesystem:
@@ -181,17 +190,68 @@ class TestSearchAssetsFilesystem:
 
 
 class TestSearchAssetsAssetLibrary:
+    def test_broken_library_does_not_hide_later_valid_library(self, tmp_path):
+        _touch(tmp_path / "hero.obj")
+        bpy = _library_bpy(
+            [
+                SimpleNamespace(name="Missing", path=str(tmp_path / "missing")),
+                SimpleNamespace(name="Valid", path=str(tmp_path)),
+            ]
+        )
+        result = load_and_call("blender-asset-source/scripts/search_assets.py", bpy, source="asset_library")
+        assert result["success"], result
+        assert result["context"]["count"] == 1
+        assert result["context"]["asset_library_status"] == "partial"
+        assert result["context"]["warnings"]
+
+    def test_missing_registered_directory_returns_scan_error(self, tmp_path):
+        """A configured library that disappeared must not look like no matches."""
+        bpy = _library_bpy([SimpleNamespace(name="MissingAssets", path=str(tmp_path / "missing"))])
+
+        result = load_and_call("blender-asset-source/scripts/search_assets.py", bpy, source="asset_library")
+
+        assert result["success"] is False
+        assert result["context"]["asset_library_status"] == "error"
+        assert "MissingAssets" in result["error"]
+
+    def test_no_registered_libraries_reports_empty_configuration(self):
+        """An available but empty registration list is a successful empty search."""
+        result = load_and_call(
+            "blender-asset-source/scripts/search_assets.py", _library_bpy([]), source="asset_library"
+        )
+
+        assert result["success"] is True
+        assert result["context"]["count"] == 0
+        assert result["context"]["asset_library_status"] == "no_libraries"
+
+    def test_missing_asset_library_api_returns_unavailable(self):
+        """Missing Blender API is not an empty successful library search."""
+        bpy = _library_bpy([])
+        del bpy.context.preferences.filepaths.asset_libraries
+
+        result = load_and_call("blender-asset-source/scripts/search_assets.py", bpy, source="asset_library")
+
+        assert result["success"] is False
+        assert "unavailable" in result["message"].lower()
+
+    def test_asset_library_scan_does_not_refresh_or_mutate_preferences(self, tmp_path):
+        """A read-only scan never invokes context-dependent asset operators."""
+        bpy = _library_bpy([SimpleNamespace(name="MyAssets", path=str(tmp_path))])
+        refreshed = []
+        bpy.ops = SimpleNamespace(asset=SimpleNamespace(library_refresh=lambda: refreshed.append(True)))
+
+        result = load_and_call("blender-asset-source/scripts/search_assets.py", bpy, source="asset_library")
+
+        assert result["success"] is True
+        assert refreshed == []
+
     def test_asset_library_scan_returns_results(self, tmp_path):
-        """Mock asset library scan returns descriptors from library paths."""
+        """Registered preferences libraries return discoverable file descriptors."""
         lib_dir = tmp_path / "asset_library"
         _touch(lib_dir / "hero.fbx")
         _touch(lib_dir / "sword.obj")
 
-        bpy = make_mock_bpy()
-        mock_lib = MagicMock()
-        mock_lib.name = "MyAssets"
-        mock_lib.path = str(lib_dir)
-        bpy.data.asset_libraries = [mock_lib]
+        bpy = _library_bpy([SimpleNamespace(name="MyAssets", path=str(lib_dir))])
 
         result = load_and_call(
             "blender-asset-source/scripts/search_assets.py",
@@ -228,15 +288,14 @@ class TestSearchAssetsAssetLibrary:
 
 
 class TestSearchAssetsErrors:
-    def test_no_bpy_returns_empty_for_asset_library(self):
-        """Without bpy, asset_library source returns no results gracefully."""
-        from dcc_mcp_blender._asset_source_ops import search_assets
-
+    def test_no_bpy_returns_unavailable_for_asset_library(self):
+        """Without bpy, the public library tool reports an unavailable runtime."""
+        tool = load_skill_script("blender-asset-source", "search_assets")
         with patch.dict(sys.modules, {"bpy": None}):
-            result = search_assets(source="asset_library")
+            result = tool.main(source="asset_library")
 
-        assert result["success"] is True
-        assert result["context"]["count"] == 0
+        assert result["success"] is False
+        assert "unavailable" in result["message"].lower()
 
     def test_descriptor_fields_match_contract(self, tmp_path):
         """All AssetDescriptor fields present and non-null for a real file."""

--- a/tests/test_skills_asset_source.py
+++ b/tests/test_skills_asset_source.py
@@ -190,6 +190,61 @@ class TestSearchAssetsFilesystem:
 
 
 class TestSearchAssetsAssetLibrary:
+    def test_permission_exception_does_not_hide_later_valid_library(self, tmp_path, monkeypatch):
+        restricted = tmp_path / "restricted"
+        restricted.mkdir()
+        valid = tmp_path / "valid"
+        _touch(valid / "hero.obj")
+        bpy = _library_bpy(
+            [
+                SimpleNamespace(name="Restricted", path=str(restricted)),
+                SimpleNamespace(name="Valid", path=str(valid)),
+            ]
+        )
+        original_is_dir = Path.is_dir
+
+        def is_dir(path):
+            if path == restricted:
+                raise PermissionError("Directory access denied")
+            return original_is_dir(path)
+
+        monkeypatch.setattr(Path, "is_dir", is_dir)
+        result = load_and_call("blender-asset-source/scripts/search_assets.py", bpy, source="asset_library")
+
+        assert result["success"], result
+        context = result["context"]
+        assert context["count"] == 1
+        assert context["asset_library_status"] == "partial"
+        assert "Restricted" in context["warnings"][0]
+        assert context["descriptors"][0]["name"] == "hero"
+        assert context["descriptors"][0]["metadata"]["library_name"] == "Valid"
+
+    def test_all_library_exceptions_return_error_with_each_failed_library(self, tmp_path, monkeypatch):
+        restricted = tmp_path / "restricted"
+        offline = tmp_path / "offline"
+        bpy = _library_bpy(
+            [
+                SimpleNamespace(name="Restricted", path=str(restricted)),
+                SimpleNamespace(name="Offline", path=str(offline)),
+            ]
+        )
+        original_is_dir = Path.is_dir
+
+        def is_dir(path):
+            if path == restricted:
+                raise PermissionError("Directory access denied")
+            if path == offline:
+                raise OSError("Library device offline")
+            return original_is_dir(path)
+
+        monkeypatch.setattr(Path, "is_dir", is_dir)
+        result = load_and_call("blender-asset-source/scripts/search_assets.py", bpy, source="asset_library")
+
+        assert result["success"] is False
+        assert result["context"]["asset_library_status"] == "error"
+        assert "Restricted" in result["error"]
+        assert "Offline" in result["error"]
+
     def test_broken_library_does_not_hide_later_valid_library(self, tmp_path):
         _touch(tmp_path / "hero.obj")
         bpy = _library_bpy(


### PR DESCRIPTION
Read registered local libraries from PreferencesFilePaths without UI refresh or preference writes. Isolate per-library failures so broken registrations cannot hide valid libraries; all-failed scans return errors. Preserve file-descriptor semantics. Validation: 781 unit tests, 22 focused tests, lint, and native registered-library checks on Blender 5.2.1 and 4.5.13 passed. Final-head CI passed. Native Asset Browser catalogs and remote libraries remain out of scope.