### PR TITLE
feat: guard component edits with mesh revisions

### DIFF
--- a/docs/capability-coverage.md
+++ b/docs/capability-coverage.md
@@ -22,6 +22,19 @@ Version-specific unavailable capabilities must report that state explicitly.
 Long-running operations require bounded admission, status, cancellation and
 terminal artifact validation. Existing unrelated worktrees remain independent.
 
+### Submitted slices (not phase completion)
+
+- #206: current LTS/Python CI and compatibility, nonempty native test evidence,
+  and UV handle lifetime repair. Version/context discovery and gateway
+  workflow acceptance remain open.
+- #207: registered local asset-library directory discovery. Native asset
+  catalogs and dependency inspection remain open.
+- #208: bounded original-mesh component discovery with revision-pinned pages.
+- Follow-up: optional revision checks before extrude, bevel, inset, and edge
+  subdivision. Unguarded callers and other mutation tools are not protected.
+
+These slices do not establish full Phase 1 coverage or the Phase 4 benchmarks.
+
 ## Domain gaps
 
 | Domain | Existing foundation | Remaining workflow coverage |

--- a/src/dcc_mcp_blender/_mesh_query_ops.py
+++ b/src/dcc_mcp_blender/_mesh_query_ops.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
-from typing import Any, Optional, Sequence
+from typing import Any, Optional, Sequence, Tuple
 
 from dcc_mcp_core.skill import skill_error, skill_exception, skill_success
 
@@ -42,6 +42,56 @@ def _revision(obj: Any) -> str:
     for face in mesh.polygons:
         append(["f", list(face.vertices), _vector(face.normal)])
     return "mesh-query-v1:" + digest.hexdigest()
+
+
+def mesh_revision(obj: Any, expected_revision: Optional[str] = None) -> Tuple[Optional[str], Optional[dict]]:
+    """Read or check a bounded revision without selection, mode changes or adjacency allocation."""
+    if expected_revision is not None and (
+        not isinstance(expected_revision, str)
+        or not expected_revision.startswith("mesh-query-v1:")
+        or len(expected_revision) != 78
+        or any(character not in "0123456789abcdef" for character in expected_revision[14:])
+    ):
+        return None, skill_error(
+            "Invalid revision",
+            "Use the unchanged revision returned by inspect_mesh_components.",
+            error_code="invalid_mesh_revision",
+            mutation_applied=False,
+        )
+    try:
+        if obj.mode != "OBJECT" or obj.data.is_editmode:
+            return None, skill_error(
+                "Object mode required",
+                "Leave Edit/Sculpt/Paint mode explicitly before querying or using a component revision.",
+                error_code="mesh_revision_mode_required",
+                mutation_applied=False,
+            )
+        mesh = obj.data
+        if sum(len(items) for items in (mesh.vertices, mesh.edges, mesh.polygons, mesh.loops)) > MAX_SCAN_ELEMENTS:
+            return None, skill_error(
+                "Mesh scan limit exceeded",
+                "Use a smaller mesh; component revisions are never partial.",
+                error_code="mesh_revision_scan_limit",
+                mutation_applied=False,
+            )
+        revision = _revision(obj)
+        if expected_revision is not None and revision != expected_revision:
+            return None, skill_error(
+                "Mesh revision changed",
+                "Discard previous component indices and query again without expected_revision.",
+                error_code="stale_mesh_revision",
+                current_revision=revision,
+                mutation_applied=False,
+            )
+        return revision, None
+    except Exception as exc:
+        return None, skill_error(
+            "Mesh revision unavailable",
+            "The original mesh could not be read safely. Inspect the object before retrying.",
+            error_code="mesh_revision_unavailable",
+            error_type=type(exc).__name__,
+            mutation_applied=False,
+        )
 
 
 def _connectivity(mesh: Any) -> dict:
