### PR TITLE
fix: make camera tool contracts discoverable and safe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "jsonschema>=4.23",
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "pytest-mock>=3.0",

--- a/src/dcc_mcp_blender/_camera_validation.py
+++ b/src/dcc_mcp_blender/_camera_validation.py
@@ -3,9 +3,17 @@
 import math
 
 
-def positive_number(value, name):
-    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value <= 0:
-        raise ValueError("{} must be a finite positive number".format(name))
+def camera_number(value, name):
+    minimum = {"lens": 1.0, "clip_start": 1e-6, "clip_end": 1e-6, "ortho_scale": 0.0}[name]
+    # RNA stores camera properties as float32; reject values it would clamp.
+    maximum = 3.4028234663852886e38
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or not minimum <= value <= maximum
+    ):
+        raise ValueError("{} must be a finite number between {} and {}".format(name, minimum, maximum))
 
 
 def camera_location(value):

--- a/src/dcc_mcp_blender/_camera_validation.py
+++ b/src/dcc_mcp_blender/_camera_validation.py
@@ -1,0 +1,15 @@
+"""Validate camera requests before allocating or modifying Blender data."""
+
+import math
+
+
+def positive_number(value, name):
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value <= 0:
+        raise ValueError("{} must be a finite positive number".format(name))
+
+
+def camera_location(value):
+    if not isinstance(value, (list, tuple)) or len(value) != 3:
+        raise ValueError("location must contain three finite coordinates")
+    if any(isinstance(x, bool) or not isinstance(x, (int, float)) or not math.isfinite(x) for x in value):
+        raise ValueError("location must contain three finite coordinates")

--- a/src/dcc_mcp_blender/skills/blender-camera/SKILL.md
+++ b/src/dcc_mcp_blender/skills/blender-camera/SKILL.md
@@ -34,3 +34,12 @@ metadata:
 # blender-camera
 
 Blender camera management skill.
+
+Use `set_camera_properties` with `lens` in millimetres for perspective focal
+length, and `ortho_scale` in scene units for orthographic framing. Changing
+`lens` does not change the orthographic view width. `list_cameras` reports
+both values and the clipping range for readback.
+
+Camera requests validate numeric values and the effective clipping range
+before changing camera properties. Invalid requests leave those properties
+unchanged. Discover the explicit tool schemas and call examples before use.

