### PR TITLE
feat: add bounded mesh component discovery

### DIFF
--- a/src/dcc_mcp_blender/_mesh_query_ops.py
+++ b/src/dcc_mcp_blender/_mesh_query_ops.py
@@ -1,0 +1,221 @@
+"""Bounded component discovery for the original, object-local mesh."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from typing import Any, Optional, Sequence
+
+from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
+
+from dcc_mcp_blender._modeling_common import object_identity
+
+MAX_SCAN_ELEMENTS = 100_000
+MAX_PAGE_SIZE = 256
+MAX_RECORD_CONNECTIONS = 64
+
+
+def _vector(value: Any) -> list:
+    result = list(value)
+    if len(result) != 3 or any(isinstance(item, bool) or not isinstance(item, (int, float)) for item in result):
+        raise ValueError("Expected three finite numeric coordinates")
+    result = [float(item) for item in result]
+    if not all(math.isfinite(item) for item in result):
+        raise ValueError("Expected three finite numeric coordinates")
+    return result
+
+
+def _revision(obj: Any) -> str:
+    mesh = obj.data
+    digest = hashlib.sha256()
+
+    def append(value: Any) -> None:
+        digest.update(json.dumps(value, allow_nan=False, separators=(",", ":")).encode("ascii"))
+        digest.update(b"\n")
+
+    append(["mesh-query-v1", object_identity(obj), object_identity(mesh)])
+    for vertex in mesh.vertices:
+        append(["v", _vector(vertex.co), _vector(vertex.normal)])
+    for edge in mesh.edges:
+        append(["e", list(edge.vertices)])
+    for face in mesh.polygons:
+        append(["f", list(face.vertices), _vector(face.normal)])
+    return "mesh-query-v1:" + digest.hexdigest()
+
+
+def _connectivity(mesh: Any) -> dict:
+    vertex_edges = [[] for _ in mesh.vertices]
+    vertex_faces = [[] for _ in mesh.vertices]
+    edge_faces = [[] for _ in mesh.edges]
+    face_edges = []
+    edge_lookup = {}
+    for index, edge in enumerate(mesh.edges):
+        left, right = edge.vertices
+        vertex_edges[left].append(index)
+        vertex_edges[right].append(index)
+        edge_lookup[tuple(sorted((left, right)))] = index
+    for index, face in enumerate(mesh.polygons):
+        vertices = list(face.vertices)
+        edges = []
+        for left, right in zip(vertices, vertices[1:] + vertices[:1]):
+            vertex_faces[left].append(index)
+            edge_index = edge_lookup[tuple(sorted((left, right)))]
+            edge_faces[edge_index].append(index)
+            edges.append(edge_index)
+        face_edges.append(edges)
+    return {
+        "vertex_edges": vertex_edges,
+        "vertex_faces": vertex_faces,
+        "edge_faces": edge_faces,
+        "face_edges": face_edges,
+    }
+
+
+def _record(mesh: Any, connectivity: dict, component: str, index: int) -> dict:
+    record = {"index": index}
+    if component == "vertex":
+        vertex = mesh.vertices[index]
+        record.update(position=_vector(vertex.co), normal=_vector(vertex.normal))
+        connections = {"edge": connectivity["vertex_edges"][index], "face": connectivity["vertex_faces"][index]}
+    else:
+        item = (mesh.edges if component == "edge" else mesh.polygons)[index]
+        vertices = list(item.vertices)
+        positions = [_vector(mesh.vertices[vertex].co) for vertex in vertices]
+        record["position"] = _vector(
+            [sum(position[axis] / len(positions) for position in positions) for axis in range(3)]
+        )
+        connections = {"vertex": vertices}
+        if component == "edge":
+            connections["face"] = connectivity["edge_faces"][index]
+        else:
+            record["normal"] = _vector(item.normal)
+            connections["edge"] = connectivity["face_edges"][index]
+    record["connectivity_complete"] = True
+    for kind, indices in connections.items():
+        record[kind + "_count"] = len(indices)
+        record[kind + "_indices"] = indices[:MAX_RECORD_CONNECTIONS]
+        record["connectivity_complete"] &= len(indices) <= MAX_RECORD_CONNECTIONS
+    return record
+
+
+def _unit_vector(value: Any) -> list:
+    vector = _vector(value)
+    scale = max(abs(item) for item in vector)
+    if not scale:
+        raise ValueError("Normal direction cannot be zero")
+    scaled = [item / scale for item in vector]
+    length = math.sqrt(sum(item * item for item in scaled))
+    return [item / length for item in scaled]
+
+
+def _matches(
+    record: dict, bounds_min: Optional[list], bounds_max: Optional[list], direction: Optional[list], dot: float
+) -> bool:
+    if bounds_min is not None and any(
+        not low <= coordinate <= high for coordinate, low, high in zip(record["position"], bounds_min, bounds_max)
+    ):
+        return False
+    if direction is not None:
+        normal = record["normal"]
+        if not any(normal):
+            return False
+        if sum(left * right for left, right in zip(_unit_vector(normal), direction)) < dot:
+            return False
+    return True
+
+
+def inspect_mesh_components(
+    object_name: str,
+    component: str = "vertex",
+    offset: int = 0,
+    limit: int = 64,
+    expected_revision: Optional[str] = None,
+    bounds_min: Optional[Sequence[float]] = None,
+    bounds_max: Optional[Sequence[float]] = None,
+    normal_direction: Optional[Sequence[float]] = None,
+    normal_min_dot: float = 0.9,
+) -> dict:
+    """Return a bounded page of original-mesh components without changing mode."""
+    if not isinstance(object_name, str) or not object_name.strip():
+        return skill_error("Invalid object name", "Provide a non-empty mesh object name.")
+    if component not in ("vertex", "edge", "face"):
+        return skill_error("Invalid component", "Choose vertex, edge, or face.")
+    if isinstance(offset, bool) or not isinstance(offset, int) or not 0 <= offset <= MAX_SCAN_ELEMENTS:
+        return skill_error("Invalid offset", "Offset must be an integer within the scan bound.")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= MAX_PAGE_SIZE:
+        return skill_error("Invalid limit", "Limit must be an integer between 1 and 256.")
+    if expected_revision is not None and (
+        not isinstance(expected_revision, str)
+        or not expected_revision.startswith("mesh-query-v1:")
+        or len(expected_revision) != 78
+        or any(character not in "0123456789abcdef" for character in expected_revision[14:])
+    ):
+        return skill_error("Invalid revision", "Use the unchanged revision returned by this tool.")
+    try:
+        if (bounds_min is None) != (bounds_max is None):
+            raise ValueError("Provide both bounds_min and bounds_max")
+        lower = _vector(bounds_min) if bounds_min is not None else None
+        upper = _vector(bounds_max) if bounds_max is not None else None
+        if lower is not None and any(low > high for low, high in zip(lower, upper)):
+            raise ValueError("bounds_min must not exceed bounds_max")
+        if (
+            isinstance(normal_min_dot, bool)
+            or not isinstance(normal_min_dot, (int, float))
+            or not -1 <= normal_min_dot <= 1
+        ):
+            raise ValueError("normal_min_dot must be finite and between -1 and 1")
+        direction = _unit_vector(normal_direction) if normal_direction is not None else None
+        if direction is not None and component == "edge":
+            raise ValueError("Edges have no unique normal; use a vertex or face normal filter")
+    except (TypeError, ValueError) as exc:
+        return skill_error("Invalid geometric filter", str(exc))
+    try:
+        import bpy
+
+        obj = bpy.data.objects.get(object_name)
+        if obj is None or obj.type != "MESH":
+            return skill_error("Mesh not found", "Choose an existing mesh object.")
+        if obj.mode != "OBJECT" or obj.data.is_editmode:
+            return skill_error("Object mode required", "Leave Edit/Sculpt/Paint mode explicitly before inspecting.")
+        mesh = obj.data
+        counts = {"vertex": len(mesh.vertices), "edge": len(mesh.edges), "face": len(mesh.polygons)}
+        if sum(counts.values()) + len(mesh.loops) > MAX_SCAN_ELEMENTS:
+            return skill_error(
+                "Mesh scan limit exceeded", "Use a smaller mesh; this tool never returns partial revisions."
+            )
+        revision = _revision(obj)
+        if expected_revision is not None and revision != expected_revision:
+            return skill_error(
+                "Mesh revision changed",
+                "Discard previous component indices and query again without expected_revision.",
+                error_code="stale_mesh_revision",
+                current_revision=revision,
+            )
+        connectivity = _connectivity(mesh)
+        records = []
+        stop = min(offset, counts[component])
+        for index in range(offset, counts[component]):
+            stop = index + 1
+            record = _record(mesh, connectivity, component, index)
+            if _matches(record, lower, upper, direction, normal_min_dot):
+                records.append(record)
+                if len(records) == limit:
+                    break
+        return skill_success(
+            "Inspected mesh components",
+            object_name=obj.name,
+            mesh_name=mesh.name,
+            component=component,
+            coordinate_space="local",
+            mesh_source="original",
+            revision=revision,
+            counts=counts,
+            records=records,
+            next_offset=stop if stop < counts[component] else None,
+            prompt="Re-query after geometry edits; component indices are not stable across topology changes.",
+        )
+    except ImportError:
+        return skill_error("Blender not available", "bpy could not be imported.")
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to inspect mesh components")

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/SKILL.md
@@ -19,6 +19,7 @@ metadata:
       create primitive, loft sections, lathe profile, extrude faces, bevel edges,
       inset faces, boolean, edge loop, array instances, mirror, pivot, freeze transforms,
       auto UV, UV projection, assign material, select by material
+      inspect mesh components, vertex coordinates, edge adjacency, face normals
     search-aliases: [polygon edit, hard surface modeling, fuselage loft, revolve profile, rotor array, pivot origin, mesh cleanup, topology fix, UV projection, material binding]
     intent: "Build and verify polygon models through the shared cross-DCC modeling vocabulary."
     recall-context:
@@ -70,3 +71,22 @@ existing names, and does not cut the wall behind the opening, create glass,
 assign material, bevel, or unwrap UVs. Follow with the corresponding typed
 tools. Recess the glazing and cut the wall separately so the depth remains
 visible; a coplanar opaque wall can hide the entire reveal.
+
+## Component discovery
+
+Use `inspect_mesh_components` before choosing vertex, edge, or face indices.
+It reads the original mesh in Object mode without changing selection or mode.
+Coordinates, centroids, and normal filters are object-local, not evaluated or
+world-space. The optional bounds filter tests each component's centroid.
+
+Pages contain at most 256 records. Pass `next_offset` and the returned
+`revision` as `expected_revision` for subsequent pages, with unchanged filters.
+The token covers mesh identity, coordinates, normals and connectivity; any
+change rejects stale paging. Discard indices after edits. Existing mutation
+tools do not yet consume this query token, so it is not a mutation guard.
+
+The scan rejects meshes above 100,000 total vertices/edges/faces/loops.
+Connectivity lists are capped at 64 entries per relation, with full counts and
+`connectivity_complete=false` when truncated. A rejected scan never returns
+a partial revision. For example, query faces with `normal_direction=[0,0,1]`
+and `normal_min_dot=0.9` to find locally upward-facing faces.

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/groups.yaml
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/groups.yaml
@@ -4,6 +4,7 @@ groups:
     default_active: true
     tools:
       - get_poly_count
+      - inspect_mesh_components
       - cleanup_mesh
       - triangulate_mesh
       - separate_mesh

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/inspect_mesh_components.py
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/scripts/inspect_mesh_components.py
@@ -1,0 +1,19 @@
+"""Inspect a bounded page of original Blender mesh components."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+
+from dcc_mcp_blender._mesh_query_ops import inspect_mesh_components
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Run the typed component query."""
+    return inspect_mesh_components(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/tools.yaml
@@ -34,6 +34,74 @@ tools:
       idempotent_hint: true
       open_world_hint: false
 
+  - name: inspect_mesh_components
+    description: >
+      Inspect bounded vertex, edge, or face coordinates, normals and adjacency
+      from the original Object-mode mesh. Local-space centroid/normal filters
+      and revision-pinned pagination help choose component indices before edits.
+    source_file: scripts/inspect_mesh_components.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 5
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [object_name]
+      properties:
+        object_name:
+          type: string
+          minLength: 1
+        component:
+          type: string
+          enum: [vertex, edge, face]
+          default: vertex
+        offset:
+          type: integer
+          minimum: 0
+          maximum: 100000
+          default: 0
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 256
+          default: 64
+        expected_revision:
+          type: string
+          pattern: '^mesh-query-v1:[0-9a-f]{64}$'
+          description: Revision returned by the preceding page; rejects stale indices.
+        bounds_min:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items: {type: number}
+          description: Inclusive local-space centroid minimum; requires bounds_max.
+        bounds_max:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items: {type: number}
+          description: Inclusive local-space centroid maximum; requires bounds_min.
+        normal_direction:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items: {type: number}
+          description: Nonzero local-space direction for vertex/face filtering; unsupported for edges.
+        normal_min_dot:
+          type: number
+          minimum: -1
+          maximum: 1
+          default: 0.9
+    output_schema: *mesh_result_schema
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+      open_world_hint: false
+
   - name: cleanup_mesh
     description: "Run common Blender mesh cleanup operators: merge doubles, fix normals, and delete loose geometry."
     source_file: scripts/cleanup_mesh.py

--- a/tests/e2e/test_mesh_component_query_e2e.py
+++ b/tests/e2e/test_mesh_component_query_e2e.py
@@ -1,0 +1,42 @@
+"""Native component coordinates, adjacency, paging and stale revision evidence."""
+
+from __future__ import annotations
+
+import pytest
+
+bpy = pytest.importorskip("bpy", reason="Requires native Blender")
+pytestmark = pytest.mark.e2e
+
+from tests.e2e.conftest import load_skill  # noqa: E402
+
+
+def test_cube_components_and_revision_pinned_pages():
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    bpy.ops.mesh.primitive_cube_add()
+    obj = bpy.context.object
+    query = load_skill("blender-mesh-ops", "inspect_mesh_components")
+    first = query.main(object_name=obj.name, component="vertex", limit=4)
+    assert first["success"], first
+    context = first["context"]
+    assert context["counts"] == {"vertex": 8, "edge": 12, "face": 6}
+    assert len(context["records"]) == 4
+    record = context["records"][0]
+    assert record["position"] == list(obj.data.vertices[0].co)
+    assert record["edge_count"] == 3
+    second = query.main(object_name=obj.name, offset=context["next_offset"], expected_revision=context["revision"])
+    assert second["success"], second
+    assert [record["index"] for record in second["context"]["records"]] == [4, 5, 6, 7]
+    assert second["context"]["next_offset"] is None
+    faces = query.main(object_name=obj.name, component="face", normal_direction=[0, 0, 1], normal_min_dot=0.99)
+    assert faces["success"], faces
+    assert len(faces["context"]["records"]) == 1
+    assert faces["context"]["records"][0]["vertex_count"] == 4
+    edges = query.main(object_name=obj.name, component="edge", limit=1)
+    assert edges["context"]["records"][0]["vertex_count"] == 2
+    assert edges["context"]["records"][0]["face_count"] == 2
+    obj.data.vertices[0].co.x += 0.125
+    obj.data.update()
+    stale = query.main(object_name=obj.name, expected_revision=context["revision"])
+    assert not stale["success"]
+    assert stale["context"]["error_code"] == "stale_mesh_revision"
+    assert obj.mode == "OBJECT"

--- a/tests/test_mesh_component_query.py
+++ b/tests/test_mesh_component_query.py
@@ -1,0 +1,139 @@
+"""Public skill behavior for bounded, read-only mesh component discovery."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tests.conftest import load_and_call
+
+SCRIPT = "blender-mesh-ops/scripts/inspect_mesh_components.py"
+
+
+def mesh_host():
+    """A small host boundary fixture with real collections and numeric values."""
+    coordinates = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    mesh = SimpleNamespace(
+        name="TriangleMesh",
+        is_editmode=False,
+        vertices=[SimpleNamespace(index=i, co=co, normal=(0.0, 0.0, 1.0)) for i, co in enumerate(coordinates)],
+        edges=[SimpleNamespace(index=i, vertices=pair) for i, pair in enumerate([(0, 1), (1, 2), (2, 0)])],
+        polygons=[SimpleNamespace(index=0, vertices=(0, 1, 2), normal=(0.0, 0.0, 1.0))],
+        loops=[SimpleNamespace(vertex_index=i, edge_index=i) for i in range(3)],
+    )
+    obj = SimpleNamespace(name="Triangle", type="MESH", mode="OBJECT", data=mesh)
+    return SimpleNamespace(data=SimpleNamespace(objects={obj.name: obj})), obj
+
+
+def test_query_discovers_one_vertex_page_without_mutating_the_host():
+    host, obj = mesh_host()
+    result = load_and_call(SCRIPT, host, object_name=obj.name, component="vertex", limit=2)
+
+    assert result["success"] is True
+    context = result["context"]
+    assert context["component"] == "vertex"
+    assert context["coordinate_space"] == "local"
+    assert context["mesh_source"] == "original"
+    assert [record["index"] for record in context["records"]] == [0, 1]
+    assert context["records"][0]["position"] == [0.0, 0.0, 0.0]
+    assert context["records"][0]["normal"] == [0.0, 0.0, 1.0]
+    assert context["next_offset"] == 2
+    assert context["revision"].startswith("mesh-query-v1:")
+    assert obj.mode == "OBJECT"
+    assert len(obj.data.vertices) == 3
+
+
+@pytest.mark.parametrize(
+    ("component", "expected"),
+    [
+        ("vertex", {"position": [0.0, 0.0, 0.0], "edge_indices": [0, 2], "face_indices": [0]}),
+        ("edge", {"position": [0.5, 0.0, 0.0], "vertex_indices": [0, 1], "face_indices": [0]}),
+        ("face", {"position": [1 / 3, 1 / 3, 0.0], "vertex_indices": [0, 1, 2], "edge_indices": [0, 1, 2]}),
+    ],
+)
+def test_query_returns_deterministic_component_geometry_and_connectivity(component, expected):
+    host, obj = mesh_host()
+    result = load_and_call(SCRIPT, host, object_name=obj.name, component=component, limit=1)
+
+    assert result["success"] is True
+    record = result["context"]["records"][0]
+    for key, value in expected.items():
+        assert record[key] == value
+    assert record["connectivity_complete"] is True
+
+
+def test_revision_pins_pages_and_rejects_even_small_coordinate_changes():
+    host, obj = mesh_host()
+    first = load_and_call(SCRIPT, host, object_name=obj.name, limit=1)["context"]
+    second = load_and_call(
+        SCRIPT, host, object_name=obj.name, offset=first["next_offset"], limit=1, expected_revision=first["revision"]
+    )
+    assert second["success"] is True
+    assert second["context"]["revision"] == first["revision"]
+    assert second["context"]["records"][0]["index"] == 1
+
+    obj.data.vertices[0].co = (1e-12, 0.0, 0.0)
+    stale = load_and_call(SCRIPT, host, object_name=obj.name, expected_revision=first["revision"])
+    assert stale["success"] is False
+    assert stale["context"]["error_code"] == "stale_mesh_revision"
+    assert "records" not in stale["context"]
+    assert stale["context"]["current_revision"] != first["revision"]
+
+
+def test_geometric_filters_scan_component_indices_in_order_and_pin_followup_pages():
+    host, obj = mesh_host()
+    arguments = dict(
+        object_name=obj.name,
+        bounds_min=[-0.1, -0.1, -0.1],
+        bounds_max=[0.1, 1.1, 0.1],
+        normal_direction=[0.0, 0.0, 2.0],
+        normal_min_dot=0.99,
+        limit=1,
+    )
+    first = load_and_call(SCRIPT, host, **arguments)
+    assert first["success"] is True
+    context = first["context"]
+    assert [item["index"] for item in context["records"]] == [0]
+    followup = load_and_call(
+        SCRIPT, host, **arguments, offset=context["next_offset"], expected_revision=context["revision"]
+    )
+    assert followup["success"] is True
+    assert [item["index"] for item in followup["context"]["records"]] == [2]
+    assert followup["context"]["next_offset"] is None
+
+    obj.data.vertices[0].normal = (0.0, 0.0, -1.0)
+    filtered = load_and_call(SCRIPT, host, **arguments)
+    assert [item["index"] for item in filtered["context"]["records"]] == [2]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"limit": 257},
+        {"limit": True},
+        {"offset": -1},
+        {"offset": 1.5},
+        {"expected_revision": "wrong"},
+        {"bounds_min": [0, 0, 0]},
+        {"normal_direction": [0, 0, 0]},
+        {"normal_min_dot": float("nan")},
+        {"component": "edge", "normal_direction": [0, 0, 1]},
+    ],
+)
+def test_invalid_queries_fail_without_component_records(kwargs):
+    host, obj = mesh_host()
+    result = load_and_call(SCRIPT, host, object_name=obj.name, **kwargs)
+    assert result["success"] is False
+    assert "records" not in result["context"]
+
+
+def test_edit_mode_and_oversized_mesh_fail_without_partial_revision():
+    host, obj = mesh_host()
+    obj.mode = "EDIT"
+    assert not load_and_call(SCRIPT, host, object_name=obj.name)["success"]
+    obj.mode = "OBJECT"
+    obj.data.loops = range(100_001)
+    result = load_and_call(SCRIPT, host, object_name=obj.name)
+    assert not result["success"]
+    assert "revision" not in result["context"]

--- a/tests/test_skills_mesh_scene_ops.py
+++ b/tests/test_skills_mesh_scene_ops.py
@@ -29,6 +29,7 @@ NEW_OBJECT_TOOLS = {
 }
 
 MESH_OPS_TOOLS = {
+    "inspect_mesh_components",
     "add_edge_loop",
     "array_instances",
     "assign_material",


### PR DESCRIPTION
Add bounded original-mesh component discovery with coordinates, normals, adjacency, geometric filters, and revision-pinned paging. Preserve selection and mode; reject oversized, stale, or unavailable mesh snapshots. Validation: 797 unit tests, 36 focused tests, lint, and native paging/revision checks on Blender 5.2.1 and 4.5.13 passed. Final-head CI passed. Mutation guards follow separately.