@@ -145,13 +195,6 @@ def inspect_mesh_components(
         return skill_error("Invalid offset", "Offset must be an integer within the scan bound.")
     if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= MAX_PAGE_SIZE:
         return skill_error("Invalid limit", "Limit must be an integer between 1 and 256.")
-    if expected_revision is not None and (
-        not isinstance(expected_revision, str)
-        or not expected_revision.startswith("mesh-query-v1:")
-        or len(expected_revision) != 78
-        or any(character not in "0123456789abcdef" for character in expected_revision[14:])
-    ):
-        return skill_error("Invalid revision", "Use the unchanged revision returned by this tool.")
     try:
         if (bounds_min is None) != (bounds_max is None):
             raise ValueError("Provide both bounds_min and bounds_max")
@@ -176,22 +219,11 @@ def inspect_mesh_components(
         obj = bpy.data.objects.get(object_name)
         if obj is None or obj.type != "MESH":
             return skill_error("Mesh not found", "Choose an existing mesh object.")
-        if obj.mode != "OBJECT" or obj.data.is_editmode:
-            return skill_error("Object mode required", "Leave Edit/Sculpt/Paint mode explicitly before inspecting.")
+        revision, error = mesh_revision(obj, expected_revision)
+        if error:
+            return error
         mesh = obj.data
         counts = {"vertex": len(mesh.vertices), "edge": len(mesh.edges), "face": len(mesh.polygons)}
-        if sum(counts.values()) + len(mesh.loops) > MAX_SCAN_ELEMENTS:
-            return skill_error(
-                "Mesh scan limit exceeded", "Use a smaller mesh; this tool never returns partial revisions."
-            )
-        revision = _revision(obj)
-        if expected_revision is not None and revision != expected_revision:
-            return skill_error(
-                "Mesh revision changed",
-                "Discard previous component indices and query again without expected_revision.",
-                error_code="stale_mesh_revision",
-                current_revision=revision,
-            )
         connectivity = _connectivity(mesh)
         records = []
         stop = min(offset, counts[component])

--- a/src/dcc_mcp_blender/_modeling_topology.py
+++ b/src/dcc_mcp_blender/_modeling_topology.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import math
-from typing import Sequence
+from typing import Optional, Sequence
 
 from dcc_mcp_core.skill import skill_error, skill_exception
 
+from dcc_mcp_blender._mesh_query_ops import mesh_revision
 from dcc_mcp_blender._modeling_common import (
     bounded_indices,
     mesh_evidence_counts,
@@ -40,7 +41,13 @@ def _topology_exception_receipt(obj, before, exc, operation) -> dict:
     )
 
 
-def bevel_edges(object_name: str, edge_indices: Sequence[int], width: float, segments: int = 1) -> dict:
+def bevel_edges(
+    object_name: str,
+    edge_indices: Sequence[int],
+    width: float,
+    segments: int = 1,
+    expected_revision: Optional[str] = None,
+) -> dict:
     """Bevel explicit edges and require a host topology delta."""
     obj = None
     before = None
@@ -59,6 +66,10 @@ def bevel_edges(object_name: str, edge_indices: Sequence[int], width: float, seg
         obj, error = mesh_object(bpy, object_name)
         if error:
             return error
+        if expected_revision is not None:
+            _, error = mesh_revision(obj, expected_revision)
+            if error:
+                return error
         selected, error = bounded_indices(edge_indices, "edge_indices", len(obj.data.edges))
         if error:
             return error
@@ -80,10 +91,13 @@ def bevel_edges(object_name: str, edge_indices: Sequence[int], width: float, seg
                 before=before,
                 after=after,
             )
+        parameters = {"edge_indices": selected, "segments": segments, "width": width_value}
+        if expected_revision is not None:
+            parameters["expected_revision"] = expected_revision
         return topology_result(
             "Bevel edges",
             obj,
-            {"edge_indices": selected, "segments": segments, "width": width_value},
+            parameters,
             before,
             after,
             "edge_count",
@@ -102,6 +116,7 @@ def extrude_faces(
     face_indices: Sequence[int],
     distance: float = 0.0,
     direction: Sequence[float] = (0.0, 0.0, 1.0),
+    expected_revision: Optional[str] = None,
 ) -> dict:
     """Extrude explicit faces and require a host topology delta."""
     obj = None
@@ -122,6 +137,10 @@ def extrude_faces(
         obj, error = mesh_object(bpy, object_name)
         if error:
             return error
+        if expected_revision is not None:
+            _, error = mesh_revision(obj, expected_revision)
+            if error:
+                return error
         selected, error = bounded_indices(face_indices, "face_indices", len(obj.data.polygons))
         if error:
             return error
@@ -144,10 +163,13 @@ def extrude_faces(
                 before=before,
                 after=after,
             )
+        parameters = {"direction": direction_value, "distance": distance_value, "face_indices": selected}
+        if expected_revision is not None:
+            parameters["expected_revision"] = expected_revision
         return topology_result(
             "Extrude faces",
             obj,
-            {"direction": direction_value, "distance": distance_value, "face_indices": selected},
+            parameters,
             before,
             after,
             "face_count",
@@ -166,6 +188,7 @@ def inset(
     face_indices: Sequence[int],
     thickness: float,
     depth: float = 0.0,
+    expected_revision: Optional[str] = None,
 ) -> dict:
     """Inset explicit faces and require a host topology delta."""
     obj = None
@@ -184,6 +207,10 @@ def inset(
         obj, error = mesh_object(bpy, object_name)
         if error:
             return error
+        if expected_revision is not None:
+            _, error = mesh_revision(obj, expected_revision)
+            if error:
+                return error
         selected, error = bounded_indices(face_indices, "face_indices", len(obj.data.polygons))
         if error:
             return error
@@ -205,10 +232,13 @@ def inset(
                 before=before,
                 after=after,
             )
+        parameters = {"depth": depth_value, "face_indices": selected, "thickness": thickness_value}
+        if expected_revision is not None:
+            parameters["expected_revision"] = expected_revision
         return topology_result(
             "Inset faces",
             obj,
-            {"depth": depth_value, "face_indices": selected, "thickness": thickness_value},
+            parameters,
             before,
             after,
             "face_count",
@@ -222,7 +252,9 @@ def inset(
         return skill_exception(exc, message=f"Failed to inset faces on {object_name}")
 
 
-def add_edge_loop(object_name: str, edge_indices: Sequence[int], cuts: int = 1) -> dict:
+def add_edge_loop(
+    object_name: str, edge_indices: Sequence[int], cuts: int = 1, expected_revision: Optional[str] = None
+) -> dict:
     """Subdivide an explicit edge ring and require a host topology delta."""
     obj = None
     before = None
@@ -235,6 +267,10 @@ def add_edge_loop(object_name: str, edge_indices: Sequence[int], cuts: int = 1) 
         obj, error = mesh_object(bpy, object_name)
         if error:
             return error
+        if expected_revision is not None:
+            _, error = mesh_revision(obj, expected_revision)
+            if error:
+                return error
         selected, error = bounded_indices(edge_indices, "edge_indices", len(obj.data.edges))
         if error:
             return error
@@ -256,10 +292,13 @@ def add_edge_loop(object_name: str, edge_indices: Sequence[int], cuts: int = 1) 
                 before=before,
                 after=after,
             )
+        parameters = {"cuts": cuts, "edge_indices": selected}
+        if expected_revision is not None:
+            parameters["expected_revision"] = expected_revision
         return topology_result(
             "Add edge loop",
             obj,
-            {"cuts": cuts, "edge_indices": selected},
+            parameters,
             before,
             after,
             "edge_count",

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/SKILL.md
@@ -81,9 +81,23 @@ world-space. The optional bounds filter tests each component's centroid.
 
 Pages contain at most 256 records. Pass `next_offset` and the returned
 `revision` as `expected_revision` for subsequent pages, with unchanged filters.
-The token covers mesh identity, coordinates, normals and connectivity; any
-change rejects stale paging. Discard indices after edits. Existing mutation
-tools do not yet consume this query token, so it is not a mutation guard.
+The token covers mesh identity, coordinates, normals and connectivity; changes
+to these reject stale paging. It is process-local, not a durable ID or an
+evaluated/world-space geometry revision. Discard indices after edits or reloads.
+
+For `extrude_faces`, `bevel_edges`, `inset`, and `add_edge_loop`, pass the same
+token as `expected_revision`. The tool checks it on the host main thread
+before changing mode, selection, or geometry. Stale, malformed, unreadable,
+oversized, and non-Object-mode meshes fail without an edit. Query again and
+choose fresh indices; never retry the old indices with the guard removed.
+Omitting the optional token preserves legacy unguarded behavior. Other
+mutation tools do not yet accept this guard.
+
+Use the sequence `inspect_mesh_components -> guarded edit -> inspect_mesh_components`.
+Read the edit's topology evidence before querying the resulting mesh. The
+guard prevents a stale target; it is not rollback or cancellation once the
+native operator starts. UVs, materials, selection, transforms, and modifiers
+are outside this original-mesh revision contract.
 
 The scan rejects meshes above 100,000 total vertices/edges/faces/loops.
 Connectivity lists are capped at 64 entries per relation, with full counts and

--- a/src/dcc_mcp_blender/skills/blender-mesh-ops/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-mesh-ops/tools.yaml
@@ -361,12 +361,16 @@ tools:
       open_world_hint: false
 
   - name: extrude_faces
-    description: "Extrude an explicit bounded face selection and verify the resulting topology."
+    description: "Extrude bounded face indices and verify topology. Supply the query revision to reject stale indices before editing."
     source_file: scripts/extrude_faces.py
     execution: sync
     affinity: main
+    enforce_thread_affinity: true
     group: modeling
-    timeout_hint_secs: 0
+    timeout_hint_secs: 30
+    next-tools: &component_edit_recovery
+      on-success: [inspect_mesh_components]
+      on-failure: [inspect_mesh_components]
     input_schema:
       type: object
       additionalProperties: false
@@ -375,6 +379,10 @@ tools:
         object_name:
           type: string
           minLength: 1
+        expected_revision: &component_edit_revision
+          type: string
+          pattern: '^mesh-query-v1:[0-9a-f]{64}$'
+          description: Exact inspect_mesh_components revision; checks the original Object-mode mesh before any edit. Omit for legacy unguarded behavior.
         face_indices:
           type: array
           minItems: 1
@@ -475,12 +483,14 @@ tools:
     annotations: *modeling_annotations
 
   - name: bevel_edges
-    description: "Bevel explicit mesh edges with bounded width and segments, then verify topology."
+    description: "Bevel bounded edge indices and verify topology. Supply the query revision to reject stale indices before editing."
     source_file: scripts/bevel_edges.py
     execution: sync
     affinity: main
+    enforce_thread_affinity: true
     group: modeling
-    timeout_hint_secs: 0
+    timeout_hint_secs: 30
+    next-tools: *component_edit_recovery
     input_schema:
       type: object
       additionalProperties: false
@@ -490,6 +500,7 @@ tools:
         edge_indices: {type: array, minItems: 1, maxItems: 4096, uniqueItems: true, items: {type: integer, minimum: 0}}
         width: {type: number, exclusiveMinimum: 0, maximum: 1000000}
         segments: {type: integer, minimum: 1, maximum: 64, default: 1}
+        expected_revision: *component_edit_revision
     output_schema: *mesh_result_schema
     read_only: false
     destructive: true
@@ -497,12 +508,14 @@ tools:
     annotations: *modeling_destructive_annotations
 
   - name: inset
-    description: "Inset explicit mesh faces with bounded thickness/depth and verify topology."
+    description: "Inset bounded face indices and verify topology. Supply the query revision to reject stale indices before editing."
     source_file: scripts/inset.py
     execution: sync
     affinity: main
+    enforce_thread_affinity: true
     group: modeling
-    timeout_hint_secs: 0
+    timeout_hint_secs: 30
+    next-tools: *component_edit_recovery
     input_schema:
       type: object
       additionalProperties: false
@@ -512,6 +525,7 @@ tools:
         face_indices: {type: array, minItems: 1, maxItems: 4096, uniqueItems: true, items: {type: integer, minimum: 0}}
         thickness: {type: number, minimum: 0, maximum: 1000000}
         depth: {type: number, minimum: -1000000, maximum: 1000000, default: 0}
+        expected_revision: *component_edit_revision
     output_schema: *mesh_result_schema
     read_only: false
     destructive: true
@@ -542,12 +556,14 @@ tools:
     annotations: *modeling_destructive_annotations
 
   - name: add_edge_loop
-    description: "Subdivide explicit mesh edges with bounded cuts and verify topology."
+    description: "Subdivide bounded edge indices and verify topology. Supply the query revision to reject stale indices before editing."
     source_file: scripts/add_edge_loop.py
     execution: sync
     affinity: main
+    enforce_thread_affinity: true
     group: modeling
-    timeout_hint_secs: 0
+    timeout_hint_secs: 30
+    next-tools: *component_edit_recovery
     input_schema:
       type: object
       additionalProperties: false
@@ -556,6 +572,7 @@ tools:
         object_name: {type: string, minLength: 1}
         edge_indices: {type: array, minItems: 1, maxItems: 4096, uniqueItems: true, items: {type: integer, minimum: 0}}
         cuts: {type: integer, minimum: 1, maximum: 64, default: 1}
+        expected_revision: *component_edit_revision
     output_schema: *mesh_result_schema
     read_only: false
     destructive: true

--- a/tests/e2e/test_mesh_component_guards_e2e.py
+++ b/tests/e2e/test_mesh_component_guards_e2e.py
@@ -1,0 +1,79 @@
+"""Native query-to-edit preconditions and post-edit invalidation on real meshes."""
+
+from __future__ import annotations
+
+import pytest
+
+bpy = pytest.importorskip("bpy", reason="Requires native Blender")
+pytestmark = pytest.mark.e2e
+
+from tests.e2e.conftest import load_skill  # noqa: E402
+
+EDITS = [
+    ("extrude_faces", {"face_indices": [0], "distance": 0.25}),
+    ("bevel_edges", {"edge_indices": [0], "width": 0.1}),
+    ("inset", {"face_indices": [0], "thickness": 0.1}),
+    ("add_edge_loop", {"edge_indices": [0], "cuts": 1}),
+]
+
+
+def _selection(obj):
+    return {
+        "active": bpy.context.view_layer.objects.active.as_pointer(),
+        "objects": [item.as_pointer() for item in bpy.context.selected_objects],
+        "mode": obj.mode,
+        "vertex": [item.select for item in obj.data.vertices],
+        "edge": [item.select for item in obj.data.edges],
+        "face": [item.select for item in obj.data.polygons],
+    }
+
+
+@pytest.mark.parametrize(("tool_name", "arguments"), EDITS)
+def test_fresh_revision_allows_edit_then_rejects_old_indices_without_context_changes(tool_name, arguments):
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    bpy.ops.mesh.primitive_cube_add()
+    obj = bpy.context.object
+    query = load_skill("blender-mesh-ops", "inspect_mesh_components")
+    edit = load_skill("blender-mesh-ops", tool_name)
+    before = query.main(object_name=obj.name)
+    assert before["success"], before
+    revision = before["context"]["revision"]
+
+    result = edit.main(object_name=obj.name, expected_revision=revision, **arguments)
+    assert result["success"], result
+    assert result["context"]["parameters"]["expected_revision"] == revision
+    assert result["context"]["readback"]["verified"] is True
+    after = query.main(object_name=obj.name)
+    assert after["success"], after
+    assert after["context"]["revision"] != revision
+    assert after["context"]["counts"]["vertex"] > before["context"]["counts"]["vertex"]
+
+    selection_before = _selection(obj)
+    stale = edit.main(object_name=obj.name, expected_revision=revision, **arguments)
+    assert not stale["success"], stale
+    assert stale["context"]["error_code"] == "stale_mesh_revision"
+    assert stale["context"]["mutation_applied"] is False
+    assert _selection(obj) == selection_before
+    unchanged = query.main(object_name=obj.name, expected_revision=after["context"]["revision"])
+    assert unchanged["success"], unchanged
+    assert unchanged["context"]["counts"] == after["context"]["counts"]
+
+
+def test_guard_rejection_preserves_an_explicit_edit_mode():
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    bpy.ops.mesh.primitive_cube_add()
+    obj = bpy.context.object
+    query = load_skill("blender-mesh-ops", "inspect_mesh_components")
+    revision = query.main(object_name=obj.name)["context"]["revision"]
+    bpy.ops.object.mode_set(mode="EDIT")
+    try:
+        result = load_skill("blender-mesh-ops", "extrude_faces").main(
+            object_name=obj.name, face_indices=[0], distance=0.25, expected_revision=revision
+        )
+        assert not result["success"], result
+        assert result["context"]["error_code"] == "mesh_revision_mode_required"
+        assert result["context"]["mutation_applied"] is False
+        assert obj.mode == "EDIT"
+    finally:
+        bpy.ops.object.mode_set(mode="OBJECT")
+    assert len(obj.data.polygons) == 6

--- a/tests/test_mesh_component_guards.py
+++ b/tests/test_mesh_component_guards.py
@@ -1,0 +1,90 @@
+"""Revision-pinned modeling must reject outdated component indices before edits."""
+
+import pytest
+import yaml
+
+from tests.conftest import SKILLS_ROOT, load_and_call
+from tests.test_mesh_component_query import SCRIPT, mesh_host
+
+EDITS = [
+    ("extrude_faces", {"face_indices": [0], "distance": 0.25}),
+    ("bevel_edges", {"edge_indices": [0], "width": 0.1}),
+    ("inset", {"face_indices": [0], "thickness": 0.1}),
+    ("add_edge_loop", {"edge_indices": [0], "cuts": 1}),
+]
+
+
+@pytest.mark.parametrize(("tool", "arguments"), EDITS)
+def test_edit_rejects_stale_query_revision_without_changing_the_mesh(tool, arguments):
+    host, obj = mesh_host()
+    revision = load_and_call(SCRIPT, host, object_name=obj.name)["context"]["revision"]
+    obj.data.vertices[0].co = (0.125, 0.0, 0.0)
+
+    result = load_and_call(
+        f"blender-mesh-ops/scripts/{tool}.py",
+        host,
+        object_name=obj.name,
+        expected_revision=revision,
+        **arguments,
+    )
+
+    assert not result["success"]
+    assert result["context"]["error_code"] == "stale_mesh_revision"
+    assert result["context"]["mutation_applied"] is False
+    assert obj.mode == "OBJECT"
+    assert len(obj.data.polygons) == 1
+    assert obj.data.vertices[0].co == (0.125, 0.0, 0.0)
+
+
+@pytest.mark.parametrize(("tool", "arguments"), EDITS)
+@pytest.mark.parametrize(
+    ("condition", "error_code"),
+    [
+        ("malformed", "invalid_mesh_revision"),
+        ("edit_mode", "mesh_revision_mode_required"),
+        ("oversize", "mesh_revision_scan_limit"),
+        ("unreadable", "mesh_revision_unavailable"),
+        ("nonfinite", "mesh_revision_unavailable"),
+        ("replaced_mesh", "stale_mesh_revision"),
+    ],
+)
+def test_unverifiable_revision_rejects_edit_without_operator_or_mode_changes(tool, arguments, condition, error_code):
+    host, obj = mesh_host()
+    revision = load_and_call(SCRIPT, host, object_name=obj.name)["context"]["revision"]
+    if condition == "malformed":
+        revision = "not-a-revision"
+    elif condition == "edit_mode":
+        obj.mode = "EDIT"
+    elif condition == "oversize":
+        obj.data.loops = range(100_001)
+    elif condition == "unreadable":
+        del obj.data.vertices[0].normal
+    elif condition == "nonfinite":
+        obj.data.vertices[0].co = (float("nan"), 0, 0)
+    elif condition == "replaced_mesh":
+        # Identical geometry under a replacement data block is not the queried mesh.
+        _, other = mesh_host()
+        obj.data = other.data
+    mode_before = obj.mode
+    result = load_and_call(
+        f"blender-mesh-ops/scripts/{tool}.py", host, object_name=obj.name, expected_revision=revision, **arguments
+    )
+    assert not result["success"]
+    assert result["context"]["error_code"] == error_code
+    assert result["context"]["mutation_applied"] is False
+    assert obj.mode == mode_before
+    assert len(obj.data.polygons) == 1
+
+
+@pytest.mark.parametrize(("tool", "arguments"), EDITS)
+def test_guarded_edit_discovery_declares_revision_and_query_recovery(tool, arguments):
+    tools = yaml.safe_load((SKILLS_ROOT / "blender-mesh-ops/tools.yaml").read_text(encoding="utf-8"))["tools"]
+    contract = next(item for item in tools if item["name"] == tool)
+    schema = contract["input_schema"]
+    revision = schema["properties"]["expected_revision"]
+    assert revision["type"] == "string"
+    assert revision["pattern"] == "^mesh-query-v1:[0-9a-f]{64}$"
+    assert "expected_revision" not in schema["required"]
+    assert contract["affinity"] == "main"
+    assert contract["enforce_thread_affinity"] is True
+    assert "inspect_mesh_components" in str(contract["next-tools"])


### PR DESCRIPTION
Add optional mesh revision checks before extrude, bevel, inset, and edge subdivision. Rejections preserve geometry, selection, and mode; omitted tokens retain legacy behavior. Includes recovery metadata and coverage boundaries. Validation: 829 unit tests, 108 focused tests, lint, and six native component tests on each Blender 5.2.1 and 4.5.13 passed. Final-head CI passed. Broader phases remain open.