--- a/src/dcc_mcp_blender/skills/blender-camera/scripts/create_camera.py
+++ b/src/dcc_mcp_blender/skills/blender-camera/scripts/create_camera.py
@@ -6,6 +6,8 @@ from typing import List, Optional
 
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+from dcc_mcp_blender._camera_validation import camera_location, positive_number
+
 
 def create_camera(
     name: Optional[str] = None,
@@ -27,7 +29,9 @@ def create_camera(
     try:
         import bpy
 
-        loc = location or [0.0, -8.0, 3.0]
+        loc = location if location is not None else [0.0, -8.0, 3.0]
+        positive_number(lens, "lens")
+        camera_location(loc)
         cam_data = bpy.data.cameras.new(name=name or "Camera")
         cam_data.lens = lens
 

--- a/src/dcc_mcp_blender/skills/blender-camera/scripts/create_camera.py
+++ b/src/dcc_mcp_blender/skills/blender-camera/scripts/create_camera.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
-from dcc_mcp_blender._camera_validation import camera_location, positive_number
+from dcc_mcp_blender._camera_validation import camera_location, camera_number
 
 
 def create_camera(
@@ -30,7 +30,7 @@ def create_camera(
         import bpy
 
         loc = location if location is not None else [0.0, -8.0, 3.0]
-        positive_number(lens, "lens")
+        camera_number(lens, "lens")
         camera_location(loc)
         cam_data = bpy.data.cameras.new(name=name or "Camera")
         cam_data.lens = lens

--- a/src/dcc_mcp_blender/skills/blender-camera/scripts/list_cameras.py
+++ b/src/dcc_mcp_blender/skills/blender-camera/scripts/list_cameras.py
@@ -20,6 +20,9 @@ def list_cameras() -> dict:
                 "name": obj.name,
                 "lens": obj.data.lens,
                 "type": obj.data.type,
+                "ortho_scale": obj.data.ortho_scale,
+                "clip_start": obj.data.clip_start,
+                "clip_end": obj.data.clip_end,
                 "location": list(obj.location),
                 "is_active": obj == active_camera,
             }

--- a/src/dcc_mcp_blender/skills/blender-camera/scripts/set_camera_properties.py
+++ b/src/dcc_mcp_blender/skills/blender-camera/scripts/set_camera_properties.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
-from dcc_mcp_blender._camera_validation import positive_number
+from dcc_mcp_blender._camera_validation import camera_number
 
 VALID_CAMERA_TYPES = {"PERSP", "ORTHO", "PANO"}
 
@@ -57,7 +57,7 @@ def set_camera_properties(
             ("ortho_scale", ortho_scale),
         ):
             if value is not None:
-                positive_number(value, key)
+                camera_number(value, key)
         near = clip_start if clip_start is not None else cam.clip_start
         far = clip_end if clip_end is not None else cam.clip_end
         if (clip_start is not None or clip_end is not None) and near >= far:

--- a/src/dcc_mcp_blender/skills/blender-camera/scripts/set_camera_properties.py
+++ b/src/dcc_mcp_blender/skills/blender-camera/scripts/set_camera_properties.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+from dcc_mcp_blender._camera_validation import positive_number
+
 VALID_CAMERA_TYPES = {"PERSP", "ORTHO", "PANO"}
 
 
@@ -15,15 +17,17 @@ def set_camera_properties(
     camera_type: Optional[str] = None,
     clip_start: Optional[float] = None,
     clip_end: Optional[float] = None,
+    ortho_scale: Optional[float] = None,
 ) -> dict:
     """Configure camera data properties.
 
     Args:
         name: Name of the camera object.
-        lens: Focal length in mm (perspective) or orthographic scale.
+        lens: Focal length in mm; does not change orthographic framing.
         camera_type: Camera projection type: PERSP, ORTHO, or PANO.
         clip_start: Near clipping distance.
         clip_end: Far clipping distance.
+        ortho_scale: Orthographic view width in scene units.
 
     Returns:
         ActionResultModel dict.
@@ -38,20 +42,37 @@ def set_camera_properties(
             return skill_error(f"{name} is not a camera", f"Object type is {obj.type}.")
 
         cam = obj.data
-        if lens is not None:
-            cam.lens = lens
-        if camera_type:
+        # Validate the entire request before applying any field.
+        if camera_type is not None:
             camera_type = camera_type.upper()
             if camera_type not in VALID_CAMERA_TYPES:
                 return skill_error(
                     f"Invalid camera type: {camera_type}",
                     f"Valid types: {', '.join(sorted(VALID_CAMERA_TYPES))}",
                 )
+        for key, value in (
+            ("lens", lens),
+            ("clip_start", clip_start),
+            ("clip_end", clip_end),
+            ("ortho_scale", ortho_scale),
+        ):
+            if value is not None:
+                positive_number(value, key)
+        near = clip_start if clip_start is not None else cam.clip_start
+        far = clip_end if clip_end is not None else cam.clip_end
+        if (clip_start is not None or clip_end is not None) and near >= far:
+            return skill_error("Invalid clipping range", "clip_start must be less than clip_end.")
+
+        if lens is not None:
+            cam.lens = lens
+        if camera_type is not None:
             cam.type = camera_type
         if clip_start is not None:
             cam.clip_start = clip_start
         if clip_end is not None:
             cam.clip_end = clip_end
+        if ortho_scale is not None:
+            cam.ortho_scale = ortho_scale
 
         return skill_success(
             f"Camera properties updated: {name}",
@@ -60,6 +81,7 @@ def set_camera_properties(
             camera_type=cam.type,
             clip_start=cam.clip_start,
             clip_end=cam.clip_end,
+            ortho_scale=cam.ortho_scale,
             prompt="Camera configured. Use render_scene to render.",
         )
     except ImportError:

--- a/src/dcc_mcp_blender/skills/blender-camera/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-camera/tools.yaml
@@ -25,7 +25,8 @@ tools:
         description: World position [x, y, z] in scene units.
       lens:
         type: number
-        exclusiveMinimum: 0
+        minimum: 1
+        maximum: 3.4028234663852886e+38
         default: 50.0
         description: Focal length in millimetres.
       set_as_active:
@@ -108,7 +109,8 @@ tools:
       name: *id001
       lens:
         type: number
-        exclusiveMinimum: 0
+        minimum: 1
+        maximum: 3.4028234663852886e+38
         description: Focal length in millimetres; does not affect orthographic framing.
       camera_type:
         type: string
@@ -118,15 +120,18 @@ tools:
         - PANO
       clip_start:
         type: number
-        exclusiveMinimum: 0
+        minimum: 0.000001
+        maximum: 3.4028234663852886e+38
         description: Near clipping distance; must be less than the effective far distance.
       clip_end:
         type: number
-        exclusiveMinimum: 0
+        minimum: 0.000001
+        maximum: 3.4028234663852886e+38
         description: Far clipping distance; must exceed the effective near distance.
       ortho_scale:
         type: number
-        exclusiveMinimum: 0
+        minimum: 0
+        maximum: 3.4028234663852886e+38
         description: Orthographic view width in scene units.
     required:
     - name

--- a/src/dcc_mcp_blender/skills/blender-camera/tools.yaml
+++ b/src/dcc_mcp_blender/skills/blender-camera/tools.yaml
@@ -1,33 +1,186 @@
 tools:
-  - name: create_camera
-    description: "Create a new camera object"
-    source_file: scripts/create_camera.py
-    execution: sync
-    affinity: main
-    read_only: false
-    destructive: false
-    idempotent: false
-  - name: set_active_camera
-    description: "Set the active render camera for the scene"
-    source_file: scripts/set_active_camera.py
-    execution: sync
-    affinity: main
-    read_only: false
-    destructive: false
-    idempotent: true
-  - name: set_camera_properties
-    description: "Configure camera properties (focal length, type, etc.)"
-    source_file: scripts/set_camera_properties.py
-    execution: sync
-    affinity: main
-    read_only: false
-    destructive: false
-    idempotent: true
-  - name: list_cameras
-    description: "List all cameras in the scene"
-    source_file: scripts/list_cameras.py
-    execution: sync
-    affinity: main
-    read_only: true
-    destructive: false
-    idempotent: true
+- name: create_camera
+  description: Create a new camera object
+  source_file: scripts/create_camera.py
+  execution: sync
+  affinity: main
+  read_only: false
+  destructive: false
+  idempotent: false
+  enforce_thread_affinity: true
+  input_schema:
+    type: object
+    additionalProperties: false
+    properties:
+      name: &id001
+        type: string
+        minLength: 1
+        description: Exact Blender camera object name.
+      location:
+        type: array
+        minItems: 3
+        maxItems: 3
+        items:
+          type: number
+        description: World position [x, y, z] in scene units.
+      lens:
+        type: number
+        exclusiveMinimum: 0
+        default: 50.0
+        description: Focal length in millimetres.
+      set_as_active:
+        type: boolean
+        default: false
+  output_schema:
+    type: object
+    required:
+    - success
+    properties:
+      success:
+        type: boolean
+      message:
+        type: string
+      context:
+        type: object
+    additionalProperties: true
+  annotations:
+    read_only_hint: false
+    destructive_hint: false
+    idempotent_hint: false
+    open_world_hint: false
+  call_examples:
+  - arguments:
+      name: ReviewCamera
+      location:
+      - 0
+      - -8
+      - 3
+      lens: 85
+- name: set_active_camera
+  description: Set the active render camera for the scene
+  source_file: scripts/set_active_camera.py
+  execution: sync
+  affinity: main
+  read_only: false
+  destructive: false
+  idempotent: true
+  enforce_thread_affinity: true
+  input_schema:
+    type: object
+    additionalProperties: false
+    properties:
+      name: *id001
+    required:
+    - name
+  output_schema:
+    type: object
+    required:
+    - success
+    properties:
+      success:
+        type: boolean
+      message:
+        type: string
+      context:
+        type: object
+    additionalProperties: true
+  annotations:
+    read_only_hint: false
+    destructive_hint: false
+    idempotent_hint: true
+    open_world_hint: false
+  call_examples:
+  - arguments:
+      name: ReviewCamera
+- name: set_camera_properties
+  description: Configure camera properties (focal length, type, etc.)
+  source_file: scripts/set_camera_properties.py
+  execution: sync
+  affinity: main
+  read_only: false
+  destructive: false
+  idempotent: true
+  enforce_thread_affinity: true
+  input_schema:
+    type: object
+    additionalProperties: false
+    properties:
+      name: *id001
+      lens:
+        type: number
+        exclusiveMinimum: 0
+        description: Focal length in millimetres; does not affect orthographic framing.
+      camera_type:
+        type: string
+        enum:
+        - PERSP
+        - ORTHO
+        - PANO
+      clip_start:
+        type: number
+        exclusiveMinimum: 0
+        description: Near clipping distance; must be less than the effective far distance.
+      clip_end:
+        type: number
+        exclusiveMinimum: 0
+        description: Far clipping distance; must exceed the effective near distance.
+      ortho_scale:
+        type: number
+        exclusiveMinimum: 0
+        description: Orthographic view width in scene units.
+    required:
+    - name
+  output_schema:
+    type: object
+    required:
+    - success
+    properties:
+      success:
+        type: boolean
+      message:
+        type: string
+      context:
+        type: object
+    additionalProperties: true
+  annotations:
+    read_only_hint: false
+    destructive_hint: false
+    idempotent_hint: true
+    open_world_hint: false
+  call_examples:
+  - arguments:
+      name: ReviewCamera
+      camera_type: ORTHO
+      ortho_scale: 3.2
+- name: list_cameras
+  description: List all cameras in the scene
+  source_file: scripts/list_cameras.py
+  execution: sync
+  affinity: main
+  read_only: true
+  destructive: false
+  idempotent: true
+  enforce_thread_affinity: true
+  input_schema:
+    type: object
+    additionalProperties: false
+    properties: {}
+  output_schema:
+    type: object
+    required:
+    - success
+    properties:
+      success:
+        type: boolean
+      message:
+        type: string
+      context:
+        type: object
+    additionalProperties: true
+  annotations:
+    read_only_hint: true
+    destructive_hint: false
+    idempotent_hint: true
+    open_world_hint: false
+  call_examples:
+  - arguments: {}

--- a/tests/test_camera_tool_contracts.py
+++ b/tests/test_camera_tool_contracts.py
@@ -1,0 +1,23 @@
+"""Published camera schemas must be usable without importing bpy scripts."""
+
+import inspect
+
+import jsonschema
+import yaml
+
+from tests.conftest import SKILLS_ROOT, load_skill_script
+
+
+def test_camera_schemas_describe_script_arguments_and_examples():
+    tools = yaml.safe_load((SKILLS_ROOT / "blender-camera" / "tools.yaml").read_text())["tools"]
+    for tool in tools:
+        schema = tool["input_schema"]
+        jsonschema.Draft202012Validator.check_schema(schema)
+        module = load_skill_script("blender-camera", tool["name"])
+        signature = inspect.signature(getattr(module, tool["name"]))
+        assert set(schema["properties"]) == set(signature.parameters)
+        required = [key for key, value in signature.parameters.items() if value.default is inspect.Parameter.empty]
+        assert sorted(schema.get("required", [])) == sorted(required)
+        assert tool["enforce_thread_affinity"] is True
+        for example in tool["call_examples"]:
+            jsonschema.validate(example["arguments"], schema)

--- a/tests/test_skills_camera.py
+++ b/tests/test_skills_camera.py
@@ -25,7 +25,15 @@ def _make_camera_obj(name="Camera"):
 
 class TestCreateCamera:
     @pytest.mark.parametrize(
-        "args", [{"lens": 0}, {"lens": float("nan")}, {"location": []}, {"location": [0, 0, float("inf")]}]
+        "args",
+        [
+            {"lens": 0},
+            {"lens": 0.5},
+            {"lens": 1e39},
+            {"lens": float("nan")},
+            {"location": []},
+            {"location": [0, 0, float("inf")]},
+        ],
     )
     def test_invalid_request_does_not_allocate_camera(self, args):
         bpy = make_mock_bpy()
@@ -108,6 +116,10 @@ class TestSetCameraProperties:
             {"camera_type": "ORTHO", "lens": float("nan")},
             {"lens": 85, "clip_end": float("inf")},
             {"lens": True},
+            {"lens": 0.5},
+            {"lens": 85, "clip_start": 1e-9},
+            {"lens": 85, "clip_end": 1e-9},
+            {"lens": 85, "ortho_scale": 1e39},
         ],
     )
     def test_invalid_request_preserves_every_property(self, args):
@@ -140,7 +152,23 @@ class TestSetCameraProperties:
         assert result["success"] is True
         assert result["context"]["ortho_scale"] == 3.2
         assert result["context"]["lens"] == 50
+        assert (obj.data.type, obj.data.ortho_scale) == ("ORTHO", 3.2)
         assert (obj.data.clip_start, obj.data.clip_end) == (0.02, 20)
+
+    def test_native_lower_bounds_are_applied(self):
+        bpy = make_mock_bpy()
+        obj = _make_camera_obj()
+        bpy.data.objects.get.return_value = obj
+        result = load_and_call(
+            "blender-camera/scripts/set_camera_properties.py",
+            bpy,
+            name="Camera",
+            lens=1,
+            clip_start=1e-6,
+            ortho_scale=0,
+        )
+        assert result["success"] is True
+        assert (obj.data.lens, obj.data.clip_start, obj.data.ortho_scale) == (1, 1e-6, 0)
 
     def test_set_lens(self):
         bpy = make_mock_bpy()

--- a/tests/test_skills_camera.py
+++ b/tests/test_skills_camera.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from tests.conftest import load_and_call, make_mock_bpy
 
 
@@ -17,10 +19,21 @@ def _make_camera_obj(name="Camera"):
     obj.data.type = "PERSP"
     obj.data.clip_start = 0.1
     obj.data.clip_end = 1000.0
+    obj.data.ortho_scale = 6.0
     return obj
 
 
 class TestCreateCamera:
+    @pytest.mark.parametrize(
+        "args", [{"lens": 0}, {"lens": float("nan")}, {"location": []}, {"location": [0, 0, float("inf")]}]
+    )
+    def test_invalid_request_does_not_allocate_camera(self, args):
+        bpy = make_mock_bpy()
+        result = load_and_call("blender-camera/scripts/create_camera.py", bpy, **args)
+        assert result["success"] is False
+        bpy.data.cameras.new.assert_not_called()
+        bpy.data.objects.new.assert_not_called()
+
     def test_creates_camera(self):
         bpy = make_mock_bpy()
         cam_data = MagicMock()
@@ -85,6 +98,50 @@ class TestSetActiveCamera:
 
 
 class TestSetCameraProperties:
+    @pytest.mark.parametrize(
+        "args",
+        [
+            {"lens": 85, "camera_type": "INVALID"},
+            {"lens": 85, "clip_start": 1001},
+            {"lens": 85, "clip_end": 0.01},
+            {"camera_type": "ORTHO", "ortho_scale": -1},
+            {"camera_type": "ORTHO", "lens": float("nan")},
+            {"lens": 85, "clip_end": float("inf")},
+            {"lens": True},
+        ],
+    )
+    def test_invalid_request_preserves_every_property(self, args):
+        bpy = make_mock_bpy()
+        obj = _make_camera_obj()
+        bpy.data.objects.get.return_value = obj
+        result = load_and_call("blender-camera/scripts/set_camera_properties.py", bpy, name="Camera", **args)
+        assert result["success"] is False
+        assert (obj.data.lens, obj.data.type, obj.data.clip_start, obj.data.clip_end, obj.data.ortho_scale) == (
+            50,
+            "PERSP",
+            0.1,
+            1000,
+            6,
+        )
+
+    def test_orthographic_framing_and_clipping_readback(self):
+        bpy = make_mock_bpy()
+        obj = _make_camera_obj()
+        bpy.data.objects.get.return_value = obj
+        result = load_and_call(
+            "blender-camera/scripts/set_camera_properties.py",
+            bpy,
+            name="Camera",
+            camera_type="ORTHO",
+            ortho_scale=3.2,
+            clip_start=0.02,
+            clip_end=20,
+        )
+        assert result["success"] is True
+        assert result["context"]["ortho_scale"] == 3.2
+        assert result["context"]["lens"] == 50
+        assert (obj.data.clip_start, obj.data.clip_end) == (0.02, 20)
+
     def test_set_lens(self):
         bpy = make_mock_bpy()
         obj = _make_camera_obj()


### PR DESCRIPTION
Camera discovery returned an empty parameter schema, and invalid projection requests could change the lens before failing. Publish explicit camera schemas and examples, validate requests before mutation, and add orthographic scale control with readback.

Validated with 24 camera tests, skill lint, and typed calls in Blender 5.2: orthographic framing succeeds and an invalid clipping update preserves every camera property. The temporary camera was removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added orthographic framing support through `ortho_scale`.
  - Camera listings now report orthographic scale and clipping distances.
  - Published camera tools now include structured input/output schemas and usage examples.
  - Added clearer camera controls for lens, framing, and clipping ranges.

- **Bug Fixes**
  - Invalid camera requests are rejected before changes are applied.
  - Invalid requests no longer create cameras or partially modify existing camera properties.
  - Camera locations and numeric settings now receive stricter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->